### PR TITLE
chore: backlog 7.6 fetchAllInList — mark Implemented, archive detail section

### DIFF
--- a/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
@@ -1,6 +1,6 @@
 ---
 description: Historical archive: completed/declined maintenance-audit findings, extracted from maintenance-backlog.md.
-last_verified: 2026-07-27
+last_verified: 2026-07-28
 ---
 
 # Maintenance-Cost Reduction Backlog — Archive
@@ -1113,6 +1113,16 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Status:** Completed (merged #1089, maintenance-39b) — `DatabaseCache` now extends `BaseMysqliRepository`; failure paths log instead of silently returning null.
 
 **Table evidence (2026-07-25):** DatabaseCache extends BaseMysqliRepository + logs (#1089).
+
+### 7.6 IN-Clause Boilerplate Copy-Pasted Across 10 Repositories
+**Location:** `FreeAgencyAdminRepository`, `TradeAssetRepository`, `TradeCashRepository`, `SeasonQueryRepository`, `VotingRepository`, `SeasonArchiveRepository`, `LeagueControlPanelRepository`, `PlrParserRepository`, `UI/Tables/PeriodAverages`, `ProjectedDraftOrderRepository`
+**Problem:** Every repo reinvents `implode + array_fill + str_repeat`. No shared helper.
+**Suggested direction:** Add `protected fetchAllInList(string $query, string $type, array $ids): array` to `BaseMysqliRepository`.
+**Est. effort:** S
+**Risk if untouched:** Off-by-one risk; missing empty-array guards drift.
+**Status:** ✅ Implemented (verified 2026-07-26) — all 7 migratable repositories adopted (8 call sites: LeagueControlPanel, SeasonArchive, Voting, SeasonQuery, FreeAgencyAdmin, TradeAsset ×2, TradeCash). Excluded: PlrParser (INSERT VALUES, not IN-clause), PeriodAverages (not a `BaseMysqliRepository` subclass), ProjectedDraftOrder (hardcoded `IN (1, 2)`), LastSimRecap (suffix params after IN-list unsupported by helper).
+
+**Table evidence (2026-07-26):** All 7 migratable repos adopted `fetchAllInList()` (8 call sites). 4 structural exclusions: PlrParser (INSERT VALUES multi-column, not IN-clause), PeriodAverages (static view class, not a `BaseMysqliRepository` subclass), ProjectedDraftOrder (hardcoded `IN (1, 2)` literal), LastSimRecap (suffix params after IN-list, unsupported by helper).
 
 ### 7.7 `FreeAgencyView` and `FreeAgencyProcessor` Store Raw `\mysqli`
 **Location:** `ibl5/classes/FreeAgency/FreeAgencyView.php`, `FreeAgencyProcessor.php`

--- a/ibl5/docs/backlog/maintenance-backlog.md
+++ b/ibl5/docs/backlog/maintenance-backlog.md
@@ -525,20 +525,11 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 
 **Automouse audit (verified 2026-06-20):**
 
-> ✅ resolved (16): 7.1, 7.2, 7.3, 7.4, 7.5, 7.7, 7.8, 7.9, 7.10, 7.12, 7.13, 7.14, 7.15, 7.16, 7.17, 7.18 — evidence in [archive](archive/maintenance-backlog-archive.md)
+> ✅ resolved (17): 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 7.10, 7.12, 7.13, 7.14, 7.15, 7.16, 7.17, 7.18 — evidence in [archive](archive/maintenance-backlog-archive.md)
 
 | # | Status | Automouse | Evidence / note |
 |---|--------|-----------|-----------------|
-| 7.6 | ◑ Partial | 🟩 | `fetchAllInList()` exists, adopted by ~4 repos (8 file refs); remaining repos unmigrated. Mechanical migration, green-green. |
 | 7.11 | ⬜ Open | 🟨 | Inconsistent caching decorators. Upfront decision: add `Cached*Repository` for SeasonHighs/FranchiseRecordBook/etc. vs document why page-cache suffices. |
-
-### 7.6 IN-Clause Boilerplate Copy-Pasted Across 10 Repositories
-**Location:** `FreeAgencyAdminRepository`, `TradeAssetRepository`, `TradeCashRepository`, `SeasonQueryRepository`, `VotingRepository`, `SeasonArchiveRepository`, `LeagueControlPanelRepository`, `PlrParserRepository`, `UI/Tables/PeriodAverages`, `ProjectedDraftOrderRepository`
-**Problem:** Every repo reinvents `implode + array_fill + str_repeat`. No shared helper.
-**Suggested direction:** Add `protected fetchAllInList(string $query, string $type, array $ids): array` to `BaseMysqliRepository`.
-**Est. effort:** S
-**Risk if untouched:** Off-by-one risk; missing empty-array guards drift.
-**Status:** Partially completed (verified 2026-05-29 audit) — `BaseMysqliRepository::fetchAllInList()` helper exists and is adopted by LeagueControlPanel/SeasonArchive/Voting repos; remaining repos not yet migrated.
 
 ### 7.11 Inconsistent Caching Decorators
 **Location:** `PageCache::MODULE_TTLS` lists `SeasonHighs`, `FranchiseRecordBook`, `DraftHistory`, `AwardHistory`, `FranchiseHistory`


### PR DESCRIPTION
## Summary

Backlog audit (2026-07-26): all 7 migratable repositories already adopted `fetchAllInList()` on master (8 call sites). This PR ships backlog housekeeping only — no code changes.

**Adopted on master (8 call sites across 7 repos):**
- `LeagueControlPanel/LeagueControlPanelRepository.php:50`
- `SeasonArchive/SeasonArchiveRepository.php:242`
- `Voting/VotingRepository.php:164`
- `Season/SeasonQueryRepository.php:36`
- `FreeAgency/FreeAgencyAdminRepository.php:49`
- `Trading/TradeAssetRepository.php:57`
- `Trading/TradeAssetRepository.php:92`
- `Trading/TradeCashRepository.php:86`

**Excluded (structurally incompatible):**
- `PlrParser` — INSERT VALUES, not IN-clause
- `PeriodAverages` — not a `BaseMysqliRepository` subclass
- `ProjectedDraftOrder` — hardcoded `IN (1, 2)`
- `LastSimRecap` — suffix params after IN-list unsupported by helper

## Changes

- Updates `maintenance-backlog.md` item 7.6 row to ✅ Implemented with exclusion notes
- Archives detail section to `archive/maintenance-backlog-archive.md`
- Bumps `last_verified` frontmatter to 2026-07-26

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.