### PR TITLE
fix: dead-glob sweep to nightly audit — invert Check 3 guard, add --report-mode, wire staleness-report

### DIFF
--- a/.github/workflows/doc-freshness-audit.yml
+++ b/.github/workflows/doc-freshness-audit.yml
@@ -37,23 +37,44 @@ jobs:
         run: |
           bin/check-docs --staleness-report > /tmp/stale.json
           COUNT=$(jq 'length' /tmp/stale.json)
-          SIG=$(jq -r '.[].path' /tmp/stale.json | sort | paste -sd, -)
+          STALE_COUNT=$(jq '[.[] | select(.reason == "stale")] | length' /tmp/stale.json)
+          GLOB_COUNT=$(jq '[.[] | select(.reason == "dead-glob")] | length' /tmp/stale.json)
+          # sort -u, not sort: one doc can carry several dead globs, so its path
+          # repeats in the report. Without -u the sig churns on a set that never
+          # changed and re-pings the issue every night.
+          SIG=$(jq -r '.[].path' /tmp/stale.json | sort -u | paste -sd, -)
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "stale-count=$STALE_COUNT" >> "$GITHUB_OUTPUT"
+          echo "glob-count=$GLOB_COUNT" >> "$GITHUB_OUTPUT"
           echo "sig=$SIG" >> "$GITHUB_OUTPUT"
-          echo "Stale docs: $COUNT"
+          echo "Doc issues: $STALE_COUNT stale, $GLOB_COUNT dead globs"
 
       - name: Build issue body
         run: |
           {
-            echo "Repo-wide doc staleness audit ($(date -u +%Y-%m-%d))."
+            echo "Repo-wide doc audit ($(date -u +%Y-%m-%d))."
             echo ""
-            echo "These in-scope docs have a \`last_verified\` older than the 60-day window."
-            echo ""
-            echo "| Doc | last_verified | Age (days) | Days over |"
-            echo "|-----|---------------|------------|-----------|"
-            jq -r '.[] | "| `\(.path)` | \(.last_verified) | \(.age_days) | \(.days_over) |"' /tmp/stale.json
-            echo ""
-            echo "**Remediation:** re-verify each doc against reality, then bump its \`last_verified\` to today and commit (on a branch that touches the doc, \`bin/check-docs --fix-dates --since=master\` bumps the changed-but-unbumped ones)."
+            if [ "${{ steps.report.outputs.stale-count }}" -gt 0 ]; then
+              echo "### Stale docs"
+              echo ""
+              echo "These in-scope docs have a \`last_verified\` older than the 60-day window."
+              echo ""
+              echo "| Doc | last_verified | Age (days) | Days over |"
+              echo "|-----|---------------|------------|-----------|"
+              jq -r '.[] | select(.reason == "stale") | "| `\(.path)` | \(.last_verified) | \(.age_days) | \(.days_over) |"' /tmp/stale.json
+              echo ""
+            fi
+            if [ "${{ steps.report.outputs.glob-count }}" -gt 0 ]; then
+              echo "### Dead \`paths:\` globs"
+              echo ""
+              echo "These rule files declare a \`paths:\` glob matching no tracked file, so the rule can never load. Correct the pattern, or delete the entry."
+              echo ""
+              echo "| Doc | Dead glob |"
+              echo "|-----|-----------|"
+              jq -r '.[] | select(.reason == "dead-glob") | "| `\(.path)` | `\(.glob)` |"' /tmp/stale.json
+              echo ""
+            fi
+            echo "**Remediation:** re-verify each doc against reality, then bump its \`last_verified\` to today and commit (on a branch that touches the doc, \`bin/check-docs --fix-dates --since=master\` bumps the changed-but-unbumped ones). For a dead glob, correct the pattern or delete the entry — a deletion must be stated explicitly in the PR body."
             echo ""
             echo "<!-- stale-set: ${{ steps.report.outputs.sig }} -->"
             echo "<!-- stale-since: $(date -u +%Y-%m-%dT%H:%M:%SZ) -->"
@@ -70,6 +91,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COUNT: ${{ steps.report.outputs.count }}
           CUR_SIG: ${{ steps.report.outputs.sig }}
+          STALE_COUNT: ${{ steps.report.outputs.stale-count }}
+          GLOB_COUNT: ${{ steps.report.outputs.glob-count }}
         run: |
           NUM=$(gh issue list --label stale-docs --state open --json number --jq '.[0].number // empty')
           PREV_SIG=""
@@ -86,7 +109,7 @@ jobs:
             echo "notify=false" >> "$GITHUB_OUTPUT"
           elif [ -z "$NUM" ]; then
             gh issue create \
-              --title "Stale docs: $COUNT over the 60-day window" \
+              --title "Doc issues: $STALE_COUNT stale, $GLOB_COUNT dead globs" \
               --body-file /tmp/issue-body.md \
               --label stale-docs
             echo "notify=true" >> "$GITHUB_OUTPUT"
@@ -95,7 +118,9 @@ jobs:
             echo "Stale set unchanged; leaving issue #$NUM as-is."
             echo "notify=false" >> "$GITHUB_OUTPUT"
           else
-            gh issue edit "$NUM" --body-file /tmp/issue-body.md
+            gh issue edit "$NUM" \
+              --title "Doc issues: $STALE_COUNT stale, $GLOB_COUNT dead globs" \
+              --body-file /tmp/issue-body.md
             echo "notify=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -109,7 +134,7 @@ jobs:
           if [ "${{ steps.report.outputs.count }}" -gt 0 ]; then
             cat /tmp/issue-body.md >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "No stale docs — all in-scope docs are within the 60-day window." >> "$GITHUB_STEP_SUMMARY"
+            echo "No doc issues — every in-scope doc is within the 60-day window and every paths: glob resolves." >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Evaluate refresh-pipeline health
@@ -134,7 +159,7 @@ jobs:
           COUNT: ${{ steps.report.outputs.count }}
           DETAIL: ${{ steps.health.outputs.detail }}
         run: |
-          MSG=$(printf 'Doc refresh needs you: %s doc(s) are stale and the pipeline could not clear them on its own.\n%s\nRun: https://github.com/%s/actions/runs/%s' \
+          MSG=$(printf 'Doc refresh needs you: %s doc issue(s) (stale dates or dead paths: globs) and the pipeline could not clear them on its own.\n%s\nRun: https://github.com/%s/actions/runs/%s' \
             "$COUNT" "$DETAIL" "${{ github.repository }}" "${{ github.run_id }}")
           printf '%s' "$MSG" > /tmp/discord-msg.txt
 

--- a/bin/check-docs
+++ b/bin/check-docs
@@ -432,6 +432,60 @@ function stalenessReport(string $repoRoot, \DateTimeImmutable $today): array
 }
 
 /**
+ * Repo-wide dead-`paths:`-glob findings, sourced from
+ * `bin/check-rules-byte-budget --report-mode`. The per-PR gate stays
+ * changeset-scoped; the repo-wide sweep belongs to this nightly report.
+ *
+ * Fail-quiet: a non-zero exit, empty output, or non-array JSON yields [] — a
+ * broken sweep must never break the staleness report or the audit that consumes
+ * it. Same contract as bin/docfix-poll's `health_report()` guard at :200.
+ *
+ * @return list<array{path: string, last_verified: string, age_days: int, days_over: int, reason: string, glob: string}>
+ */
+function deadGlobReport(string $repoRoot): array
+{
+    // cd into the repo first: the sweep resolves its own ROOT from
+    // `git rev-parse --show-toplevel`, and check-docs is invoked from arbitrary
+    // cwd (bin/docfix-poll calls it as "$MAIN/bin/check-docs").
+    $cmd = sprintf(
+        'cd %s && %s --report-mode 2>/dev/null',
+        escapeshellarg($repoRoot),
+        escapeshellarg($repoRoot . '/bin/check-rules-byte-budget')
+    );
+    $out = [];
+    $code = 0;
+    exec($cmd, $out, $code);
+    if ($code !== 0) {
+        return [];
+    }
+    $decoded = json_decode(implode("\n", $out), true);
+    if (!is_array($decoded)) {
+        return [];
+    }
+
+    $entries = [];
+    foreach ($decoded as $item) {
+        if (!is_array($item)
+            || !isset($item['path'], $item['glob'])
+            || !is_string($item['path'])
+            || !is_string($item['glob'])
+        ) {
+            continue;   // malformed row: drop it, never emit a half-built entry
+        }
+        $entries[] = [
+            'path' => $item['path'],
+            'last_verified' => '',
+            'age_days' => 0,
+            'days_over' => 0,
+            'reason' => 'dead-glob',
+            'glob' => $item['glob'],
+        ];
+    }
+
+    return $entries;
+}
+
+/**
  * Verify ADR bidirectional Supersedes / Superseded-by integrity.
  *
  * Forward: if ADR-X has `Status: Superseded by ADR-Y`, then ADR-Y must exist
@@ -1073,11 +1127,20 @@ foreach (array_slice($argv, 1) as $arg) {
 $root = repoRoot();
 $today = new \DateTimeImmutable('today');
 
-// Report mode short-circuits: emit the stale-doc list as JSON and exit 0
+// Report mode short-circuits: emit the stale-doc and dead-glob list as JSON and exit 0
 // regardless of whether any doc is stale. It is a report, not a gate — the
 // nightly audit workflow decides what to do with the list.
 if ($opts['staleness_report']) {
-    echo json_encode(stalenessReport($root, $today), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), "\n";
+    // Two finding kinds share one report: date staleness and dead paths: globs.
+    // `reason` is additive — every existing consumer reads only .path, length,
+    // .age_days, .days_over (bin/docfix-poll uncovered_count/health_report,
+    // the audit workflow's jq), so the extra key breaks nothing.
+    $stale = array_map(
+        static fn (array $e): array => $e + ['reason' => 'stale'],
+        stalenessReport($root, $today)
+    );
+    $report = array_merge($stale, deadGlobReport($root));
+    echo json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), "\n";
     exit(0);
 }
 

--- a/bin/check-rules-byte-budget
+++ b/bin/check-rules-byte-budget
@@ -4,18 +4,32 @@
 # context, so their size is a permanent token cost. Path-scoped rules (those
 # with a `paths:` frontmatter key) load only for matching files and are exempt.
 #
+# Usage:
+#   bin/check-rules-byte-budget                 gate mode — the four checks below,
+#                                               exit 1 on any violation (CI default)
+#   bin/check-rules-byte-budget --report-mode   report mode — repo-wide dead-glob
+#                                               sweep only, JSON array on stdout,
+#                                               always exit 0, no gate semantics
+#
 # Four checks (T2 + T13 — ibl5/docs/backlog/token-spend-backlog.md):
 #   1. Per-file cap: each path-unscoped file <= RULES_BYTE_BUDGET (default 5000)
 #   2. Aggregate cap: total path-unscoped bytes <= RULES_TOTAL_BUDGET (default 16000)
-#   3. Glob reachability: every paths: glob in any .claude/rules/*.md file must
-#      match at least one tracked file (out-of-repo globs are SKIPped, not FAILed)
+#   3. Glob reachability: every paths: glob in a rules file THIS CHANGESET TOUCHES
+#      must match at least one tracked file (out-of-repo globs are SKIPped, not
+#      FAILed). Untouched files are swept repo-wide by --report-mode instead —
+#      nightly, not per-PR. See Check 3 below.
 #   4. Resident stub references: every path-scoped rule must be named by some
 #      always-on file, so its payload is reachable without a prior Read
 #
 # Extend-before-add (meta-tooling-bar.md): distinct trigger (size budget) vs
 # bin/check-docs (freshness / dead-refs). Owns the ALLOWLIST — the single
-# machine-readable statement of which rules are always-on. ~80 lines bash.
+# machine-readable statement of which rules are always-on. ~210 lines bash.
 set -euo pipefail
+
+# --report-mode: repo-wide dead-glob sweep for the nightly doc-freshness audit.
+# Prints ONE JSON array on stdout and exits 0 — no gate semantics, no exit 1.
+REPORT_MODE=0
+if [ "${1:-}" = "--report-mode" ]; then REPORT_MODE=1; shift || true; fi
 
 MAX_BYTES="${RULES_BYTE_BUDGET:-5000}"
 # NOTE: do NOT ratchet MAX_BYTES / RULES_BYTE_BUDGET — agent-tiering.md sits at
@@ -31,6 +45,44 @@ RULES_DIR="$ROOT/.claude/rules"
 # paths: globs; both keep a one-line trigger stub in workflow-continuity.md, which
 # names the scoped file so the payload stays one Read away. See Check 4 below.
 ALLOWLIST="agent-tiering auto-commit work-triage workflow-continuity"
+
+# Shared by Check 3 and --report-mode — the single paths: parser. Prints one glob
+# per line for $1; prints nothing when the file has no paths: key. Handles BOTH
+# shapes: scalar (`paths: "ibl5/**"`) and list (`paths:` + `  - "…"` lines).
+_rule_globs() {
+  local fm
+  fm="$(awk '/^---$/{c++; next} c==1{print} c>=2{exit}' "$1")"
+  printf '%s\n' "$fm" | grep -q '^paths:' || return 0
+  printf '%s\n' "$fm" | awk '
+    /^paths:[[:space:]]*$/            { inlist=1; next }
+    /^paths:[[:space:]]*[^[:space:]]/ { sub(/^paths:[[:space:]]*/, ""); print; next }
+    inlist && /^[[:space:]]*-[[:space:]]/ { sub(/^[[:space:]]*-[[:space:]]*/, ""); print; next }
+    inlist && /^[^[:space:]]/         { inlist=0 }
+  ' | tr -d '"\047'
+}
+
+# --- --report-mode -----------------------------------------------------------
+# Repo-wide (NOT changeset-scoped) dead-glob scan. Exits 0 BEFORE Checks 1/2/3/4
+# run, so no SKIP/FAIL/budget text can reach stdout — the caller
+# (bin/check-docs --staleness-report) json_decode()s stdout directly.
+if (( REPORT_MODE )); then
+  _first=1
+  printf '['
+  for f in "$RULES_DIR"/*.md; do
+    _rel=".claude/rules/$(basename "$f")"
+    while IFS= read -r g; do
+      [ -n "$g" ] || continue
+      case "$g" in "~"*|/*) continue ;; esac        # out-of-repo globs are legitimate
+      [ -z "$(git -C "$ROOT" ls-files -- ":(glob)$g" | head -1)" ] || continue
+      _esc="$(printf '%s' "$g" | sed 's/\\/\\\\/g')"
+      (( _first )) || printf ','
+      _first=0
+      printf '{"path":"%s","glob":"%s"}' "$_rel" "$_esc"
+    done <<< "$(_rule_globs "$f")"
+  done
+  printf ']\n'
+  exit 0
+fi
 
 fail=0
 total_bytes=0
@@ -70,18 +122,24 @@ if [[ -n "$missing" ]]; then
   fail=1
 fi
 
-# ─── Check 3: glob reachability ────────────────────────────────────────────────
+# ─── Check 3: glob reachability (CHANGESET-SCOPED) ─────────────────────────────
 # A `paths:` glob that matches no tracked file means the rule can never load.
-# Scope: only files new or changed vs. origin/master — pre-existing broken globs
-# in untouched files are pre-existing debt, not caught here (per plan Out-of-Scope:
-# "Checks 3 and 4 assert reachability for the files this PR touches").
+# Scope: ONLY files new or changed vs. origin/<base> — the scope this check was
+# always documented to have. A dead glob in a file this PR did not touch is not
+# ignored, it is handled elsewhere: --report-mode sweeps the whole repo nightly,
+# bin/check-docs --staleness-report merges the findings into the Doc Freshness
+# Audit report, and the docs-stale-refresh remediation run fixes them (ADR-0079).
+# Failing them here instead would block an unrelated PR on debt it did not create.
 # Out-of-repo globs are LEGITIMATE (work-triage-detail.md points at
 # ~/.claude/hooks/plan-gate-edit.sh) — report SKIP, never FAIL.
 #
 # In CI the checkout may be shallow (fetch-depth: 1), so `git diff origin/master`
 # can fail non-fatally due to missing objects. Fetch the base branch first to
 # guarantee origin/<base> is available, then compute the changed-files set once
-# before the loop.
+# before the loop. An EMPTY changed set means "no rules file changed",
+# so every file is skipped — NOT "scan everything". Inverting that condition is
+# the bug this gate carried: `-n … &&` degraded an empty changeset into a
+# repo-wide sweep, so the guard is `-z … ||`. Do not "simplify" it back.
 #
 # `--depth=1` is CI-ONLY and MUST stay behind the is-shallow guard. In a full
 # clone a shallow fetch CREATES .git/shallow, grafting origin/<base> to a single
@@ -100,9 +158,10 @@ _CHANGED_RULES="$(git diff --name-only "origin/$_BASE_BRANCH" -- .claude/rules/ 
 
 glob_fail=0
 for f in "$RULES_DIR"/*.md; do
-  # Skip files not in this PR's changeset — pre-existing broken globs are out-of-scope debt.
+  # Skip files not in this changeset — a dead glob elsewhere is swept nightly
+  # by --report-mode, never failed here. Empty changeset => skip everything.
   _rel=".claude/rules/$(basename "$f")"
-  if [ -n "$_CHANGED_RULES" ] && ! printf '%s\n' "$_CHANGED_RULES" | grep -qxF "$_rel"; then
+  if [ -z "$_CHANGED_RULES" ] || ! printf '%s\n' "$_CHANGED_RULES" | grep -qxF "$_rel"; then
     continue
   fi
   fm="$(awk '/^---$/{c++; next} c==1{print} c>=2{exit}' "$f")"

--- a/bin/docfix-poll
+++ b/bin/docfix-poll
@@ -255,7 +255,7 @@ REPORT="$(mktemp)"
 trap 'rm -f "$REPORT"' EXIT
 "$MAIN/bin/check-docs" --staleness-report > "$REPORT"
 COUNT="$(jq 'length' "$REPORT")"
-SIG="$(jq -r '.[].path' "$REPORT" | sort | paste -sd, -)"
+SIG="$(jq -r '.[].path' "$REPORT" | sort -u | paste -sd, -)"
 [ "$COUNT" -eq 0 ] && { echo "docfix-poll: no stale docs — nothing to do."; exit 0; }
 
 # Reap leftovers whose PR is finished (merged or declined). An OPEN PR's branch

--- a/bin/docfix-run
+++ b/bin/docfix-run
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #
-# bin/docfix-run <issue-num> <sig> — Mac-side headless stale-docs remediation launcher.
-# Fired by bin/docfix-poll (launchd, daily) when the nightly audit has flagged a
-# stale set. Creates a worktree, seeds an auto_merge:false hold plan, and launches
-# a detached headless Claude run that refreshes exactly the stale docs and opens a
-# PR (held for human merge) that Closes the stale-docs issue.
+# bin/docfix-run <issue-num> <sig> — Mac-side headless doc remediation launcher.
+# Fired by bin/docfix-poll (launchd, daily) when the nightly audit has flagged
+# stale docs or dead `paths:` globs. Creates a worktree, seeds an auto_merge:false
+# hold plan, and launches a detached headless Claude run that fixes the flagged docs
+# and opens a PR (held for human merge) that Closes the stale-docs issue.
 #
 # Detach mechanism cloned in structure from bin/post-plan-now:71-109 (launchd
 # RunAtLoad one-shot) — a plain `nohup … &` from the poll dies with it.
@@ -73,7 +73,7 @@ LABEL="com.ibl5.docfix-run-$SLUG-$TS"
 PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
 TODAY="$(date -u +%Y-%m-%d)"
 
-PROMPT="You are refreshing stale documentation with NO human present — never ask questions or wait for input; make the safe choice and continue. Refresh ONLY these docs (comma-separated paths): $SIG. For each: re-verify its content against the current reality of the codebase, correct drifted content, and bump its \`last_verified\` to today ($TODAY). Then run \`bin/check-docs --fix-dates --since=master\` to bump any in-scope doc you changed but did not hand-bump. Do NOT touch any doc outside the list above. Commit with a message whose body contains the line \`Closes #$ISSUE_NUM\`. Then fire \`bin/post-plan-now\` (NOT --auto) to open the PR; the PR body MUST include \`Closes #$ISSUE_NUM\` so merging it closes the stale-docs issue."
+PROMPT="You are fixing doc findings with NO human present — never ask questions or wait for input; make the safe choice and continue. The findings are the nightly Doc Freshness Audit set for issue #$ISSUE_NUM. Work ONLY on these paths (comma-separated): $SIG. First run \`bin/check-docs --staleness-report\` and split its JSON with jq into entries whose \`reason\` is \`stale\` and entries whose \`reason\` is \`dead-glob\`; that command is the authoritative finding list, and the body of issue #$ISSUE_NUM shows the same two tables for reference. For each \`stale\` entry: re-verify its content against the current reality of the codebase, correct drifted content, and bump its \`last_verified\` to today ($TODAY). For each \`dead-glob\` entry: the named file declares a \`paths:\` frontmatter glob matching no tracked file, so that rule can never load — PREFER correcting the glob so it matches the tracked files it was meant to cover, and delete the \`paths:\` entry only when no correction is identifiable. IF you delete a glob you MUST disclose it: add one line per deletion to the commit message body AND to the PR body under a heading reading \`## Dead globs deleted\`, in exactly this form: \`Dead glob deleted: in FILE_PATH, removed paths: entry GLOB — REASON\`, substituting the real repo-relative path, the exact glob text, and one clause saying why no correction was possible, so the maintainer can review the deletion without opening the diff. Never delete a whole file, and never remove a \`paths:\` key that still carries a working glob. Then run \`bin/check-docs --fix-dates --since=master\` to bump any in-scope doc you changed but did not hand-bump, and re-run \`bin/check-docs --staleness-report\` to confirm every finding you were given is gone. Do NOT touch any doc outside the list above. Commit with a message whose body contains the line \`Closes #$ISSUE_NUM\`. Then fire \`bin/post-plan-now\` (NOT --auto) to open the PR; the PR body MUST include \`Closes #$ISSUE_NUM\` so merging it closes the stale-docs issue."
 
 # launchd runs a minimal env → same PATH prelude as bin/post-plan-now:94.
 cat > "$PLIST" <<PLIST_EOF

--- a/ibl5/docs/decisions/0079-stale-docs-auto-remediation.md
+++ b/ibl5/docs/decisions/0079-stale-docs-auto-remediation.md
@@ -1,6 +1,6 @@
 ---
-description: Act on the nightly stale-docs audit automatically — on a NEW/CHANGED stale set, a self-hosted macOS runner fires a headless Claude run that refreshes exactly the stale docs and opens a PR (held for human merge) that Closes the tracker issue.
-last_verified: 2026-07-24
+description: Act on the nightly stale-docs audit automatically — on a NEW/CHANGED stale set, a self-hosted macOS runner fires a headless Claude run that refreshes exactly the flagged docs (stale last_verified dates and dead paths: globs) and opens a PR (held for human merge) that Closes the tracker issue.
+last_verified: 2026-07-28
 ---
 
 # ADR-0079: Autonomous stale-docs remediation via a self-hosted macOS runner
@@ -80,3 +80,21 @@ not repo artifacts:
 4. Prerequisites on the Mac PATH: the `claude` CLI (authenticated), `gh` (persistent
    `gh auth login`, able to open PRs), `git` (worktree support), and `caffeinate` — the same tools
    `bin/post-plan-now` assumes.
+
+## Addendum (2026-07-28): dead `paths:` globs join the remediated set
+
+The audit's finding set is no longer date-staleness only. `bin/check-rules-byte-budget`
+gained a `--report-mode` that sweeps the whole repo for `paths:` frontmatter globs matching
+no tracked file; `bin/check-docs --staleness-report` merges those findings into the same
+JSON report, tagging every entry with `reason: "stale"` or `reason: "dead-glob"`. The audit
+issue renders them as two tables, and the `bin/docfix-run` prompt now instructs the headless
+run to correct or delete a dead glob — and to disclose any deletion explicitly in the PR body,
+so the human who holds the merge can judge it without opening the diff.
+
+Why the sweep moved here rather than staying on the per-PR gate: `bin/check-rules-byte-budget`
+Check 3 was always documented as changeset-scoped, but a guard inversion made an *empty*
+changeset degrade into a repo-wide scan, so a PR touching no rule file could fail on debt it
+did not create. The gate now matches its documented scope, and the repo-wide sweep runs
+nightly — where a finding becomes a tracked issue and an autonomous fix instead of a blocked PR.
+Nothing about the transport decision in ADR-0086, or the human-merge hold this ADR established,
+changes.


### PR DESCRIPTION
## What

Fixes the Check 3 changeset guard inversion bug in `bin/check-rules-byte-budget` and adds the systemic dead-glob detection + nightly remediation path.

**The bug (Phase 1):** `if [ -n "$_CHANGED_RULES" ] && …` short-circuits to false on an empty changeset, so a PR touching no `.claude/rules/` file degraded Check 3 into a full repo sweep — failing on debt it did not create. De Morgan fix: `[ -z … ] ||`.

**The compensating sweep (Phases 1–4):**
- `bin/check-rules-byte-budget --report-mode`: new flag, repo-wide dead-glob sweep, JSON array on stdout, always exits 0 (no gate semantics)
- `bin/check-docs --staleness-report`: merges dead-glob findings with stale-date findings, tagging each entry `reason: "stale"` or `reason: "dead-glob"`
- `doc-freshness-audit.yml`: renders two conditional tables in the nightly issue body, dedups the sig with `sort -u`, updates issue title to reflect the mix
- `bin/docfix-run`: prompt now instructs the headless run to split findings by `reason`, repair-or-delete a dead glob, and disclose any deletion in the commit body and PR body

**ADR-0079 addendum (Phase 6):** records that dead globs joined the remediated set and why the sweep moved off the per-PR gate.

## Known Limitation

The no-stacking guard in `bin/docfix-run:34-42` defers a dead-glob finding discovered while a `docs-stale-refresh-*` branch or PR is parked. That is existing behavior for date staleness — widening the finding set does not change the queueing. Fix is out of scope here (separate design question about ADR-0079's hold posture).

## Manual Testing

No manual testing needed — all changes are covered by automated tests.

## Automouse Hold

`auto_merge: false` — intrinsic self-gating hazard. This PR narrows `bin/check-rules-byte-budget`, which is the `Static guards` required check on `master`. A green check on this PR is evidence about the new gate's behavior, not independent confirmation. A human merges it under the old gate.