### PR TITLE
chore(work-triage): add `.claude/skills` invariants to safety mirror

### DIFF
--- a/.claude/rules/work-triage.md
+++ b/.claude/rules/work-triage.md
@@ -23,10 +23,11 @@ If any are open, it wants a `/plan`.
 
 ## Ad-hoc safety mirror
 
-Even when the bar says ad-hoc, run a quick safety check — the same surfaces `/plan` Step 4 gate 14 holds for. If the change touches any of:
+Even when the bar says ad-hoc, run a quick safety check — the surfaces `/plan` Step 4 gate 14 holds the merge for, plus the ship-pipeline surface `/plan` Step 3 escalates to `plan-architect-xhigh`. If the change touches any of:
 - a **security surface** (SQL, POST/form endpoint, auth/authz-gated route, user-facing output rendering),
 - a **destructive or schema-tightening migration**,
-- **new or redesigned user-visible UI/UX**, or
+- **new or redesigned user-visible UI/UX**,
+- a **`.claude/skills` ship-pipeline invariant** — a change to what fires, what gates, or which disposition applies; *not* a prose edit that preserves the decision procedure, or
 - a property needing **subjective human judgment** to confirm,
 
 then prefer `/plan`, so the defense and its verification are designed up front. Why the PR-time backstop is not a substitute: `work-triage-detail.md` § Safety mirror backstop.

--- a/.claude/skills/plan-prompt/SKILL.md
+++ b/.claude/skills/plan-prompt/SKILL.md
@@ -48,10 +48,8 @@ tokens go.
 
 `.claude/rules/work-triage.md` is always loaded and already owns this decision: apply
 § The ad-hoc bar and § Ad-hoc safety mirror as written — downgrade only when every
-clause of the bar holds, never when a mirror trigger fires. Treat a **`.claude/skills`
-ship-pipeline invariant** as a fifth mirror trigger (a change to what fires, what gates,
-or which disposition applies — not a prose edit that preserves the decision procedure).
-Four things are specific to triaging from *here*:
+clause of the bar holds, never when a mirror trigger fires. Four things are specific to
+triaging from *here*:
 
 - **You cannot resolve the empirical unknowns.** Step 0 forbids scans and re-reads, so
   the bar's "resolve empirical unknowns first" inverts: an unknown that would change the


### PR DESCRIPTION
## Summary
- Add `.claude/skills` ship-pipeline invariants (changes to what fires, gates, or disposition) as an explicit safety mirror trigger in ad-hoc workflow
- Clarify the distinction: changes to invariants require `/plan`, but prose edits preserving decision logic do not
- Remove redundant statement from plan-prompt/SKILL.md, now centralized in work-triage.md

## Manual Testing

No manual testing needed — verified by automated tests.
