### PR TITLE
chore(pr-review): add review thread resolution API

### DIFF
--- a/.claude/skills/post-plan/_phase-4-review-audit.md
+++ b/.claude/skills/post-plan/_phase-4-review-audit.md
@@ -105,4 +105,12 @@ The helper provides two public functions:
 - Issues survived filter → build findings JSON (`body` = `**[SEVERITY]** Type in \`Class::method()\` — description` + full-SHA range link, `score`); call `post_review_findings "$PR" "$FULL_SHA" "Security audit" <file>`. Severity: CRITICAL (SQLi/CMDi), HIGH (missing auth/open redirect), MEDIUM (CSRF/missing auth on non-critical endpoints), LOW (best practice).
 - No issues → call `post_review_summary "$PR" "Security audit" "No security issues found. <brief evidence per category> (XSS and input validation are enforced by PHPStan custom rules.)"`.
 
+**Dispositioning open threads:** a finding posted as an inline thread stays open until something replies *in-thread* and resolves it. Never announce a fixed finding with `gh pr comment` to close a thread — a top-level comment cannot associate with a review thread. Use `list_open_review_findings` to find the COMMENT_ID, then `resolve_review_finding` to reply in-thread and mark the thread resolved. The same call applies when declining a finding — the body says why, and the thread still closes. A finding is dispositioned when it is fixed *or* explicitly declined; silence is not a disposition.
+
+```bash
+source "$(git rev-parse --show-toplevel)/bin/lib/post-review-findings.sh"
+list_open_review_findings "$PR"                              # TSV: COMMENT_ID, score, path:line, excerpt
+resolve_review_finding "$PR" <COMMENT_ID> "Fixed in $FULL_SHA — <what changed>"
+```
+
 **Link format (in `body` field):** `https://github.com/a-jay85/IBL5/blob/{FULL_SHA}/path/to/file#L{start}-L{end}` — expand SHA from 4A beforehand, never use bash interpolation in the body string. Include 1 line of context before/after the anchor line.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -6,7 +6,7 @@ name: pr-review
 description: Token-efficient code review for pull requests
 disable-model-invocation: true
 model: claude-sonnet-4-6
-last_verified: 2026-07-20
+last_verified: 2026-07-28
 ---
 
 Provide a code review for the given pull request. This command optimizes token usage by fetching the diff once and distributing only what each agent needs.
@@ -124,6 +124,18 @@ The helper routes on-diff findings to a batch resolvable review POST (inline thr
 post_review_summary "$PR_NUMBER" "Code review" \
     "No issues found. <1-2 sentence evidence summary>"
 ```
+
+### Dispositioning open threads:
+
+A finding posted as an inline thread stays open until something replies *in-thread* and resolves it. Never use `gh pr comment` to announce that a finding is fixed or to close a thread — a top-level comment cannot associate with a review thread. To disposition a finding:
+
+```bash
+source "$(git rev-parse --show-toplevel)/bin/lib/post-review-findings.sh"
+list_open_review_findings "$PR_NUMBER"                      # TSV: COMMENT_ID, score, path:line, excerpt
+resolve_review_finding "$PR_NUMBER" <COMMENT_ID> "Fixed in <sha> — <what changed>"
+```
+
+The same call applies when declining a finding — the body says why, and the thread still closes. A finding is dispositioned when it is fixed *or* explicitly declined; silence is not a disposition.
 
 ### Notes:
 - Do not check build signal or attempt to build or typecheck the app. These will run separately.

--- a/.claude/skills/security-audit/SKILL.md
+++ b/.claude/skills/security-audit/SKILL.md
@@ -5,7 +5,7 @@ name: security-audit
 description: Token-efficient security audit for pull requests
 disable-model-invocation: true
 model: claude-sonnet-4-6
-last_verified: 2026-07-20
+last_verified: 2026-07-28
 ---
 
 Perform a security audit on the given pull request. This command optimizes token usage by fetching the diff once and passing it to a single merged security agent.
@@ -111,6 +111,18 @@ The helper routes on-diff findings to a batch resolvable review POST (inline thr
 post_review_summary "$PR_NUMBER" "Security audit" \
     "No security issues found. <brief evidence per category> (XSS and input validation are enforced by PHPStan custom rules.)"
 ```
+
+### Dispositioning open threads:
+
+A finding posted as an inline thread stays open until something replies *in-thread* and resolves it. Never use `gh pr comment` to announce that a finding is fixed or to close a thread — a top-level comment cannot associate with a review thread. To disposition a finding:
+
+```bash
+source "$(git rev-parse --show-toplevel)/bin/lib/post-review-findings.sh"
+list_open_review_findings "$PR_NUMBER"                      # TSV: COMMENT_ID, score, path:line, excerpt
+resolve_review_finding "$PR_NUMBER" <COMMENT_ID> "Fixed in <sha> — <what changed>"
+```
+
+The same call applies when declining a finding — the body says why, and the thread still closes. A finding is dispositioned when it is fixed *or* explicitly declined; silence is not a disposition.
 
 ### Per-finding body format:
 

--- a/bin/lib/post-review-findings.sh
+++ b/bin/lib/post-review-findings.sh
@@ -6,8 +6,15 @@
 # Usage: source "$(git rev-parse --show-toplevel)/bin/lib/post-review-findings.sh"
 #
 # Public API:
-#   post_review_findings PR_NUMBER HEAD_SHA REVIEW_TITLE FINDINGS_FILE
-#   post_review_summary  PR_NUMBER REVIEW_TITLE BODY
+#   post_review_findings     PR_NUMBER HEAD_SHA REVIEW_TITLE FINDINGS_FILE
+#   post_review_summary      PR_NUMBER REVIEW_TITLE BODY
+#   list_open_review_findings PR_NUMBER
+#   resolve_review_finding   PR_NUMBER COMMENT_ID BODY
+#
+# The last two are the DISPOSITION half of the lifecycle: a finding posted as an
+# inline thread stays open forever unless something replies in-thread and calls
+# the resolveReviewThread mutation.  A top-level `gh pr comment` announcing the
+# fix does NOT close the thread — GitHub never associates the two.
 #
 # Test seam: GH_CMD (default `gh`) and REPO_SLUG (default `a-jay85/IBL5`) are
 # overridable env-vars so the shim test can drive both without network calls.
@@ -139,4 +146,97 @@ post_review_summary() {
     printf '<details><summary>✅ %s — no issues found</summary>\n\n### %s\n\n%s\n\n%s\n\n</details>\n' \
         "$title" "$title" "$body" "$PRF_FOOTER" > "$out"
     "$GH_CMD" pr comment "$pr" --body-file "$out"
+}
+
+# ── Disposition half: reply in-thread and resolve ─────────────────────────────
+
+# prf_review_threads PR_NUMBER
+#   Emits one JSON object per review thread:
+#     {id, isResolved, isOutdated, path, line, commentId, score, body}
+#   `commentId` is the REST databaseId of the thread's FIRST comment — the id the
+#   replies endpoint keys on.  `score` is parsed from the `<!-- score: N -->`
+#   marker post_review_findings embeds, or null for a human-authored thread.
+#   CAP: the first 100 threads only — no pagination.  A PR with more than 100
+#   review threads silently truncates here; every caller inherits that cap.
+#   A thread whose only comment was deleted yields commentId/body null, so the
+#   `// ""` guards below are load-bearing (jq errors on `null | capture`).
+prf_review_threads() {
+    local pr="$1"
+    local owner="${REPO_SLUG%%/*}" repo="${REPO_SLUG##*/}"
+    "$GH_CMD" api graphql \
+        -F owner="$owner" -F repo="$repo" -F pr="$pr" \
+        -f query='
+        query($owner:String!, $repo:String!, $pr:Int!) {
+          repository(owner:$owner, name:$repo) {
+            pullRequest(number:$pr) {
+              reviewThreads(first:100) {
+                nodes {
+                  id isResolved isOutdated path line
+                  comments(first:1) { nodes { databaseId body } }
+                }
+              }
+            }
+          }
+        }' \
+        --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+              | {id, isResolved, isOutdated, path, line,
+                 commentId: .comments.nodes[0].databaseId,
+                 score: ((.comments.nodes[0].body // "")
+                         | capture("<!-- score: (?<s>[0-9]+) -->") // null
+                         | if . == null then null else (.s|tonumber) end),
+                 body: (.comments.nodes[0].body // "")}'
+}
+
+# list_open_review_findings PR_NUMBER
+#   Human/agent-readable TSV of every UNRESOLVED review thread on the PR:
+#     COMMENT_ID <TAB> SCORE <TAB> path:line <TAB> first line of the finding
+#   Empty output = every thread is dispositioned.  Feed COMMENT_ID straight into
+#   resolve_review_finding.  Threads whose sole comment was deleted have no
+#   COMMENT_ID to reply to, so they are skipped rather than listed as "null".
+list_open_review_findings() {
+    local pr="$1"
+    prf_review_threads "$pr" \
+        | jq -r 'select(.isResolved == false and .commentId != null)
+                 | [ (.commentId|tostring),
+                     (if .score == null then "-" else (.score|tostring) end),
+                     ((.path // "?") + ":" + (if .line == null then "?" else (.line|tostring) end)),
+                     (.body | split("\n")[0] | .[0:100]) ]
+                 | @tsv'
+}
+
+# resolve_review_finding PR_NUMBER COMMENT_ID BODY
+#   Dispositions one review finding: posts BODY as a threaded REPLY to
+#   COMMENT_ID, then marks the containing thread resolved.  BODY should say what
+#   happened — "Fixed in <sha> — <what changed>" or why it is being declined.
+#   Prints the thread's post-mutation isResolved value.  Returns 1 if COMMENT_ID
+#   matches no thread on the PR, 2 on a malformed COMMENT_ID.
+#
+#   Use this INSTEAD of `gh pr comment` when announcing that a finding is
+#   handled: a top-level comment leaves the thread open forever.
+resolve_review_finding() {
+    local pr="$1" cid="$2" body="$3"
+    case "$cid" in
+        ''|*[!0-9]*) echo "resolve_review_finding: COMMENT_ID must be numeric, got '$cid'" >&2; return 2 ;;
+    esac
+
+    local tid
+    tid=$(prf_review_threads "$pr" | jq -r --argjson cid "$cid" \
+        'select(.commentId == $cid) | .id' | head -1)
+    if [ -z "$tid" ]; then
+        echo "resolve_review_finding: comment ${cid} owns no review thread in the first 100 on PR #${pr}" >&2
+        return 1
+    fi
+
+    # -f (raw-field) sends BODY as a literal string: no temp file, and no `@file`
+    # expansion to escape from — a finding reply routinely starts with a backtick
+    # or contains newlines.
+    "$GH_CMD" api --method POST \
+        "repos/${REPO_SLUG}/pulls/${pr}/comments/${cid}/replies" \
+        -f body="$body" >/dev/null || return 1
+
+    "$GH_CMD" api graphql -F tid="$tid" -f query='
+        mutation($tid: ID!) {
+          resolveReviewThread(input:{threadId:$tid}) { thread { id isResolved } }
+        }' \
+        --jq '.data.resolveReviewThread.thread.isResolved'
 }

--- a/bin/test-post-review-findings
+++ b/bin/test-post-review-findings
@@ -12,6 +12,10 @@
 #   • empty findings array → complete no-op
 #   • all 3 callers reference post-review-findings.sh (structural)
 #   • /pr-review & /security-audit Step 1 guards check PR reviews (structural)
+#   • list_open_review_findings lists only UNRESOLVED threads, with score/line
+#   • resolve_review_finding replies in-thread AND resolves the owning thread
+#   • resolve_review_finding refuses an unknown / malformed comment id
+#   • all 3 callers document the disposition step (structural)
 #
 # Run: bin/test-post-review-findings  (exit 0 = all pass, 1 = some failed)
 
@@ -36,7 +40,7 @@ if [ "$1" = "pr" ] && [ "$2" = "diff" ]; then
     cat "$GH_DIFF_FIXTURE"
     exit 0
 fi
-if [ "$1" = "api" ] && [ "$2" = "--method" ] && [ "$3" = "POST" ]; then
+if [ "$1" = "api" ] && [ "$2" = "--method" ] && [ "$3" = "POST" ] && [[ "$*" == *--input* ]]; then
     input_file=""
     for ((i=1; i<=$#; i++)); do
         if [ "${!i}" = "--input" ]; then j=$((i+1)); input_file="${!j}"; fi
@@ -51,6 +55,42 @@ if [ "$1" = "pr" ] && [ "$2" = "comment" ]; then
         if [ "${!i}" = "--body-file" ]; then j=$((i+1)); body_file="${!j}"; fi
     done
     cp "$body_file" "$COMMENT_OUT"
+    exit 0
+fi
+# gh api graphql -F k=v -f query=... --jq FILTER
+# The shim serves the RAW GraphQL response from a fixture and applies the caller's
+# --jq itself, so the lib's real jq filters are exercised rather than stubbed out.
+if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
+    query=""; jqf=""; tid=""
+    for ((i=1; i<=$#; i++)); do
+        case "${!i}" in
+            -f)    j=$((i+1)); case "${!j}" in query=*) query="${!j#query=}" ;; esac ;;
+            -F)    j=$((i+1)); case "${!j}" in tid=*)   tid="${!j#tid=}"     ;; esac ;;
+            --jq)  j=$((i+1)); jqf="${!j}" ;;
+        esac
+    done
+    if printf '%s' "$query" | grep -q 'resolveReviewThread'; then
+        printf '%s\n' "$tid" > "$RESOLVE_OUT"
+        fixture="$GH_MUTATION_FIXTURE"
+    else
+        fixture="$GH_THREADS_FIXTURE"
+    fi
+    if [ -n "$jqf" ]; then jq -rc "$jqf" "$fixture"; else cat "$fixture"; fi
+    exit 0
+fi
+# gh api --method POST repos/O/R/pulls/N/comments/CID/replies -f body=...
+if [ "$1" = "api" ] && [ "$2" = "--method" ] && [ "$3" = "POST" ]; then
+    endpoint=""; body=""; skip=0
+    for ((i=4; i<=$#; i++)); do
+        if [ "$skip" = 1 ]; then skip=0; continue; fi
+        case "${!i}" in
+            -f|-F) j=$((i+1)); case "${!j}" in body=*) body="${!j#body=}" ;; esac; skip=1 ;;
+            -*)    ;;
+            *)     [ -z "$endpoint" ] && endpoint="${!i}" ;;
+        esac
+    done
+    printf '%s\n%s\n' "$endpoint" "$body" > "$REPLY_OUT"
+    echo '{"id":2}'
     exit 0
 fi
 exit 1
@@ -73,23 +113,60 @@ diff --git a/classes/Foo.php b/classes/Foo.php
  context line 13
 DIFF
 
+# ── review-thread fixtures ────────────────────────────────────────────────────
+# Four threads on PR 42, mirroring the real GraphQL shape:
+#   111 — UNRESOLVED, score 85, on-line     → must be listed, must be resolvable
+#   222 — RESOLVED,   score 90              → must NOT be listed
+#   333 — UNRESOLVED, no score marker (human-authored), line null (outdated)
+#   ——— UNRESOLVED, comments.nodes EMPTY (sole comment deleted) → must not abort
+#       the whole query: `null | capture(...)` is a hard jq error, so the library
+#       guards with `// ""`.  Deleting this node hides that regression.
+GH_THREADS_FIXTURE="$BASE_TMP/threads.json"
+cat > "$GH_THREADS_FIXTURE" <<'THREADS'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[
+  {"id":"PRRT_open85","isResolved":false,"isOutdated":false,
+   "path":"classes/Foo.php","line":12,
+   "comments":{"nodes":[{"databaseId":111,"body":"Bug X — first line\nmore detail\n\n<!-- score: 85 -->"}]}},
+  {"id":"PRRT_done90","isResolved":true,"isOutdated":false,
+   "path":"classes/Foo.php","line":13,
+   "comments":{"nodes":[{"databaseId":222,"body":"Bug Y already handled\n\n<!-- score: 90 -->"}]}},
+  {"id":"PRRT_human","isResolved":false,"isOutdated":true,
+   "path":"classes/Bar.php","line":null,
+   "comments":{"nodes":[{"databaseId":333,"body":"A human asked a question"}]}},
+  {"id":"PRRT_ghost","isResolved":false,"isOutdated":false,
+   "path":null,"line":null,
+   "comments":{"nodes":[]}}
+]}}}}}
+THREADS
+
+GH_MUTATION_FIXTURE="$BASE_TMP/mutation.json"
+cat > "$GH_MUTATION_FIXTURE" <<'MUT'
+{"data":{"resolveReviewThread":{"thread":{"id":"PRRT_open85","isResolved":true}}}}
+MUT
+
 # ── output capture files ──────────────────────────────────────────────────────
 REVIEW_OUT="$BASE_TMP/review.json"
 COMMENT_OUT="$BASE_TMP/comment.txt"
+REPLY_OUT="$BASE_TMP/reply.txt"
+RESOLVE_OUT="$BASE_TMP/resolved-thread.txt"
 
 # Export all vars the shim and lib need to see from child processes
 export GH_CMD="$SHIMD/gh"
 export REPO_SLUG="a-jay85/IBL5"
 export GH_DIFF_FIXTURE
+export GH_THREADS_FIXTURE
+export GH_MUTATION_FIXTURE
 export REVIEW_OUT
 export COMMENT_OUT
+export REPLY_OUT
+export RESOLVE_OUT
 
 # Source the lib once (GH_CMD and REPO_SLUG already exported above; lib's
 # `:-` defaults are no-ops because the vars are already set)
 # shellcheck disable=SC1090
 source "$LIB"
 
-reset_outputs() { rm -f "$REVIEW_OUT" "$COMMENT_OUT"; }
+reset_outputs() { rm -f "$REVIEW_OUT" "$COMMENT_OUT" "$REPLY_OUT" "$RESOLVE_OUT"; }
 
 # ── assertion helpers ─────────────────────────────────────────────────────────
 ok()   { printf 'ok: %s\n' "$*"; }
@@ -202,6 +279,70 @@ post_review_findings 42 deadbeefcafe "Code review" "$f6"
 assert_absent "case6: no review on empty"   "$REVIEW_OUT"
 assert_absent "case6: no comment on empty"  "$COMMENT_OUT"
 
+# ── case 9: list_open_review_findings ────────────────────────────────────────
+# Expect: 111 and 333 listed (unresolved), 222 omitted (resolved), the
+# comment-less ghost thread skipped without aborting the query.
+reset_outputs
+LIST_OUT="$BASE_TMP/list.tsv"
+list_open_review_findings 42 > "$LIST_OUT"
+
+assert_contains     "case9: unresolved 111 listed"  "$LIST_OUT" "111"
+if awk -F'\t' '$1==111 && $2=="85"' "$LIST_OUT" | grep -q .; then
+    ok "case9: scored thread renders score 85"
+else
+    fail "case9: thread 111 should carry score 85, got: $(awk -F'\t' '$1==111{print $2}' "$LIST_OUT")"
+fi
+assert_contains     "case9: path:line"              "$LIST_OUT" "classes/Foo.php:12"
+assert_contains     "case9: first body line only"   "$LIST_OUT" "Bug X — first line"
+assert_not_contains "case9: resolved 222 omitted"   "$LIST_OUT" "222"
+assert_contains     "case9: human thread 333 listed" "$LIST_OUT" "333"
+if awk -F'\t' '$1==333 && $2=="-"' "$LIST_OUT" | grep -q .; then
+    ok "case9: unscored (human) thread renders score as -"
+else
+    fail "case9: thread 333 should carry score '-', got: $(awk -F'\t' '$1==333{print $2}' "$LIST_OUT")"
+fi
+assert_contains     "case9: null line renders as ?" "$LIST_OUT" "classes/Bar.php:?"
+assert_not_contains "case9: comment-less thread skipped, not listed as null" \
+                    "$LIST_OUT" "null"
+if [ "$(wc -l < "$LIST_OUT")" -eq 2 ]; then
+    ok "case9: exactly 2 unresolved rows (ghost thread did not abort the query)"
+else
+    fail "case9: expected 2 rows, got $(wc -l < "$LIST_OUT")"
+fi
+
+# ── case 10: resolve_review_finding — reply AND resolve ──────────────────────
+# The whole point of the function: a threaded reply alone leaves the thread open,
+# and a resolve alone leaves no record of WHY. Both must happen.
+reset_outputs
+rc=0
+resolve_review_finding 42 111 'Fixed in abc1234 — tightened the guard.' > "$BASE_TMP/resolve-stdout.txt" || rc=$?
+
+if [ "$rc" -eq 0 ]; then ok "case10: exit 0"; else fail "case10: exit $rc, expected 0"; fi
+assert_contains "case10: reply hits the replies endpoint" "$REPLY_OUT" \
+    "repos/a-jay85/IBL5/pulls/42/comments/111/replies"
+assert_contains "case10: reply carries the body"          "$REPLY_OUT" "Fixed in abc1234"
+assert_contains "case10: resolved the OWNING thread"      "$RESOLVE_OUT" "PRRT_open85"
+assert_not_contains "case10: did not resolve a sibling"   "$RESOLVE_OUT" "PRRT_human"
+assert_contains "case10: prints post-mutation isResolved" "$BASE_TMP/resolve-stdout.txt" "true"
+assert_absent   "case10: no top-level pr comment"         "$COMMENT_OUT"
+
+# ── case 11: NEGATIVE — comment id on no thread ──────────────────────────────
+# Must fail loudly rather than resolve an arbitrary thread.
+reset_outputs
+rc=0
+resolve_review_finding 42 999 'Fixed.' >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 1 ]; then ok "case11: unknown comment id → exit 1"; else fail "case11: exit $rc, expected 1"; fi
+assert_absent "case11: no reply posted"   "$REPLY_OUT"
+assert_absent "case11: nothing resolved"  "$RESOLVE_OUT"
+
+# ── case 12: BOUNDARY — malformed comment id ─────────────────────────────────
+reset_outputs
+rc=0
+resolve_review_finding 42 "abc" 'Fixed.' >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 2 ]; then ok "case12: non-numeric comment id → exit 2"; else fail "case12: exit $rc, expected 2"; fi
+assert_absent "case12: no reply posted"  "$REPLY_OUT"
+assert_absent "case12: nothing resolved" "$RESOLVE_OUT"
+
 # ── structural case 7: all 3 callers reference the helper ────────────────────
 for f in \
     "$REPO_ROOT/.claude/skills/post-plan/SKILL.md" \
@@ -230,6 +371,23 @@ do
         ok "case8: $name Step 1 checks PR reviews for prior findings"
     else
         fail "case8: $name Step 1 does NOT check PR reviews — re-run guard broken after findings move off issue comments"
+    fi
+done
+
+# ── structural case 13: all 3 callers document the DISPOSITION step ──────────
+# The posting half without the disposition half is exactly the defect this guards:
+# a session that fixes a finding reaches for `gh pr comment`, which can never close
+# the thread. Each skill that posts findings must also name resolve_review_finding.
+for f in \
+    "$REPO_ROOT/.claude/skills/post-plan/_phase-4-review-audit.md" \
+    "$REPO_ROOT/.claude/skills/pr-review/SKILL.md" \
+    "$REPO_ROOT/.claude/skills/security-audit/SKILL.md"
+do
+    name="$(basename "$f")"
+    if grep -q 'resolve_review_finding' "$f" 2>/dev/null; then
+        ok "case13: $name documents resolve_review_finding"
+    else
+        fail "case13: $name does NOT document resolve_review_finding — a fixed finding will be announced with 'gh pr comment' and its thread left open forever"
     fi
 done
 


### PR DESCRIPTION
## Summary
- `list_open_review_findings`: enumerate unresolved review threads via GraphQL
- `resolve_review_finding`: reply in-thread and mark thread resolved
- Updated skill docs to document disposition workflow
- Prevents findings posted as threads from staying open when addressed

## Manual Testing

No manual testing needed — verified by automated tests.
