### PR TITLE
fix(plan-now): place marker in final message for headless runs

### DIFF
--- a/.claude/rules/headless-marker-contract.md
+++ b/.claude/rules/headless-marker-contract.md
@@ -1,0 +1,67 @@
+---
+description: Headless `claude -p` runners — where a machine-parsed marker must be printed, because text-mode `-p` emits only the model's final message. Path-scoped to bin/**, loads only when authoring or editing a runner.
+last_verified: 2026-07-28
+paths: "bin/**"
+---
+
+# Headless Marker Contract
+
+Several `bin/` scripts fire a headless `claude -p` run and then read a machine-readable
+marker back out of what the run printed — `bin/plan-now` reads `PLAN_FILE: <abs path>`
+to attribute its `bin/check-plan` verdict to the right plan.
+
+## The invariant
+
+**`claude -p` with the default `--output-format text` emits ONLY the model's final
+assistant message.** Everything the model prints earlier in the run — however loudly,
+however early — never reaches the runner's stdout.
+
+So a runner that scrapes a marker out of that stdout has exactly two correct shapes:
+
+| Shape | Where the marker goes |
+|-------|----------------------|
+| Default text mode | The marker MUST be on the **last line of the model's final message**. Say so in the prompt, in those words. |
+| `--output-format stream-json --verbose` (or `json`) | Anywhere — the full event stream is captured. Costs a JSON-parsing step and a non-human-readable transcript. |
+
+Anything else is a silent failure. Asking for the marker "as soon as you decide" or
+"before you start writing" reads as helpful and is structurally unreachable: the model
+complies, text mode discards it, and the runner reports a false negative forever.
+
+**Instruct strictly, parse tolerantly.** Tell the model to print the line bare, then
+accept it wrapped in bold, backticks, or a list marker anyway — the one real transcript
+we have closed with `**Plan:** ` around a backticked path. "Print it bare" is prose
+compliance, and prose compliance is what failed in the first place; do not make it the
+only thing standing between a 45-minute run and `unconfirmed`. Tolerance belongs in the
+*decoration*, never in the *validation*: `bin/plan-now` still requires the parsed path
+to sit inside `$PLANS_DIR` and to exist, so a garbled marker costs a false negative and
+never a false green.
+
+## Why it's worth a rule
+
+`bin/plan-now` shipped with exactly that instruction. Every run it ever made logged
+`RESULT unconfirmed` and never reached its `check-plan` gate — including a 2026-07-28
+run that took 2855s, exited 0, and wrote a perfectly good plan, on a 1294-byte
+transcript containing only its closing message. The failure is fail-safe (never a wrong
+green) and therefore easy to mistake for the model misbehaving.
+
+The other runners are already correct, by different routes — check the one you are
+editing against the table above rather than assuming:
+
+- `bin/bug-pipeline-tick` — `--output-format json`, reads `.result` (that field *is*
+  the final message); the hunter uses `stream-json` and has its agent write results to
+  a file rather than stdout.
+- `bin/automouse-run` — `stream-json --verbose` through `bin/lib/automouse-stream-filter`;
+  it *passes* `PLAN_FILE=` into the prompt as input and parses nothing back out.
+- `bin/post-plan-now`, `bin/docfix-run` — derive the plan path from the branch slug in
+  shell; no model output is parsed.
+
+`bin/test-plan-now` pins all of this for `plan-now` — the decorated shapes it accepts,
+and the three ways a marker still lands `unconfirmed`. It stubs the model call through
+`PLAN_NOW_CLAUDE` / `PLAN_NOW_PLANS_DIR` and runs the runner directly, so it costs no
+tokens and spawns no launchd job. Copy that shape if a second runner ever parses stdout.
+
+## When you add a runner
+
+Choosing text mode is usually right — the transcript stays readable and the log can
+`cat` it. Just put the marker requirement in the final message, and make the prompt say
+*why*, so the next editor does not "improve" it back to an early print.

--- a/bin/plan-now
+++ b/bin/plan-now
@@ -31,9 +31,28 @@
 #     already runs in production (claude -p "/plan …" --model claude-sonnet-4-6
 #     --dangerously-skip-permissions).
 #
-# The run IDENTIFIES ITS OWN PLAN: the coda tells it to print `PLAN_FILE: <abs path>`
-# the moment it picks a slug, and the job reads that line back out of the captured
-# transcript. bug-pipeline-tick's plan-dir diff is NOT concurrency-safe and is kept
+# The run IDENTIFIES ITS OWN PLAN: the coda tells it to end its FINAL message with
+# `PLAN_FILE: <abs path>`, and the job reads that line back out of the captured
+# transcript.
+#
+# THE PLACEMENT IS LOAD-BEARING, NOT STYLISTIC. `claude -p` with the default
+# --output-format text emits ONLY the final assistant message; everything the model
+# prints earlier in the run is discarded before this job ever sees stdout. The coda
+# originally asked for the marker "the moment you have chosen the slug — before you
+# start writing the file", which is precisely the point in the run where text mode
+# guarantees it is thrown away. Every run therefore logged RESULT unconfirmed and
+# never reached check-plan (2026-07-28: a 2855s run exited 0, wrote a valid plan, and
+# still landed unconfirmed on a 1294-byte transcript containing only its closing
+# message). If you ever move that marker instruction, it must stay in the final
+# message — or this job must switch to `--output-format stream-json --verbose` and
+# parse the event stream, the way bin/automouse-run and bin/bug-pipeline-tick do.
+# That was considered and not taken: it turns $OUT from the human-readable transcript
+# the log `cat`s into a multi-MB JSON event stream, which would need a filter
+# (bin/lib/automouse-stream-filter) this job has no other use for. The only thing the
+# early print bought was identifying a TIMED-OUT run, and rc != 0 is already a
+# never-green path below that skips check-plan regardless.
+#
+# bug-pipeline-tick's plan-dir diff is NOT concurrency-safe and is kept
 # only as a labelled best-effort guess — two overlapping plan-now runs each snapshot
 # ~/claude-plans before either writes, so the second finisher sees BOTH new files and
 # `head -1` picks the alphabetically-first. That is not theoretical: the first two
@@ -130,17 +149,19 @@ cat >> "$PROMPT" <<CODA
 **Headless run constraints (appended by \`bin/plan-now\` — these override any
 conflicting default in the skill):**
 
-- **Announce your plan's path.** The moment you have chosen the slug — **before**
-  you start writing the file — print this line on its own, nothing else on it and
-  no backticks or bullet around it:
+- **Announce your plan's path — in your FINAL message.** The **last line** of your
+  final message must be exactly this line, on its own, with nothing after it and no
+  backticks, bullet, bold or fence around it:
   \`\`\`
   PLAN_FILE: $PLANS_DIR/<slug>.md
   \`\`\`
   (absolute path). This job identifies your plan by that line; without it the
   check-plan verdict cannot be attributed to your run, because a directory scan is
-  ambiguous whenever another \`plan-now\` run overlaps yours. Print it early so an
-  interrupted or timed-out run is still identifiable. If you later change the slug,
-  print the line again with the new path — the last one wins.
+  ambiguous whenever another \`plan-now\` run overlaps yours. **The final message is
+  the only placement that works**: this job runs you under \`claude -p\`, which emits
+  only your final assistant message, so a marker printed at any earlier point is
+  discarded before this job can read it. Printing it earlier as well is harmless —
+  the last occurrence wins — but never a substitute.
 - **No human is present.** Never call \`AskUserQuestion\`, never pause for input,
   never end a turn waiting for an answer. The forks a human could answer were
   already resolved by the session that drafted this prompt; they appear above as
@@ -191,7 +212,9 @@ started=$(date +%s)
 # autoCompactWindow pin — rationale in bin/automouse-run.
 # caffeinate -s keeps the Mac awake on AC for the run's duration.
 # 5400s: the first two real runs took 36 and 42 minutes, too close to the old
-# 3600s cap. claude -p does not stream, so $OUT stays empty until it exits.
+# 3600s cap. claude -p does not stream, so $OUT stays empty until it exits — and with
+# the default --output-format text it then holds ONLY the final assistant message,
+# which is why the coda demands PLAN_FILE: on that message's last line (see header).
 CLAUDE_HEADLESS=1 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 caffeinate -s \
     timeout 5400 "$CLAUDE_BIN" -p "$(cat "$PROMPT")" \
     --dangerously-skip-permissions \
@@ -206,10 +229,17 @@ elapsed=$(( $(date +%s) - started ))
 #   1. the run's own PLAN_FILE: line (concurrency-safe — see the header)
 #   2. otherwise the newest new .md in $PLANS_DIR, reported as an UNVERIFIED guess
 #      and never check-plan'd, because a concurrent run's file can be newer.
-# Leading whitespace is tolerated: the model may indent the line inside a fence or
-# a list. A mis-shaped marker costs us `unconfirmed`, never a wrong green.
-plan=$(grep -oE '^[[:space:]]*PLAN_FILE:[[:space:]]*\S.*' "$OUT" 2>/dev/null | tail -1 \
-       | sed -E 's/^[[:space:]]*PLAN_FILE:[[:space:]]*//; s/[[:space:]]+$//')
+# The parse is deliberately tolerant of markdown decoration on BOTH sides of the
+# marker — the model writes prose, and "print it bare" is an instruction it can
+# soften. The one real transcript we have closed with `**Plan:** ` + a backticked
+# path, so `**PLAN_FILE:** ...`, `- PLAN_FILE: ...` and a backtick-wrapped path are
+# all treated as compliant. (The old comment claimed a list-indented line was
+# tolerated; it was not — a `-` is not [[:space:]], so that case never matched.)
+# tail -1 keeps the last occurrence, so restating the marker wins. Nothing here
+# relaxes the $PLANS_DIR + file-exists guard below: a mis-shaped or bogus marker
+# still costs us `unconfirmed`, never a wrong green.
+plan=$(grep -E '^[-*>`[:space:]]*PLAN_FILE:' "$OUT" 2>/dev/null | tail -1 \
+       | sed -E 's/^.*PLAN_FILE:[[:space:]*`]*//; s/[[:space:]*`]+$//')
 case "$plan" in
     "$PLANS_DIR"/*.md) [ -f "$plan" ] || { echo "plan-now: PLAN_FILE named a file that does not exist: $plan"; plan=""; } ;;
     "")   ;;

--- a/bin/test-plan-now
+++ b/bin/test-plan-now
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-plan-now — pins how bin/plan-now identifies the plan a headless run
+# produced, i.e. the PLAN_FILE: marker contract (.claude/rules/headless-marker-contract.md).
+#
+# Why this test exists: every plan-now run up to 2026-07-28 logged `RESULT
+# unconfirmed` and never reached its check-plan gate, because the coda asked for the
+# marker BEFORE the plan was written and `claude -p` (default --output-format text)
+# emits only the model's final message. The stub below emulates exactly that — it is
+# the run's final message and nothing else — so the "no marker" case IS the original
+# bug, and the decorated cases pin the tolerant parse that keeps prose deviation from
+# reproducing it.
+#
+# No launchd: PLAN_NOW_DRY_RUN=1 makes plan-now write its runner and stop, and the
+# test executes that runner directly. Synchronous, no background jobs, no cleanup debt.
+# PLAN_NOW_CLAUDE / PLAN_NOW_PLANS_DIR are the seams plan-now already documents.
+#
+# Run: bin/test-plan-now  (exit 0 = all pass, 1 = a case failed)
+
+set -u
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+PLAN_NOW="$ROOT/bin/plan-now"
+FAILS=0
+
+ok()   { printf '  ok   %s\n' "$1"; }
+fail() { printf '  FAIL %s\n' "$1"; FAILS=$((FAILS + 1)); }
+
+TMP=$(mktemp -d -t test-plan-now)
+trap 'rm -rf "$TMP"' EXIT
+
+PLANS="$TMP/plans"
+mkdir -p "$PLANS"
+
+# The prompt plan-now is handed. Only the leading /plan line matters to it.
+PROMPT="$TMP/prompt.md"
+printf '/plan a throwaway task for bin/test-plan-now\n' > "$PROMPT"
+
+# ── The stub model ────────────────────────────────────────────────────────────
+# Stands in for `claude -p`: writes a plan file (unless STUB_NO_PLAN), then prints
+# ONLY what a text-mode run would emit — the final assistant message. $STUB_TAIL is
+# whatever that message ends with.
+STUB="$TMP/claude-stub"
+cat > "$STUB" <<'STUB_EOF'
+#!/usr/bin/env bash
+[ -n "${STUB_PLAN:-}" ] && [ -z "${STUB_NO_PLAN:-}" ] && printf '# stub plan\n' > "$STUB_PLAN"
+printf 'Done — the plan is written and check-plan is clean.\n'
+[ -n "${STUB_TAIL:-}" ] && printf '%s\n' "$STUB_TAIL"
+exit 0
+STUB_EOF
+chmod +x "$STUB"
+
+# run_case <plan-file-the-stub-writes> <final-message-tail>  → transcript on stdout
+run_case() {
+    local plan_path="$1" tail_line="$2"
+    rm -f "$PLANS"/*.md
+    local dry runner
+    dry=$(PLAN_NOW_DRY_RUN=1 PLAN_NOW_CLAUDE="$STUB" PLAN_NOW_PLANS_DIR="$PLANS" \
+              "$PLAN_NOW" --implement "$PROMPT" 2>&1)
+    runner=$(printf '%s\n' "$dry" | sed -n 's/^  runner: //p')
+    [ -x "$runner" ] || { printf 'could not get a runner out of plan-now:\n%s\n' "$dry"; return 1; }
+    STUB_PLAN="$plan_path" STUB_TAIL="$tail_line" STUB_NO_PLAN="${STUB_NO_PLAN:-}" \
+        bash "$runner" 2>&1
+    rm -f "$runner"
+}
+
+want()    { case "$2" in *"$3"*) ok "$1" ;; *) fail "$1 — expected to see: $3" ;; esac; }
+want_no() { case "$2" in *"$3"*) fail "$1 — should NOT have seen: $3" ;; *) ok "$1" ;; esac; }
+
+P="$PLANS/demo-slug.md"
+
+echo "── identification: the shapes a model actually emits ──"
+
+out=$(run_case "$P" "PLAN_FILE: $P")
+want "bare marker on the last line identifies the plan" "$out" "plan-now: new plan -> $P"
+
+# ★ THE REGRESSION. The one real transcript closed with `**Plan:** ` + a backticked
+# path, so bold/backticks are the deviation we have evidence for. The pre-fix regex
+# was anchored `^[[:space:]]*PLAN_FILE:` and matched none of the three below.
+out=$(run_case "$P" "**PLAN_FILE:** $P")
+want "bold-wrapped marker still identifies the plan" "$out" "plan-now: new plan -> $P"
+
+out=$(run_case "$P" "- PLAN_FILE: \`$P\`")
+want "list-prefixed + backticked path still identifies the plan" "$out" "plan-now: new plan -> $P"
+
+out=$(run_case "$P" "PLAN_FILE: $P")
+want "an identified plan reaches the check-plan gate" "$out" "check-plan"
+
+echo "── fail-safe: a bad marker costs 'unconfirmed', never a wrong green ──"
+
+# This is the original bug verbatim: a clean run, a written plan, and a final message
+# with no marker in it (the marker went out early and text mode discarded it).
+out=$(run_case "$P" "")
+want "no marker → unconfirmed" "$out" "RESULT unconfirmed"
+want_no "no marker → check-plan is NOT run" "$out" "plan-now: new plan ->"
+
+out=$(run_case "$P" "PLAN_FILE: /etc/passwd")
+want "marker outside \$PLANS_DIR is rejected" "$out" "ignoring PLAN_FILE outside"
+want "marker outside \$PLANS_DIR → unconfirmed" "$out" "RESULT unconfirmed"
+
+out=$(STUB_NO_PLAN=1 run_case "$P" "PLAN_FILE: $P")
+want "marker naming a nonexistent file is rejected" "$out" "named a file that does not exist"
+want "marker naming a nonexistent file → unconfirmed" "$out" "RESULT unconfirmed"
+
+echo "── the coda still tells the model where to put it ──"
+
+dry=$(PLAN_NOW_DRY_RUN=1 PLAN_NOW_CLAUDE="$STUB" PLAN_NOW_PLANS_DIR="$PLANS" \
+          "$PLAN_NOW" --implement "$PROMPT" 2>&1)
+coda=$(cat "$(printf '%s\n' "$dry" | sed -n 's/^  prompt: //p')" 2>/dev/null)
+want "coda demands the FINAL message" "$coda" "FINAL message"
+want "coda demands the last line" "$coda" "last line"
+# Tolerant parsing is a backstop for prose drift, not a licence to move the
+# instruction: under text mode an early-only marker is unreachable, full stop.
+want "coda explains why an earlier print is discarded" "$coda" "discarded"
+
+echo
+if [ "$FAILS" -eq 0 ]; then
+    echo "test-plan-now: all cases passed"
+else
+    echo "test-plan-now: $FAILS case(s) FAILED"
+fi
+exit $(( FAILS > 0 ? 1 : 0 ))


### PR DESCRIPTION
## Summary

Fixes a silent failure in `bin/plan-now` where the `PLAN_FILE:` marker was emitted too early in the agent turn. In `claude -p` text-mode (headless), only the **final** assistant message is captured — earlier prints are silently discarded, so parsing always returned `unconfirmed` even on successful runs.

### Changes
- **`bin/plan-now`** — Move marker emission to the final assistant message block; broaden parse tolerance for markdown decoration (bold, backticks, list markers)
- **`.claude/rules/headless-marker-contract.md`** — Documents the invariant: for any agent invoked via `claude -p`, the `PLAN_FILE:` marker must appear in the final message
- **`bin/test-plan-now`** — Regression test suite pinning the parsing contract (marker format variants, negative cases, extraction accuracy)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.