### PR TITLE
chore: wire unwired tests and fix cross-platform compat

### DIFF
--- a/.claude/rules/meta-tooling-bar.md
+++ b/.claude/rules/meta-tooling-bar.md
@@ -1,6 +1,6 @@
 ---
 description: Before adding a new hook, CI gate, workflow, or bin/ script, first ask whether an existing one can be extended; quarterly cull retires dead meta-tooling.
-last_verified: 2026-07-25
+last_verified: 2026-07-28
 paths:
   - "bin/**"
   - ".github/workflows/**"
@@ -42,6 +42,7 @@ The teeth are documented hand-run greps, not a maintained script (a `bin/cull-au
 
 - **Orphaned `test-*`** — a `test-*` in `bin/` whose target no longer exists: list `bin/`'s `test-*`, derive each target, confirm it still exists.
 - **Unreferenced gate** — a `check-*` referenced by no `.github/workflows/*.yml`: grep the workflows dir for each `check-*` name; zero hits ⇒ candidate.
+- **Unwired `test-*`** — a `test-*` whose target still exists but which **no workflow ever runs**: `for t in bin/test-*; do n=$(basename "$t"); grep -rqF "$n" .github/workflows/ || echo "UNWIRED $n"; done`, then check each hit for an invoking wrapper (a wrapper counts as wired). Such a test passes locally forever and protects nothing — it sits between the two checks above, which is how `bin/test-plan-now` went unrun from creation until 2026-07-28. The disposition is **wire it or retire it**, judgment-gated as usual; a test that self-skips off-platform (`bin/test-automouse-single`, macOS-only) is a legitimate stay-unwired, since wiring it to a Linux runner buys a SKIP line. This is the *inverse* of the trap below — it never mandates a new `test-*`, it only asks whether an existing one runs.
 - **Buggy gate/hook** — a gate/hook with bugs recorded in memory: is it still earning its keep, or has its cost outgrown its value?
 - **Dead rule / silent hook** — a rule superseded by another, or a hook that never fires: confirm against recent logs/PRs.
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -722,6 +722,10 @@ jobs:
         run: bin/test-sim-recap-tick
       - name: bin/test-plan-now
         run: bin/test-plan-now
+      - name: bin/test-token-report
+        run: bin/test-token-report
+      - name: bin/test-automouse-escalation
+        run: bin/test-automouse-escalation
 
   gate:
     name: Tests and Analysis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -720,6 +720,8 @@ jobs:
         run: bin/test-bug-pipeline-hunt
       - name: bin/test-sim-recap-tick
         run: bin/test-sim-recap-tick
+      - name: bin/test-plan-now
+        run: bin/test-plan-now
 
   gate:
     name: Tests and Analysis

--- a/bin/plan-now
+++ b/bin/plan-now
@@ -300,6 +300,10 @@ RUNNER_EOF
 } > "$RUNNER"
 chmod +x "$RUNNER"
 
+# ~/Library/LaunchAgents always exists on the Mac this job runs on; the mkdir is for
+# the Linux CI box, where bin/test-plan-now drives this script under PLAN_NOW_DRY_RUN
+# and `set -e` would otherwise abort here before the runner path is printed.
+mkdir -p "$(dirname "$PLIST")"
 cat > "$PLIST" <<PLIST_EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/bin/test-plan-now
+++ b/bin/test-plan-now
@@ -27,11 +27,29 @@ FAILS=0
 ok()   { printf '  ok   %s\n' "$1"; }
 fail() { printf '  FAIL %s\n' "$1"; FAILS=$((FAILS + 1)); }
 
-TMP=$(mktemp -d -t test-plan-now)
+# A full template, not `mktemp -d -t <prefix>`: GNU mktemp rejects a -t argument
+# with too few X's, so the BSD spelling would fail on the Linux CI runner.
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/test-plan-now.XXXXXX")
 trap 'rm -rf "$TMP"' EXIT
 
 PLANS="$TMP/plans"
 mkdir -p "$PLANS"
+
+# `caffeinate` is macOS-only and the runner wraps the model call in it. Unshimmed,
+# this test cannot run on Linux CI: command-not-found → rc != 0 → every
+# identification case falls into the RESULT-failed branch and the marker contract
+# goes untested. The shim also keeps a local run from taking a real power assertion.
+# It lives in the inherited PATH, which the runner's own PATH prelude only
+# *prepends* to, so it is reachable on both platforms.
+SHIM="$TMP/bin"
+mkdir -p "$SHIM"
+cat > "$SHIM/caffeinate" <<'SHIM_EOF'
+#!/usr/bin/env bash
+while [ $# -gt 0 ]; do case "$1" in -*) shift ;; *) break ;; esac; done
+exec "$@"
+SHIM_EOF
+chmod +x "$SHIM/caffeinate"
+export PATH="$SHIM:$PATH"
 
 # The prompt plan-now is handed. Only the leading /plan line matters to it.
 PROMPT="$TMP/prompt.md"
@@ -84,8 +102,12 @@ want "bold-wrapped marker still identifies the plan" "$out" "plan-now: new plan 
 out=$(run_case "$P" "- PLAN_FILE: \`$P\`")
 want "list-prefixed + backticked path still identifies the plan" "$out" "plan-now: new plan -> $P"
 
+# Asserting on `RESULT degraded`, NOT on the substring "check-plan": the unconfirmed
+# branch prints "check-plan was NOT run", so a substring test there passes whether or
+# not the gate ever ran. `degraded` is printed only after check-plan actually executed
+# and failed — which it does here, the stub plan being one line of nothing.
 out=$(run_case "$P" "PLAN_FILE: $P")
-want "an identified plan reaches the check-plan gate" "$out" "check-plan"
+want "an identified plan actually reaches the check-plan gate" "$out" "RESULT degraded"
 
 echo "── fail-safe: a bad marker costs 'unconfirmed', never a wrong green ──"
 
@@ -108,6 +130,10 @@ echo "── the coda still tells the model where to put it ──"
 dry=$(PLAN_NOW_DRY_RUN=1 PLAN_NOW_CLAUDE="$STUB" PLAN_NOW_PLANS_DIR="$PLANS" \
           "$PLAN_NOW" --implement "$PROMPT" 2>&1)
 coda=$(cat "$(printf '%s\n' "$dry" | sed -n 's/^  prompt: //p')" 2>/dev/null)
+# This dry-run's runner is never executed, and the runner is what deletes the plist.
+# Without this, every test run leaves a RunAtLoad plist in ~/Library/LaunchAgents
+# pointing at a /tmp runner that no longer exists.
+rm -f "$(printf '%s\n' "$dry" | sed -n 's/^  plist:  //p')"
 want "coda demands the FINAL message" "$coda" "FINAL message"
 want "coda demands the last line" "$coda" "last line"
 # Tolerant parsing is a backstop for prose drift, not a licence to move the


### PR DESCRIPTION
## Summary
- Wired three unwired tests (`test-plan-now`, `test-token-report`, `test-automouse-escalation`) to CI workflow
- Documented unwired test detection pattern in meta-tooling rules
- Fixed `bin/test-plan-now` mktemp for BSD/GNU compatibility and added caffeinate shim for Linux
- Fixed `bin/plan-now` to create plist parent directory on Linux CI

## Manual Testing

No manual testing needed — verified by automated tests.
