### PR TITLE
chore(rules): remove cascading paths and update verification dates

### DIFF
--- a/.claude/rules/linear-history-squash-merge.md
+++ b/.claude/rules/linear-history-squash-merge.md
@@ -1,8 +1,7 @@
 ---
 description: Linear history — squash/rebase-merge only — path-scoped, loads only for post-plan/rebase surfaces. Read before diagnosing a "SHA not in master" result or rebasing a stacked branch after its parent merged.
-last_verified: 2026-07-25
+last_verified: 2026-07-28
 paths:
-  - ".claude/rules/workflow-continuity.md"
   - ".claude/skills/post-plan/SKILL.md"
   - "tools/postplan-harness/**"
 ---

--- a/.claude/rules/work-triage-detail.md
+++ b/.claude/rules/work-triage-detail.md
@@ -2,7 +2,6 @@
 description: Read-on-demand detail for work-triage — measurement context for the inline-Opus leak, ADR-0067 gateway framing, hard-trigger gate properties (sub-agent exemption, per-turn scoping, escape hatch, self-test), the cross-worktree straddle gate's four-rung remedy ladder, inline-vs-delegated criteria, safety-mirror backstop, and repeat-polling spend rationale.
 last_verified: 2026-07-28
 paths:
-  - ".claude/rules/work-triage.md"
   - "~/.claude/hooks/plan-gate-edit.sh"
 ---
 

--- a/.claude/rules/workflow-continuity-detail.md
+++ b/.claude/rules/workflow-continuity-detail.md
@@ -1,8 +1,7 @@
 ---
 description: Post-plan engine internals — compiled harness vs. Sonnet skill fallback, what `--auto`'s skip gate does, and where the auto-merge arming decision is made. Lazy companion to workflow-continuity.md; loads only when a post-plan surface is in play.
-last_verified: 2026-07-25
+last_verified: 2026-07-28
 paths:
-  - ".claude/rules/workflow-continuity.md"
   - ".claude/skills/post-plan/SKILL.md"
   - ".claude/skills/ship/SKILL.md"
   - "tools/postplan-harness/**"


### PR DESCRIPTION
## Summary
- Removed cross-file cascading rule dependencies from path lists
- Updated verification dates to 2026-07-28
- Simplifies rule configuration by eliminating transitive path references

## Manual Testing

No manual testing needed — verified by automated tests.
