### PR TITLE
chore(rules): clarify paths residency semantics and glob constraints

### DIFF
--- a/.claude/rules/doc-freshness.md
+++ b/.claude/rules/doc-freshness.md
@@ -1,6 +1,6 @@
 ---
-description: Frontmatter schema, 60-day staleness policy, on-touch verification rule, dead-reference rule, and the retired-figure rule enforced by bin/check-docs
-last_verified: 2026-07-24
+description: Frontmatter schema (including `paths:` residency semantics — repo-relative only, never glob an always-loaded rule), 60-day staleness policy, on-touch verification rule, dead-reference rule, and the retired-figure rule enforced by bin/check-docs
+last_verified: 2026-07-28
 paths: "**/*.md"
 ---
 
@@ -20,6 +20,17 @@ paths: "glob-or-list"  # only meaningful for .claude/rules/*
 ```
 
 `description` and `last_verified` are required. `owner` and `paths` are optional.
+
+### `paths:` residency semantics (`.claude/rules/*` only)
+
+`paths:` is the residency selector. **No `paths:` ⇒ always-loaded** into every system prompt; **with `paths:` ⇒ lazy**, attaching only when a matching file is touched. Two constraints on writing one:
+
+- **Repo-relative only.** A `~/`- or `/`-prefixed entry does not match in practice, so it is not a trigger at all — even when the doc exists to explain that out-of-repo file. Verified 2026-07-28 across session transcripts: sessions that edited the hook named in `work-triage-detail.md`'s `paths:` attached the doc zero times.
+- **Never glob an always-loaded rule's own path.** Compaction restore re-materializes the resident set as file attachments, and that re-materialization is itself a *touch* — so a companion globbing its parent re-attaches every window, self-sustaining, with no tool call anywhere in the window touching the trigger. Three companions did this until PR #1730. The per-window cost is real but varies by session — the restore set is "whatever was resident," not a fixed list — so measure it on your own transcript rather than trusting a quoted figure. Point the glob at the **source surface** the doc explains instead.
+
+This is not an argument for narrow globs generally. A deliberately broad glob aimed at a real surface — this doc's `**/*.md`, `meta-tooling-bar.md`'s `.claude/**` — re-attaches on restores too, and that is intended: both docs govern the surface being restored. The defect is a glob whose *only* purpose is to ride its parent's residency.
+
+A companion left with no live trigger is **Read-on-demand only**. That is legitimate when the always-loaded parent cites it by name at each decision point — but say so in the `description`, so the next reader doesn't assume it auto-attaches.
 
 ## On-Touch Rule
 

--- a/.claude/rules/work-triage-detail.md
+++ b/.claude/rules/work-triage-detail.md
@@ -1,5 +1,5 @@
 ---
-description: Read-on-demand detail for work-triage — measurement context for the inline-Opus leak, ADR-0067 gateway framing, hard-trigger gate properties (sub-agent exemption, per-turn scoping, escape hatch, self-test), the cross-worktree straddle gate's four-rung remedy ladder, inline-vs-delegated criteria, safety-mirror backstop, and repeat-polling spend rationale.
+description: Read-on-demand detail for work-triage — NO auto-attach trigger (its only `paths:` entry is out-of-repo and never matches); Read it when work-triage.md cites it. Covers measurement context for the inline-Opus leak, ADR-0067 gateway framing, hard-trigger gate properties (sub-agent exemption, per-turn scoping, escape hatch, self-test), the cross-worktree straddle gate's four-rung remedy ladder, inline-vs-delegated criteria, safety-mirror backstop, and repeat-polling spend rationale.
 last_verified: 2026-07-28
 paths:
   - "~/.claude/hooks/plan-gate-edit.sh"
@@ -8,6 +8,8 @@ paths:
 # Work Triage — Detail
 
 Read-on-demand companion to `work-triage.md` (always-loaded).
+
+**This file never auto-attaches.** Its `paths:` entry points at a hook outside the repo, and out-of-repo entries do not match (`doc-freshness.md` § `paths:` residency semantics). The `paths:` key is kept non-empty only so the doc isn't promoted to always-loaded — access is by explicit Read, at the points where `work-triage.md` names this file. Do **not** "fix" it by globbing `.claude/rules/work-triage.md`: that is the compaction cascade PR #1730 removed.
 
 ## Execution routing context
 


### PR DESCRIPTION
## Summary
- Added `paths:` residency semantics section to doc-freshness.md
  - Documented repo-relative-only constraint (out-of-repo entries never trigger)
  - Explained never-glob-parent rule to prevent compaction-restore cascades (PR #1730)
  - Clarified read-on-demand vs. always-loaded distinction
- Updated work-triage-detail.md to document no-auto-attach status
  - Noted its hook path is out-of-repo, so paths entry never matches
  - Explained paths key retained to prevent always-load promotion
  - Access remains explicit Read at points where work-triage.md cites it
- Bumped last_verified to 2026-07-28

## Manual Testing

No manual testing needed — verified by automated tests.
