### PR TITLE
chore(phpunit): ban broad empty catch blocks in tests

### DIFF
--- a/.claude/rules/phpunit-tests.md
+++ b/.claude/rules/phpunit-tests.md
@@ -1,7 +1,7 @@
 ---
 description: PHPUnit testing rules: output parsing, behavior-focused patterns.
 paths: ibl5/tests/**/*.php
-last_verified: 2026-07-24
+last_verified: 2026-07-28
 ---
 
 # PHPUnit Testing Rules
@@ -67,6 +67,7 @@ class ModuleServiceTest extends TestCase
 - **NEVER** `markTestSkipped()` to silently disable — delete instead. Sole exception: integration-availability skip (service unreachable) with an inline `// phpunit-hygiene-allow: <reason ≥20 chars>` marker; `bin/check-phpunit-hygiene` enforces this.
 - **NEVER** `setAccessible(true)` on a `ReflectionProperty`/`ReflectionMethod` — a no-op since PHP 8.1 and **deprecated since 8.5** (fatal in PHP 9). `getValue()`/`invoke()` already reach private members; just delete the call. `bin/check-phpunit-hygiene` enforces this.
 - **NEVER** assert full SQL structure (columns, WHERE, bind strings) except in security tests. For void writes, `assertQueryExecuted('table_name')` verifies the target table was hit — don't match beyond the table name.
+- **NEVER** wrap the system under test in a broad empty catch (`catch (\Throwable) {}`, `\Exception`, `\Error`) — it swallows every failure including a fatal on the first line, leaving a test that cannot fail. Narrow the caught type, use `expectException()`, or assert on post-state inside the catch. A comment-only body counts as empty. `RequireMeaningfulAssertionsRule` (in `composer run analyse:tests`) enforces this.
 
 ## Mock vs Stub
 

--- a/ibl5/phpstan-rules/RequireMeaningfulAssertionsRule.php
+++ b/ibl5/phpstan-rules/RequireMeaningfulAssertionsRule.php
@@ -11,8 +11,11 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\Int_ as IntLiteral;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Catch_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Nop;
+use PhpParser\Node\Stmt\TryCatch;
 use PhpParser\NodeFinder;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
@@ -26,6 +29,9 @@ use PHPStan\Type\VerbosityLevel;
  *      `assertNull(null)`, `assertEquals($x, $x)` with identical literal args.
  *   3. `assertNotNull($x)` where PHPStan statically knows `$x` is non-nullable
  *      (its type's `isNull()` is `no`), so the assertion always passes.
+ *   4. Empty `catch` blocks for a broad type (`\Throwable`, `\Exception`, `\Error`),
+ *      which swallow every failure — including a fatal on the first line of the
+ *      system under test — leaving a test that cannot fail.
  *
  * Only applies to files under tests/ whose class methods start with `test`.
  *
@@ -44,6 +50,17 @@ final class RequireMeaningfulAssertionsRule implements Rule
         'assertSame',
         'assertNotEquals',
         'assertNotSame',
+    ];
+
+    /**
+     * Fully-qualified catch types broad enough that an empty handler hides a fatal
+     * in the system under test, not just the narrow failure the test anticipated.
+     * Lower-cased for case-insensitive comparison.
+     */
+    private const BROAD_CAUGHT_TYPES = [
+        'throwable',
+        'exception',
+        'error',
     ];
 
     public function getNodeType(): string
@@ -152,7 +169,66 @@ final class RequireMeaningfulAssertionsRule implements Rule
             }
         }
 
+        // Sub-check 4: empty catch block for a broad type. Swallows every failure the
+        // system under test can produce, so the test passes even when it fatals.
+        foreach ($nodeFinder->findInstanceOf($node->stmts, TryCatch::class) as $tryCatch) {
+            if (!$tryCatch instanceof TryCatch) {
+                continue;
+            }
+            foreach ($tryCatch->catches as $catch) {
+                if (!$this->hasNoEffectiveStatements($catch)) {
+                    continue;
+                }
+                $broadType = $this->firstBroadCaughtType($catch);
+                if ($broadType === null) {
+                    continue;
+                }
+                $errors[] = RuleErrorBuilder::message(
+                    'Empty `catch (' . $broadType . ')` in test method `' . $node->name->name . '()` '
+                    . 'swallows every failure the code under test can produce — including a fatal on '
+                    . 'its first line — so the test cannot fail. Narrow the caught type to the specific '
+                    . 'exception the test expects, use `expectException()`, or assert on post-state '
+                    . 'inside the catch.'
+                )
+                    ->identifier('ibl.meaninglessAssertion')
+                    ->line($catch->getStartLine())
+                    ->build();
+            }
+        }
+
         return $errors;
+    }
+
+    /**
+     * A catch body holding nothing but a comment parses as a single `Nop`, so counting
+     * statements alone would miss the `catch (\Throwable $e) { // ignored }` shape —
+     * which is the one this check exists for.
+     */
+    private function hasNoEffectiveStatements(Catch_ $catch): bool
+    {
+        foreach ($catch->stmts as $stmt) {
+            if (!$stmt instanceof Nop) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns the first broad type this catch clause names (as written, with a leading
+     * backslash for readability), or null when every caught type is narrow.
+     */
+    private function firstBroadCaughtType(Catch_ $catch): ?string
+    {
+        foreach ($catch->types as $type) {
+            $name = ltrim($type->toString(), '\\');
+            if (in_array(strtolower($name), self::BROAD_CAUGHT_TYPES, true)) {
+                return '\\' . $name;
+            }
+        }
+
+        return null;
     }
 
     private function isConstFetchWithName(Arg $arg, string $name): bool

--- a/ibl5/tests/PHPStanRules/Fixtures/tests/BroadEmptyCatchFixture.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/tests/BroadEmptyCatchFixture.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+final class BroadEmptyCatchFixture
+{
+    public function testSwallowsEverything(): void
+    {
+        try {
+            $this->systemUnderTest();
+        } catch (\Throwable $e) {
+            // Intentionally ignored.
+        }
+
+        $this->assertTrue($this->collaboratorWasCalled());
+    }
+
+    public function testNarrowEmptyCatchIsAllowed(): void
+    {
+        try {
+            $this->systemUnderTest();
+        } catch (\RuntimeException $e) {
+        }
+
+        $this->assertTrue($this->collaboratorWasCalled());
+    }
+
+    public function testBroadCatchWithABodyIsAllowed(): void
+    {
+        try {
+            $this->systemUnderTest();
+        } catch (\Throwable $e) {
+            $this->assertSame('boom', $e->getMessage());
+        }
+    }
+
+    public function testSwallowsEverythingWithoutEvenAComment(): void
+    {
+        try {
+            $this->systemUnderTest();
+        } catch (\Exception $e) {
+        }
+
+        $this->assertTrue($this->collaboratorWasCalled());
+    }
+
+    private function systemUnderTest(): void
+    {
+    }
+
+    private function collaboratorWasCalled(): bool
+    {
+        return true;
+    }
+}

--- a/ibl5/tests/PHPStanRules/RequireMeaningfulAssertionsRuleTest.php
+++ b/ibl5/tests/PHPStanRules/RequireMeaningfulAssertionsRuleTest.php
@@ -77,6 +77,38 @@ final class RequireMeaningfulAssertionsRuleTest extends RuleTestCase
         );
     }
 
+    /**
+     * The fixture holds every shape at once, so one expectation proves all four claims:
+     * a comment-only broad catch is flagged (a comment parses as a `Nop`, not as an
+     * empty body), a bare broad catch is flagged, and neither a narrow empty catch nor
+     * a broad catch that actually asserts is.
+     */
+    public function testFlagsBroadEmptyCatchButAllowsNarrowOrAssertingCatch(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/tests/BroadEmptyCatchFixture.php'],
+            [
+                [
+                    'Empty `catch (\Throwable)` in test method `testSwallowsEverything()` '
+                    . 'swallows every failure the code under test can produce — including a '
+                    . 'fatal on its first line — so the test cannot fail. Narrow the caught '
+                    . 'type to the specific exception the test expects, use '
+                    . '`expectException()`, or assert on post-state inside the catch.',
+                    11,
+                ],
+                [
+                    'Empty `catch (\Exception)` in test method '
+                    . '`testSwallowsEverythingWithoutEvenAComment()` swallows every failure '
+                    . 'the code under test can produce — including a fatal on its first line '
+                    . '— so the test cannot fail. Narrow the caught type to the specific '
+                    . 'exception the test expects, use `expectException()`, or assert on '
+                    . 'post-state inside the catch.',
+                    41,
+                ],
+            ],
+        );
+    }
+
     public function testAllowsAssertNotNullOnNullableOrMixedValue(): void
     {
         $this->analyse(


### PR DESCRIPTION
## Summary
- Add `RequireMeaningfulAssertionsRule` check to detect empty `catch (\Throwable)`, `catch (\Exception)`, or `catch (\Error)` blocks in test methods
- These broad empty handlers swallow every failure including fatals, leaving untestable code
- Enforce via `composer run analyse:tests`; narrow the caught type, use `expectException()`, or assert on post-state inside the catch
- Update phpunit-tests.md documentation with the new rule
- Include fixture demonstrating allowed vs disallowed patterns

## Manual Testing

No manual testing needed — verified by automated tests.
