### PR TITLE
chore(postplan): skip fenced rows in matrix parsing

### DIFF
--- a/.claude/skills/post-plan/_phase-5-final-verification.md
+++ b/.claude/skills/post-plan/_phase-5-final-verification.md
@@ -11,7 +11,7 @@ At Phase 5.0 START, clear the conformance bridge file AND remove the done-marker
 rm -f /tmp/post-plan-conformance-done-$PPID
 ```
 
-Read the Verification Matrix from `$PLAN_FILE`. Collect the test-file path from the "Test file / location" column of every row whose Test type is PHPUnit, API-test, E2E, or Visual-regression. Confirm the PR diff actually wrote each one:
+Read the Verification Matrix from `$PLAN_FILE`. Collect the test-file path from the "Test file / location" column of every row whose Test type is PHPUnit, API-test, E2E, or Visual-regression. **Skip every row inside a fenced code block** — a plan that documents the matrix format carries scaffold rows (`| 1 | thing works | PHPUnit | post-impl | \`tests/X.php\` |`) inside a ```` ```bash ```` fixture block, and those are illustration, not declarations. Reading one produces a phantom path no diff can ever contain, so the resulting `MISSING:` is unresolvable and condition (3) holds the PR forever (observed on plan `critical-files-parser-unification`). Fence tracking is **width-aware**, same rule as `## Critical Files` below: this repo wraps 3-backtick blocks in 4-backtick outer ones, and per CommonMark a closing fence must be at least as long as its opener — a width-blind toggle closes on the inner fence and swallows the real matrix underneath. The same skip applies to Truly-manual rows (condition (1) reads those). Then confirm the PR diff actually wrote each collected path:
 
 ```bash
 git diff --name-only origin/master...HEAD > /tmp/post-plan-changed-$PPID

--- a/bin/test-postplan-arm-conditions
+++ b/bin/test-postplan-arm-conditions
@@ -329,6 +329,54 @@ else
     FAILED=1
 fi
 
+# ── Matrix extraction must skip fenced rows (feeds conditions (1) and (3)) ────
+# Same defect class as the decoy ## Critical Files heading above, on the other
+# Phase 5.0 parser: a plan documenting the matrix format carries scaffold rows
+# inside a fixture block. Read as declarations they become phantom MISSING: /
+# truly-manual items that no diff can resolve, holding the PR forever. Live on
+# plan `critical-files-parser-unification` (`tests/X.php`).
+MX_FIX="$BASE_TMP/matrix-fence.md"
+cat > "$MX_FIX" <<'MXEOF'
+## Verification Matrix
+
+````bash
+# Outer 4-backtick fence wrapping an inner 3-backtick one: a width-blind parity
+# toggle closes here and re-opens at the outer closer, leaking the decoy rows.
+```text
+inner block
+```
+| 1 | thing works | PHPUnit | post-impl | `tests/Decoy.php` |
+| 2 | looks right | Truly-manual | post-impl | eyeball the decoy |
+````
+
+| # | Behavior | Test type | When | Test file |
+|---|---|---|---|---|
+| 1 | saves row | PHPUnit | post-impl | `ibl5/tests/Unit/RealTest.php` |
+MXEOF
+
+MX_PY=$( cd "$REPO_ROOT/tools/postplan-harness" && python3 -c '
+import sys
+from harness.planfile import parse_matrix
+planned, manual = parse_matrix(open(sys.argv[1]).read())
+print(",".join(planned) + "|" + str(len(manual)))
+' "$MX_FIX" )
+if [ "$MX_PY" = "ibl5/tests/Unit/RealTest.php|0" ]; then
+    echo "ok: matrix parser skips fenced scaffold rows (planned + truly-manual)"
+else
+    echo "FAIL: fenced matrix rows leaked into conditions (1)/(3) — got: $MX_PY"
+    FAILED=1
+fi
+
+# The prose half of the same parser (Phase 5.0 is model-performed for the matrix,
+# unlike the Critical Files block which sources the shell lib) has no executable
+# host, so pin the instruction itself against silent removal.
+if grep -qF 'Skip every row inside a fenced code block' "$P5_SKILL"; then
+    echo "ok: phase 5.0 prose instructs skipping fenced matrix rows"
+else
+    echo "FAIL: phase 5.0 matrix prose lost its fenced-row skip (diverges from planfile.py)"
+    FAILED=1
+fi
+
 expect_block "(5) golden + headless -> BLOCK" BLOCK \
     "$(run_isolated "$B5" '{"files":[{"path":"engine/internal/sim/testdata/golden.json"}]}' '' '1')"
 expect_block "(5) golden + interactive -> NONE (warn-only)" NONE \

--- a/ibl5/docs/backlog/dev-efficiency-backlog.md
+++ b/ibl5/docs/backlog/dev-efficiency-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Development-efficiency backlog — inner-loop speed (diff-scoped analysis, parallel tests), CI caching, dependency-bump batching, and worktree lifecycle automation, with per-entry status.
-last_verified: 2026-07-24
+last_verified: 2026-07-29
 ---
 
 # Development-Efficiency Backlog
@@ -27,7 +27,7 @@ last_verified: 2026-07-24
 
 | Status | Count |
 |--------|------:|
-| ⬜ Open | 3 |
+| ⬜ Open | 4 |
 | 📋 Planned | 2 |
 | ◑ Partial | 2 |
 | ✅ Implemented | 4 |
@@ -50,6 +50,7 @@ last_verified: 2026-07-24
 | E9 | Meta-tooling growth bar | 📋 Planned | 🟦 | S |
 | E10 | Schema baseline auto-regen | ✅ Implemented | — | M |
 | E11 | In-PR pre-baked image build | 📋 Planned | 🟦 | M |
+| E12 | `bin/wt-new` fails with misleading error when invoked from inside a worktree | ⬜ Open | 🟨 | S |
 
 ### E1 Warm-standby worktree pool
 **Location:** `bin/wt-new` (no pool/claim logic today).
@@ -110,6 +111,13 @@ last_verified: 2026-07-24
 **Location:** Plan: `$HOME/claude-plans/in-pr-prebaked-image-build.md` (queued). Today only `.github/workflows/cache-dependencies.yml` builds the image, on schedule/push — never in-PR.
 **Problem:** A PR changing the Dockerfile or composer deps is E2E-tested against the *previous* master image; the mismatch surfaces only after merge.
 **Status (2026-07-07):** 📋 Planned — queued; paths-filtered so normal PRs are unaffected. 🟦.
+
+### E12 `bin/wt-new` fails with misleading error when invoked from inside a worktree
+**Location:** `bin/wt-new:9` (`REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"`) and `bin/wt-new:57` (`git -C "$REPO_ROOT" merge --ff-only "origin/$BASE_BRANCH"`).
+**Problem:** `bin/wt-new` computes `REPO_ROOT` from the script's own path and then runs `git -C "$REPO_ROOT" merge --ff-only "origin/$BASE_BRANCH"` to sync the base branch before branching. When the script is invoked by its worktree-relative path (e.g. `bin/wt-new foo` from `IBL5-worktrees/<slug>/`), `REPO_ROOT` resolves to that worktree rather than the main checkout. The `--ff-only` then targets the worktree's feature branch, which has diverged from `origin/master`, and the script aborts with `fatal: Not possible to fast-forward, aborting.` before creating anything. Observed 2026-07-29 running `bin/wt-new matrix-fence-strip` from the `critical-files-parser-unification` worktree. Failure is fail-safe (aborts, creates nothing) but the error message points at the fast-forward constraint and gives no hint that the real cause is the wrong `REPO_ROOT`. Note that `.claude/rules/workflow-continuity.md` documents the bare `bin/wt-new <slug>` form as the standard invocation — exactly the shape that fails from a worktree. Workaround: invoke the main checkout's copy by absolute path (`/Users/ajaynicolas/GitHub/IBL5/bin/wt-new <slug>`).
+**Suggested direction:** Resolve the base-branch sync against the repo's main worktree rather than `$REPO_ROOT`. Candidates: parse the first entry from `git worktree list --porcelain`; or use `git -C "$REPO_ROOT" rev-parse --git-common-dir` to locate the shared `.git/` and derive the main worktree path from it.
+**Risk if untouched:** Non-obvious failure every time a developer runs `bin/wt-new` from inside a worktree — a common pattern during multi-worktree sessions.
+**Status (2026-07-29):** ⬜ Open — 🟨 (core workflow script; needs smoke-testing from both main-checkout and worktree invocation paths). (discovered 2026-07-29 during matrix-fence-strip)
 
 ---
 

--- a/ibl5/docs/backlog/loop-engineering-backlog.md
+++ b/ibl5/docs/backlog/loop-engineering-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Loop-engineering backlog — automouse queue robustness (dependency ordering, circuit breakers, canaries, self-healing), autonomous intake loops, plan decomposition/tier-routing machinery, and the human comprehension counter-loop, with per-entry status.
-last_verified: 2026-07-24
+last_verified: 2026-07-29
 ---
 
 # Loop-Engineering Backlog
@@ -27,10 +27,10 @@ last_verified: 2026-07-24
 
 | Status | Count |
 |--------|------:|
-| ⬜ Open | 7 |
+| ⬜ Open | 8 |
 | 📋 Planned | 2 |
 | ◑ Partial | 2 |
-| ✅ Implemented | 7 |
+| ✅ Implemented | 9 |
 | 🚫 Declined | 0 |
 
 ---
@@ -58,6 +58,8 @@ last_verified: 2026-07-24
 | L17 | Shared-context artifact for multi-plan splits | ✅ Implemented | — | S |
 | L18 | Tier-default correction (`impl_model:` fails open to Opus) | ✅ Implemented | — | S |
 | L19 | Weekly product-analytics review | ⬜ Open | 🟦 | M |
+| L20 | post-plan body-rewrite clobbers `Depends-on:`, bypassing arm condition (6) | ⬜ Open | 🟥 | M |
+| L21 | Phase 5.0 parsers fail-open on an unclosed code fence (conformance check covers nothing) | ⬜ Open | 🟥 | S |
 
 ### L1 Plan dependency DAG
 **Location:** `bin/automouse-queue` — queue order is symlink mtime (`ls -1tr`); `bin/automouse-queue-reorder-ui` re-touches mtimes by hand. No `depends_on` anywhere (verified).
@@ -156,6 +158,21 @@ last_verified: 2026-07-24
 **Blocked by:** the `ibl_events` enrichment work planned 2026-07-24 (no PR number yet at filing time; traffic segmentation + `session_id` + `http_status` + domain events + route-name canonicalization). Prod measurement on 2026-07-24 over 2026-07-14→24: 13,885 rows, of which only **545 authenticated** across 17 GMs (~3 events/GM/day); the rest is unattributable — no username and no session id, so it can't be tied to a person or a visit. Fired today the review would read bare pageviews and report that GMs look at team pages. Wants 3–4 weeks of enriched data first.
 **Risk if untouched:** Analytics accrue as write-only overhead — the exact failure mode [ADR-0016](../decisions/0016-remove-duckdb-analytics.md) removed a previous analytics layer for.
 **Status (2026-07-24):** ⬜ Open — 🟦 (notify surface; human reads the recommendations, nothing auto-applies). (discovered 2026-07-24 during PR #1425 analytics review)
+
+### L20 post-plan body-rewrite clobbers `Depends-on:`, bypassing arm condition (6)
+**Location:** `.claude/skills/post-plan/_phase-6.5-arm-auto-merge.md` (arm condition 6: `depends-on-merge-order`) and `.claude/skills/post-plan/SKILL.md:93` (prescribing `Depends-on: #<n>` as the alternative to `--base` stacking in this squash-merge repo).
+**Problem:** Arm condition (6) reads the live PR body via `gh pr view` and refuses to arm auto-merge until every PR named on a `Depends-on: #<n>` line is merged. `SKILL.md:93` prescribes `Depends-on:` as the correct alternative to `--base` when the repo squash-merges (a squash collapses the parent's commits, so a stacked child's branch carries pre-squash commits that conflict on auto-retarget). Observed 2026-07-29 on PR #1734 (`fence-parity-guard`): `Depends-on: #1715` was added as line 1 of the body. A later post-plan run rewrote that PR body wholesale; `gh pr view 1734 --json body` then returned a body starting `## Summary` with no `Depends-on:` line, so condition (6) evaluated `blocked=False` and #1734 armed and merged ahead of its declared dependency (commit `1b8249f4f7a651fb78b8e8bc3d60b7af25b460a4`). Effect was harmless this time only because the branch already contained #1715's commits. The structural problem: the same pipeline that reads the `Depends-on:` marker also overwrites the text carrying it — the prescribed alternative to `--base` is silently unreliable as a dependency declaration.
+**Suggested direction:** (a) Make body rewrites preserve/re-emit any existing `Depends-on:` lines before overwriting. (b) Move the dependency declaration somewhere the pipeline does not overwrite (a label, or plan frontmatter `depends_on:` — see **L1**, which proposes exactly this field for queue ordering). (c) Have condition (6) read from a source other than the mutable PR body. This needs design; do not pick a direction ad-hoc (touches a `.claude/skills` ship-pipeline invariant per `.claude/rules/work-triage.md` § Ad-hoc safety mirror — wants a `/plan`).
+**Blocked by:** peer session active on branch `postplan-arm-unresolved-findings`; coordinate before touching arm conditions to avoid duplicating work.
+**Risk if untouched:** Silent merge-order violations in future stacked-plan programs where the parent branch is not yet in the child's commit history.
+**Status (2026-07-29):** ⬜ Open — 🟥 (ship-pipeline invariant; loop-machinery changes should default to `auto_merge: false`). (discovered 2026-07-29 during PR #1734 fence-parity-guard)
+
+### L21 Phase 5.0 parsers fail-open on an unclosed code fence (conformance check covers nothing)
+**Location:** `tools/postplan-harness/harness/planfile.py` — `parse_matrix` and `parse_critical_files` both route through `_strip_fenced`; see the `parse_matrix` docstring on branch `matrix-fence-strip` for the full exposition. `bin/check-plan:477` (`cf_fence_unbalanced`) and its gate comment at `bin/check-plan:470`.
+**Problem:** `_strip_fenced` is a line-level fence state machine: when a code fence opener has no matching closer, every subsequent line is treated as inside the fence and is swallowed. Both `parse_matrix` and `parse_critical_files` call it, so on a plan with an unclosed fence they return empty collections (`planned_test_paths == []`, `critical_files == []`). Phase 5.0's conformance check then has nothing to evaluate and passes silently — arm condition (3) never fires. That is a fail-open: the plan→diff conformance check is skipped entirely, with no signal that anything was skipped. `bin/check-plan` gate `[F]` does reject unbalanced fences, but its own comment (`bin/check-plan:470`) states it "only ever sees newly-authored plans" — a plan authored before that gate landed can still reach Phase 5.0 undetected. Live exposure is currently zero: 1 of 260 plans in `~/claude-plans/` is unbalanced (`sonnet-recipe-completeness-lint.md`) and it already shipped, so this is latent, not actively firing.
+**Suggested direction:** Have the harness report an unbalanced fence as `INDETERMINATE` rather than an empty list, so Phase 5.0 holds loudly instead of passing quietly — mirroring how condition (3) already treats unresolved items. An alternative is to run `cf_fence_unbalanced` from the post-plan path as a pre-parse guard. This changes a Phase 5.0 contract and wants a `/plan`; do not fix ad-hoc (`.claude/skills` ship-pipeline invariant per `.claude/rules/work-triage.md` § Ad-hoc safety mirror).
+**Risk if untouched:** A malformed plan that slips past `bin/check-plan` [F] silently voids the conformance gate at ship time, with no indication that it did so.
+**Status (2026-07-29):** ⬜ Open — 🟥 (ship-pipeline invariant; loop-machinery changes should default to `auto_merge: false`). (discovered 2026-07-29 during matrix-fence-strip; documented in `parse_matrix` docstring on that branch)
 
 ---
 

--- a/tools/postplan-harness/harness/planfile.py
+++ b/tools/postplan-harness/harness/planfile.py
@@ -67,10 +67,29 @@ def parse_matrix(content: str) -> tuple[list[str], list[str]]:
 
     Planned tests: rows whose Test type is PHPUnit / API-test / E2E / Visual-regression;
     path taken from the row's backticked file token.
+
+    Fenced code blocks are skipped (_strip_fenced, defined below — same width-aware
+    machine parse_critical_files uses). A plan that *documents* the matrix format —
+    a `| 1 | thing works | PHPUnit | post-impl | `tests/X.php` |` scaffold inside a
+    ```bash fixture block — otherwise reads as a real declaration, and the phantom
+    path then blocks arming forever via condition (3) since no diff can ever contain
+    it. Measured on the 260-plan corpus: 3 plans lose a planned path and 2 lose
+    truly-manual rows, every one of them fenced illustrative content (`do X`,
+    `tests/X.php`, a backslash-escaped heredoc row); no real matrix row is dropped.
+    Known fail-open, inherited from parse_critical_files (and accepted there — see
+    bin/lib/critical-files.sh's note at cf_fence_unbalanced): an UNCLOSED fence
+    swallows the rest of the file, so planned==[] and conformance holds nothing.
+    bin/check-plan gate [F] rejects that, but at PLAN-AUTHORING time only ("only
+    ever sees newly-authored plans"), so a legacy plan predating the gate can still
+    reach Phase 5.0 and silently skip its own conformance check. Live exposure today
+    is zero: 1 of 260 corpus plans is unbalanced (sonnet-recipe-completeness-lint)
+    and it already shipped. Making the harness report unbalanced-fence as
+    INDETERMINATE rather than empty changes a Phase 5.0 contract, so it is filed as
+    backlog, not fixed here.
     """
     planned: list[str] = []
     manual: list[str] = []
-    for line in content.splitlines():
+    for line in _strip_fenced(content):
         if not line.strip().startswith("|"):
             continue
         cells = [c.strip() for c in line.strip().strip("|").split("|")]

--- a/tools/postplan-harness/tests/test_planfile.py
+++ b/tools/postplan-harness/tests/test_planfile.py
@@ -50,6 +50,59 @@ def test_matrix_and_critical_files():
     assert cf[1][0] == "ibl5/schema.sql" and cf[1][2]  # "(read-only reference)" -> exempt
 
 
+def test_matrix_ignores_fenced_rows():
+    """A matrix row inside a fenced block is illustration, not a declaration.
+
+    Live regression: ~/claude-plans/critical-files-parser-unification.md carried a
+    `tests/X.php` scaffold row inside a ```bash fixture block. parse_matrix read it
+    as a planned test, Phase 5.0 emitted `MISSING: tests/X.php`, and arm condition
+    (3) held the PR on a path no diff could ever contain. Condition (1) has the same
+    exposure through truly_manual_rows, so both are pinned here.
+    """
+    fenced = PLAN + """
+## Appendix — how to write a matrix
+
+````markdown
+| Behavior | Test type | Test |
+|---|---|---|
+| thing works | PHPUnit | `tests/X.php` |
+| looks right | Truly-manual | eyeball it |
+````
+"""
+    planned, manual = parse_matrix(fenced)
+    # identical to the unfenced plan: the appendix contributes nothing
+    assert planned == parse_matrix(PLAN)[0]
+    assert len(manual) == len(parse_matrix(PLAN)[1])
+    assert "tests/X.php" not in planned
+    assert not any("eyeball it" in row for row in manual)
+
+
+def test_matrix_fence_width_awareness():
+    """A 4-backtick block wrapping 3-backtick inner ones must not invert parity.
+
+    Width-blind `in_fence = !in_fence` closes on the inner ``` and re-opens on the
+    outer closer, leaving the REAL matrix below it swallowed. Per CommonMark a
+    closing fence must be at least as long as its opener.
+    """
+    nested = """## Verification Matrix
+
+````markdown
+```bash
+echo hi
+```
+| Behavior | Test type | Test |
+|---|---|---|
+| fake | PHPUnit | `tests/Phantom.php` |
+````
+
+| Behavior | Test type | Test |
+|---|---|---|
+| real | PHPUnit | `ibl5/tests/Unit/RealTest.php` |
+"""
+    planned, _ = parse_matrix(nested)
+    assert planned == ["ibl5/tests/Unit/RealTest.php"]
+
+
 def test_locate_plan_missing_and_override():
     assert not locate_plan("no-such-slug", plans_dir="/nonexistent").found
     info = locate_plan("x", content_override=PLAN)


### PR DESCRIPTION
## Summary
- Fix phantom test paths from fenced scaffold rows blocking Phase 5.0 auto-merge
- Matrix parser now skips rows inside code fences (width-aware, per CommonMark spec)
- Fenced illustration rows (e.g. `tests/X.php` format examples) are no longer parsed as declarations
- Add test coverage for fenced-row handling and nested fence width-awareness
- Document backlog items (L20, L21, E12) for related issues discovered during fix

## Manual Testing

No manual testing needed — verified by automated tests.

---

## fix-and-prevent record

**Defect class:** any plan parser that treats illustrative content inside a fenced code block as a real declaration.

### Occurrence scan

| File:line | Same defect? | Disposition |
|---|---|---|
| `bin/lib/critical-files.sh` (`cf_section`) | was | fixed in #1715 |
| `tools/postplan-harness/harness/planfile.py` (`_strip_fenced`) | was | fixed in #1715 |
| `bin/check-plan-staleness:94` | yes — live but latent | fixed in #1734 |
| `planfile.py:65` (`parse_matrix`) | **yes — live, fired on this run** | **fixed here** |
| `.claude/skills/post-plan/_phase-5-final-verification.md:14` (prose mirror) | **yes — same gap** | **fixed here** |
| `planfile.py` `has_matrix`/`has_security`/`has_reuse` | same class, latent | **deliberately unchanged** — the only corpus flip is the known unclosed-fence plan; tightening would skip Phase 5.0 wholesale (a loosening, not a fix) |
| `tools/postplan-harness/harness/adapters/llm.py:32` | no — non-greedy single-block extraction | no action |
| `bin/test-check-plan-staleness` fixtures | no — test data | suite passes unchanged |

Corpus measurement over 260 plans in `~/claude-plans/`: 3 plans lose a planned path, 2 lose truly-manual rows — every one verified as fenced illustrative content. **Zero real matrix rows dropped.**

### Prevention ladder — rung 0/1 (extend, no add)

No new gate, hook, workflow, or `bin/` script. Extended `bin/test-postplan-arm-conditions` (already hosts the sibling three-way-agreement check with a decoy `## Critical Files` heading inside a 4-backtick fence; wired to CI at `.github/workflows/tests.yml:687`) with a fenced-scaffold fixture, plus a grep pinning the Phase 5.0 prose against silent drift from `planfile.py`.

Gate demonstrated once: pre-fix `tests/Decoy.php,ibl5/tests/Unit/RealTest.php|1` → post-fix `ibl5/tests/Unit/RealTest.php|0`. Against `origin/master`'s parser the two new pytest cases fail; against the fix, 11 pass.

### Known fail-open, documented not fixed

`_strip_fenced` swallows everything after an **unclosed** fence, so `planned == []` and Phase 5.0 conformance silently covers nothing. `bin/check-plan` gate `[F]` rejects unbalanced fences but at **plan-authoring time only** (`bin/check-plan:470`: "only ever sees newly-authored plans"), so a legacy plan can still reach Phase 5.0. `parse_critical_files` already carried this same accepted fail-open. Live exposure is zero (1/260 — `sonnet-recipe-completeness-lint.md`, already shipped). Filed as **L21**, not fixed ad-hoc: changing the Phase 5.0 contract is a `.claude/skills` ship-pipeline invariant and wants a `/plan`.

### Backlog filed

- **L20** (`loop-engineering-backlog.md`) — post-plan body-rewrite clobbers `Depends-on:`, bypassing arm condition (6)
- **L21** (`loop-engineering-backlog.md`) — Phase 5.0 parsers fail-open on an unclosed code fence
- **E12** (`dev-efficiency-backlog.md`) — `bin/wt-new` fails with a misleading error when invoked from inside a worktree

### Prevention artifact OUTSIDE the repo — not in this diff

`~/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/memory/reference_postplan_stacked_pr_topology.md` — hazard 3 added: anything hand-written into a post-plan-managed PR body is not durable, because a later post-plan run rewrites the body wholesale. Observed on #1734, where a `Depends-on: #1715` line was lost and condition (6) armed the PR ahead of its declared dependency.

### Pre-existing failure, surfaced not bumped

`bin/check-docs` fails on `ibl5/docs/REFACTORING_AUDIT_2026-05-29.md` (`last_verified 2026-05-29 is 61 days old, max 60`). Present on `origin/master` before this branch and unrelated to this diff — not touched, per `.claude/rules/` guidance against drive-by doc bumps to clear an unrelated gate.