### PR TITLE
chore(plan-now): automatically recover drafts from backgrounded runs

### DIFF
--- a/.claude/rules/headless-marker-contract.md
+++ b/.claude/rules/headless-marker-contract.md
@@ -1,6 +1,6 @@
 ---
-description: Headless `claude -p` runners — where a machine-parsed marker must be printed, because text-mode `-p` emits only the model's final message. Path-scoped to bin/**, loads only when authoring or editing a runner.
-last_verified: 2026-07-28
+description: Headless `claude -p` runners — where a machine-parsed marker must be printed, because text-mode `-p` emits only the model's final message, and how `bin/plan-now` recovers a draft when the marker never arrives. Path-scoped to bin/**, loads only when authoring or editing a runner.
+last_verified: 2026-07-29
 paths: "bin/**"
 ---
 
@@ -59,6 +59,66 @@ editing against the table above rather than assuming:
 and the three ways a marker still lands `unconfirmed`. It stubs the model call through
 `PLAN_NOW_CLAUDE` / `PLAN_NOW_PLANS_DIR` and runs the runner directly, so it costs no
 tokens and spawns no launchd job. Copy that shape if a second runner ever parses stdout.
+
+## Draft recovery fallback
+
+A missing marker is fail-safe but not free: the run's work still exists. Since
+2026-07-29 `bin/plan-now` tries to recover it before reporting `unconfirmed`, along two
+independent legs, because the arm is reached two distinct ways:
+
+- **Leg A — the architect was killed at the background-wait ceiling.** A complete draft
+  is orphaned in `.drafts/` and no plan file was ever written.
+- **Leg B — the run succeeded and the model omitted the line.** Plan written, draft
+  consumed, full completion report printed. There is no output-side fix: text-mode `-p`
+  discards everything before the final message, so a marker left out of *that* message
+  is unrecoverable from stdout. It is a compliance failure, not truncation, and no coda
+  wording closes it.
+
+Leg A, in detail. When the model exits 0 and no usable `PLAN_FILE:` line was printed, the runner reads
+this run's slug back out of its own prompt (the `- Branch slug: ` line the drafting
+session writes) and looks for exactly one file: `<plans-dir>/.drafts/<slug>.draft.md`,
+modified after the run started. Both conditions are required — the slug match keeps a
+concurrent `plan-now` run's draft out, and the mtime keeps an abandoned draft from a
+previous run of the *same* slug out. If either fails, nothing is adopted; the run
+prints the unchanged `unconfirmed` verdict, plus a pointer if some unattributable
+fresh draft is sitting there.
+
+A recovered draft is promoted the way `.claude/skills/plan/SKILL.md` Step 5 would have
+promoted it: the `<!-- PLAN OUTLINE ... -->` scaffold is dropped, and a frontmatter
+block the scaffold shape stranded below the title is hoisted to line 1 — required,
+because `bin/check-plan` parses frontmatter anchored at line 1 and would otherwise
+reject every recovered plan for a missing `impl_model`. An existing plan file is never
+overwritten. `bin/check-plan` then runs on the result exactly as it would on an
+identified plan, and only a pass reaches the queue.
+
+Leg B runs only when leg A adopted nothing. It never reads model output. Its identity
+test is **membership in this run's own before/after diff of the plans directory** —
+not an mtime comparison, because a file newer than the run's start may equally be a
+*concurrent* run's plan, which is exactly the wrong attribution recorded in the
+rejected-alternatives block at the top of `bin/plan-now`. Within that set the basename
+must be this run's prompt slug as `<slug>.md` or `<slug>-<n>.md` (`/plan`'s own loop
+writes `-2`, `-3`, … when `check-plan` rejects a draft; a bare `<slug>*` glob would
+also match a peer slug that merely prefixes this one), and the **newest** match wins.
+Newest-wins is load-bearing rather than a tiebreaker: a real run left a superseded
+5-phase `<slug>.md` beside the live 7-phase `<slug>-3.md`, and the superseded file
+*passes* `check-plan` — the gate cannot break that tie, only recency can. Nothing is
+promoted or deleted on this leg; the file is adopted where it already sits.
+
+The verdict says `RESULT degraded (recovered)` on success and
+`RESULT degraded (recovery attempted)` when the promoted plan fails `check-plan` —
+both distinct from `RESULT ok` and from `RESULT unconfirmed`, so a log line still
+tells you which of the three happened without reading the transcript. Recovery
+supplies only the *identification* leg of the queue gate; clean exit and a passing
+`bin/check-plan` are still required and still unchanged.
+
+This is a net, not a licence. The prompt coda tells the run never to background a
+sub-agent in the first place, and deliberately does not mention that this net exists.
+`bin/test-plan-now` pins all eleven branches — five on leg A, five on leg B, plus the
+regression that a valid marker still wins outright and never enters recovery at all
+(that one belongs to neither leg, which is the point of it). Five of the eleven are
+negatives, and the most important is a slugless prompt: both legs no-op for it, that is
+the *majority* of real prompts, and its verdict must stay byte-identical to the
+pre-recovery one.
 
 ## When you add a runner
 

--- a/bin/plan-now
+++ b/bin/plan-now
@@ -173,6 +173,15 @@ conflicting default in the skill):**
   section naming the unresolved fork, or \`bin/check-plan\` gate [H] fails.
 - Before finishing, run \`bin/check-plan ~/claude-plans/<slug>.md\` and fix
   everything it reports. This job re-runs it after you exit and logs the verdict.
+- **Run every sub-agent in the FOREGROUND.** Never spawn the plan-architect (or any
+  other \`Agent\`) with \`run_in_background: true\`, and never start a long task, end
+  your turn, and expect to collect it afterwards. Under \`claude -p\` there is no
+  afterwards: print mode is a single shot, so the turn you end IS the run, and a
+  background task's completion notification has no next turn to arrive on — its
+  result is discarded exactly the way an early-printed \`PLAN_FILE:\` line is. This
+  job disables the harness's background-task sweep, which stops such a task being
+  killed mid-run; it cannot create a turn for the result to land on. If you have
+  already started one, collect it before you finish.
 - $DISPOSITION_LINE
 CODA
 
@@ -207,6 +216,73 @@ cd "$ROOT" || exit 1
 before=$(ls "$PLANS_DIR"/*.md 2>/dev/null | sort)
 started=$(date +%s)
 
+# Draft recovery. A run whose plan-architect was backgrounded and cut off leaves
+# a complete draft in $PLANS_DIR/.drafts/ while printing no PLAN_FILE: line.
+# These helpers let the verdict block below adopt THAT draft — and only that one.
+# $PLANS_DIR (not $HOME/claude-plans) so PLAN_NOW_PLANS_DIR stays the test seam.
+DRAFTS_DIR="$PLANS_DIR/.drafts"
+
+# mtime in epoch seconds. BSD stat (macOS, where launchd runs this) first, GNU
+# stat second so bin/test-plan-now also passes on the Linux CI box.
+draft_mtime() {
+    stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null
+}
+
+# This run's slug, read back out of the prompt it was fired with. Prompts write
+# it as: - Branch slug: `some-slug`. Base: `master`.
+# Parsed tolerantly (case-insensitive, tolerates ** / : decoration) but anchored
+# on the literal words — same discipline as the PLAN_FILE: parse below.
+run_slug() {
+    grep -ioE 'branch slug[^`]{0,24}`[^`]+`' "$PROMPT" 2>/dev/null | head -1 \
+        | grep -oE '`[^`]+`' | head -1 | tr -d '`'
+}
+
+# Echo the path of a draft that provably belongs to THIS run, or nothing.
+# Three independent conditions, ALL required — each rules out one wrong adoption:
+#   1. slug present in the prompt  -> never guess from a directory listing;
+#   2. filename == that slug       -> a peer plan-now run's draft is never taken,
+#                                     however much newer it is;
+#   3. mtime > $started            -> a stale draft left by an EARLIER run of the
+#                                     same slug is never taken.
+recovery_candidate() {
+    local slug cand mt
+    slug=$(run_slug)
+    [ -n "$slug" ] || return 1
+    # The slug is interpolated into a path, so constrain it to a filename.
+    case "$slug" in
+        *[!A-Za-z0-9._-]* | .*) return 1 ;;
+    esac
+    cand="$DRAFTS_DIR/$slug.draft.md"
+    [ -f "$cand" ] && [ -s "$cand" ] || return 1
+    mt=$(draft_mtime "$cand")
+    [ -n "$mt" ] || return 1
+    [ "$mt" -gt "$started" ] || return 1
+    printf '%s\n' "$cand"
+}
+
+# Render draft $1 into plan $2: drop the outline scaffold, then hoist a
+# frontmatter block the scaffold shape stranded below the title. Writes via a
+# temp file in the same directory, so $2 is never observed half-written.
+# Returns non-zero and leaves $2 untouched on any failure.
+promote_draft() {
+    command -v perl >/dev/null 2>&1 || return 1
+    perl -0777 -e '
+        my $t = do { local $/; <STDIN> };
+        $t =~ s/<!-- PLAN OUTLINE.*?-->\n?//s;
+        unless ($t =~ /\A---\n/) {
+            if ($t =~ /\A((?:[^\n]*\n){0,8}?)(---\n.*?\n---\n)/s) {
+                my ($pre, $fm) = ($1, $2);
+                if ($fm =~ /\n[A-Za-z_][A-Za-z0-9_-]*:/) {
+                    substr($t, 0, length($pre) + length($fm)) = $fm . $pre;
+                }
+            }
+        }
+        print $t;
+    ' < "$1" > "$2.tmp$$" 2>/dev/null || { rm -f "$2.tmp$$"; return 1; }
+    [ -s "$2.tmp$$" ] || { rm -f "$2.tmp$$"; return 1; }
+    mv -f "$2.tmp$$" "$2"
+}
+
 # CLAUDE_HEADLESS=1 marks the run unattended (skills branch on it).
 # CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 lifts the interactive 120K
 # autoCompactWindow pin — rationale in bin/automouse-run.
@@ -215,7 +291,16 @@ started=$(date +%s)
 # 3600s cap. claude -p does not stream, so $OUT stays empty until it exits — and with
 # the default --output-format text it then holds ONLY the final assistant message,
 # which is why the coda demands PLAN_FILE: on that message's last line (see header).
-CLAUDE_HEADLESS=1 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 caffeinate -s \
+# CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 disables the harness's background-task
+# sweep. At the default (~600s) the harness TERMINATES a still-running background
+# task mid-run and prints "Background tasks still running after Ns; terminating."
+# to stderr — which kills a plan-architect Agent() spawned with run_in_background
+# on any run longer than the ceiling, so the orchestrator's turn ends with no
+# architect result and no PLAN_FILE: line while a complete draft sits in
+# $PLANS_DIR/.drafts/. 0 means wait indefinitely (the CLI says so itself);
+# timeout 5400 above remains the hard cap.
+CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 \
+    CLAUDE_HEADLESS=1 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 caffeinate -s \
     timeout 5400 "$CLAUDE_BIN" -p "$(cat "$PROMPT")" \
     --dangerously-skip-permissions \
     --model "$MODEL" \
@@ -283,15 +368,146 @@ elif [ -n "$plan" ]; then
         echo "plan-now: NOT queued. A human must fix $plan before it is queued or implemented."
     fi
 else
-    echo "plan-now: RESULT unconfirmed — the run printed no usable 'PLAN_FILE:' line,"
-    echo "plan-now: so its plan cannot be identified, check-plan was NOT run, and nothing was queued."
-    if [ -n "$newfiles" ]; then
-        guess=$(printf '%s\n' "$newfiles" | tr '\n' '\0' | xargs -0 ls -t 2>/dev/null | head -1)
-        echo "plan-now: best-effort guess (newest new file, NOT verified as this run's): $guess"
+    # Recovery. Reached only when rc == 0 (the chain's first arm owns nonzero),
+    # so "clean exit" — leg 1 of the queue gate — is already structural here.
+    # Recovery supplies leg 2 (identification) ONLY; check-plan below is still
+    # leg 3, and nothing reaches the queue without it.
+    #
+    # TWO independent recoveries, tried in order, because this arm is reached two
+    # distinct ways:
+    #   A. the architect was backgrounded and killed at the wait ceiling, so a
+    #      complete draft is orphaned in .drafts/ and no plan file exists;
+    #   B. the run SUCCEEDED end to end — plan written, draft consumed, full
+    #      completion report printed — and the model merely left `PLAN_FILE:` out
+    #      of its FINAL message. Per the rejected-alternatives block at the top of
+    #      this script, text-mode `-p` discards everything before that final
+    #      message, so the marker is then unrecoverable from stdout and NO coda
+    #      wording closes this: it is a compliance failure, not truncation.
+    #      Observed 2026-07-28 (2855s run, exit 0, valid plan, 1294-byte
+    #      transcript) and again 2026-07-29 13:13. Recovery B identifies the plan
+    #      from the filesystem instead.
+    recovered=""
+    recovery_source=""
+    draft=$(recovery_candidate) || draft=""
+
+    if [ -n "$draft" ]; then
+        slug=$(basename "${draft%.draft.md}")
+        target="$PLANS_DIR/$slug.md"
+        if [ -e "$target" ]; then
+            # A draft surviving does NOT prove the run never wrote a plan: it may
+            # have written one, failed check-plan, and left the draft behind.
+            tmt=$(draft_mtime "$target")
+            if [ -n "$tmt" ] && [ "$tmt" -gt "$started" ]; then
+                recovered="$target"
+                echo "plan-now: recovery A — this run already wrote $target; adopting it as-is, draft NOT promoted over it."
+            else
+                echo "plan-now: recovery A declined — $target predates this run; refusing to overwrite it from $draft."
+            fi
+        elif promote_draft "$draft" "$target"; then
+            recovered="$target"
+            recovery_source="$draft"
+            echo "plan-now: recovery A — promoted $draft -> $target"
+        else
+            echo "plan-now: recovery A failed — could not render $draft into $target (no perl, or the transform errored)."
+        fi
     else
-        echo "plan-now: no new file in $PLANS_DIR either — the run may have updated an existing plan, or failed."
+        # No slug in the prompt, or no fresh draft under this run's slug. If
+        # something fresh is nonetheless sitting in .drafts/, say so — but never
+        # adopt it: without a slug match a peer run's draft is indistinguishable.
+        fresh=""
+        for d in "$DRAFTS_DIR"/*.draft.md; do
+            [ -f "$d" ] || continue
+            m=$(draft_mtime "$d") || continue
+            [ -n "$m" ] || continue
+            [ "$m" -gt "$started" ] && fresh="$fresh $d"
+        done
+        if [ -n "$fresh" ]; then
+            echo "plan-now: a draft newer than this run exists but cannot be attributed to it:$fresh"
+            echo 'plan-now: not promoted — the prompt carried no `Branch slug: `-style line, or the draft slug differs.'
+            echo "plan-now: inspect manually: ls -lt $DRAFTS_DIR/*.draft.md"
+        fi
     fi
-    echo "plan-now: read the transcript above."
+
+    # ---- Recovery B: the run wrote its plan and omitted the marker ----
+    # $newfiles is this run's OWN before/after diff of $PLANS_DIR — captured by the
+    # `before=` snapshot next to `started=` and the `after=`/`newfiles=` pair just
+    # above this verdict chain (grep those assignments; deliberately not cited by
+    # line number, which drifts) — so membership in it is a strictly stronger
+    # "this run created it" signal than any mtime comparison — and it is the
+    # identity that the wrong-file incident recorded at the top of this script
+    # says the verdict must be gated on. Two further constraints:
+    #   * the basename must be the slug from THIS run's prompt, as <slug>.md or
+    #     <slug>-<n>.md. /plan's own loop writes -2, -3, … when check-plan
+    #     rejects a draft, so numbered variants are this run's plans too, while a
+    #     bare <slug>* glob would also match a peer slug that merely prefixes it.
+    #   * NEWEST WINS, and this is not a tiebreaker. On a real run (2026-07-29
+    #     12:57) the loop left <slug>.md — 5 phases, superseded — beside
+    #     <slug>-3.md — 7 phases, live — and the SUPERSEDED file PASSES
+    #     check-plan. check-plan cannot save you here; only recency can.
+    if [ -z "$recovered" ] && [ -n "$newfiles" ]; then
+        bslug=$(run_slug) || bslug=""
+        case "$bslug" in
+            "" | *[!A-Za-z0-9._-]* | .*) bslug="" ;;
+        esac
+        if [ -n "$bslug" ]; then
+            # ls -t emits newest-first, so the FIRST slug match is the newest one.
+            # Process substitution (< <(...)) instead of piped while: bash 3.2 does
+            # not allow `case … ;;` inside $() command substitution, but process
+            # substitution runs the while body in the current shell, which is fine.
+            adopt=""
+            while IFS= read -r _af; do
+                case "${_af##*/}" in
+                    "$bslug".md | "$bslug"-[0-9]*.md)
+                        if [ -f "$_af" ]; then adopt="$_af"; break; fi ;;
+                esac
+            done < <(printf '%s\n' "$newfiles" | tr '\n' '\0' | xargs -0 ls -t 2>/dev/null)
+            if [ -n "$adopt" ]; then
+                recovered="$adopt"
+                echo "plan-now: recovery B — no adoptable draft, but this run created $adopt under its own slug '$bslug'; adopting it."
+                echo "plan-now: recovery B — identity came from the prompt slug and this run's plan-dir diff, NOT from model output."
+            fi
+        fi
+    fi
+
+    if [ -n "$recovered" ]; then
+        if "$CHECK_PLAN" "$recovered"; then
+            echo "plan-now: RESULT degraded (recovered) — no PLAN_FILE: line, but this run's plan was identified and check-plan PASSED."
+            if [ -n "$recovery_source" ]; then
+                echo "plan-now: recovered from: $recovery_source"
+            fi
+            echo "plan-now: plan -> $recovered"
+            if [ -n "$recovery_source" ]; then
+                rm -f "$recovery_source"
+            fi
+            if [ "$DISPOSITION" = "queue" ]; then
+                if "$AUTOMOUSE_QUEUE" "$recovered"; then
+                    echo "plan-now: queued for automouse (recovered plan) — it will implement this plan and open its PR."
+                    echo "plan-now: to pull it back out: bin/automouse-queue remove $(basename "${recovered%.md}")"
+                else
+                    echo "plan-now: WARNING — check-plan passed but automouse-queue failed; the recovered plan is on disk, unqueued."
+                fi
+            else
+                echo "plan-now: --implement — recovered plan left on disk, NOT queued. A human reviews it first."
+            fi
+        else
+            echo "plan-now: RESULT degraded (recovery attempted) — identified $recovered but check-plan FAILED (see above)."
+            if [ -n "$recovery_source" ]; then
+                echo "plan-now: NOT queued. The draft is kept at $recovery_source. A human must fix $recovered."
+            else
+                echo "plan-now: NOT queued. A human must fix $recovered."
+            fi
+        fi
+    else
+        echo "plan-now: RESULT unconfirmed — the run printed no usable 'PLAN_FILE:' line,"
+        echo "plan-now: so its plan cannot be identified, check-plan was NOT run, and nothing was queued."
+        if [ -n "$newfiles" ]; then
+            guess=$(printf '%s\n' "$newfiles" | tr '\n' '\0' | xargs -0 ls -t 2>/dev/null | head -1)
+            echo "plan-now: best-effort guess (newest new file, NOT verified as this run's): $guess"
+        else
+            echo "plan-now: no new file in $PLANS_DIR either — the run may have updated an existing plan, or failed."
+        fi
+        echo "plan-now: read the transcript above."
+    fi
 fi
 
 rm -f "$PLIST"

--- a/bin/plan-now
+++ b/bin/plan-now
@@ -222,10 +222,21 @@ started=$(date +%s)
 # $PLANS_DIR (not $HOME/claude-plans) so PLAN_NOW_PLANS_DIR stays the test seam.
 DRAFTS_DIR="$PLANS_DIR/.drafts"
 
-# mtime in epoch seconds. BSD stat (macOS, where launchd runs this) first, GNU
-# stat second so bin/test-plan-now also passes on the Linux CI box.
+# mtime in epoch seconds on both stat dialects: BSD (macOS, where launchd runs
+# this) and GNU (the Linux CI box, where bin/test-plan-now also runs).
+#
+# Validate the OUTPUT, never the exit status. GNU `stat -f %m FILE` does not fail
+# cleanly — there `-f` is --file-system, so `%m` is read as a second operand: GNU
+# prints a whole filesystem dump for FILE on *stdout* and exits 1 for the missing
+# `%m`. An `||` fallback therefore appends the real epoch to that garbage, and the
+# `[ "$mt" -gt "$started" ]` in every caller dies on a non-integer. That shipped
+# green on macOS and red on Linux CI; keep the numeric check.
 draft_mtime() {
-    stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null
+    local mt
+    mt=$(stat -f %m "$1" 2>/dev/null)
+    case "$mt" in '' | *[!0-9]*) mt=$(stat -c %Y "$1" 2>/dev/null) ;; esac
+    case "$mt" in '' | *[!0-9]*) return 1 ;; esac
+    printf '%s\n' "$mt"
 }
 
 # This run's slug, read back out of the prompt it was fired with. Prompts write

--- a/bin/post-plan-now
+++ b/bin/post-plan-now
@@ -124,6 +124,9 @@ fi
 # caffeinate -s keeps the Mac awake on AC for the run's duration.
 # CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 lifts the interactive 120K
 # autoCompactWindow pin for this headless run — rationale in bin/automouse-run.
+# CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 stops the harness terminating a
+# long-running backgrounded sub-agent mid-run (see bin/plan-now for the full
+# rationale). Applies to the /post-plan skill fallback only.
 cat > "$PLIST" <<PLIST_EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -135,7 +138,7 @@ cat > "$PLIST" <<PLIST_EOF
 	<array>
 		<string>/bin/bash</string>
 		<string>-lc</string>
-		<string>export PATH="/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH"; cd "$ROOT" &amp;&amp; { ${FALLBACK_FN}${HARNESS_SEG}${GATE_OPEN}CLAUDE_HEADLESS=1 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 caffeinate -s claude -p "$PROMPT" --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name "$LABEL"${GATE_CLOSE}; }; rm -f "$PLIST"; launchctl bootout gui/\$(id -u)/$LABEL</string>
+		<string>export PATH="/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH"; cd "$ROOT" &amp;&amp; { ${FALLBACK_FN}${HARNESS_SEG}${GATE_OPEN}CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 CLAUDE_HEADLESS=1 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 caffeinate -s claude -p "$PROMPT" --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name "$LABEL"${GATE_CLOSE}; }; rm -f "$PLIST"; launchctl bootout gui/\$(id -u)/$LABEL</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>

--- a/bin/test-plan-now
+++ b/bin/test-plan-now
@@ -298,7 +298,11 @@ grep -q '^---$' <(head -1 "$P") && ok "frontmatter was hoisted to line 1" \
 # Harvest the leg-B fixture here and nowhere else: $P was just written by the real
 # promoter and check-plan passed on it above, so this copy is clean by
 # construction. It must be taken before case 2, whose runner wipes $PLANS/*.md.
-cp "$P" "$GOOD_PLAN"
+# Hard-fail loudly: every leg-B case below feeds on this file, so without this
+# guard a single leg-A defect reports as five misleading leg-B failures instead of
+# one root cause (exactly how the GNU-stat bug read in CI).
+cp "$P" "$GOOD_PLAN" 2>/dev/null \
+    || fail "leg-B fixture not harvested from $P — fix case 1 first; every leg-B case below is downstream of this"
 
 # 2. Stale draft — same slug, old mtime.
 out=$(run_case_recovery "$GOOD_DRAFT" demo-slug stale)

--- a/bin/test-plan-now
+++ b/bin/test-plan-now
@@ -55,6 +55,22 @@ export PATH="$SHIM:$PATH"
 PROMPT="$TMP/prompt.md"
 printf '/plan a throwaway task for bin/test-plan-now\n' > "$PROMPT"
 
+# Recovery needs a prompt the runner can read a slug back out of. This is the
+# shape real prompts use — see any /tmp/plan-now-*.prompt.
+RECOVERY_PROMPT="$TMP/recovery-prompt.md"
+{
+    printf '/plan a throwaway task for bin/test-plan-now\n'
+    printf -- '- Branch slug: `demo-slug`. Base: `master`.\n'
+} > "$RECOVERY_PROMPT"
+
+# The negative twin: a prompt with no slug line at all. Both recovery legs need a
+# slug, so this is the "no identity available" path — and measured over the 70
+# real /tmp/plan-now-*.prompt files on disk, only 15 carry a parseable slug line
+# (5 of the 10 most recent), so this is the COMMON shape, not an edge case. Its
+# verdict must stay byte-identical to today's.
+NOSLUG_PROMPT="$TMP/noslug-prompt.md"
+printf '/plan a throwaway task for bin/test-plan-now with no slug line\n' > "$NOSLUG_PROMPT"
+
 # ── The stub model ────────────────────────────────────────────────────────────
 # Stands in for `claude -p`: writes a plan file (unless STUB_NO_PLAN), then prints
 # ONLY what a text-mode run would emit — the final assistant message. $STUB_TAIL is
@@ -63,6 +79,27 @@ STUB="$TMP/claude-stub"
 cat > "$STUB" <<'STUB_EOF'
 #!/usr/bin/env bash
 [ -n "${STUB_PLAN:-}" ] && [ -z "${STUB_NO_PLAN:-}" ] && printf '# stub plan\n' > "$STUB_PLAN"
+if [ -n "${STUB_DRAFT:-}" ]; then
+    # The runner takes $started with whole-second granularity, and the recovery
+    # gate is mtime > started. A real run takes minutes; this stub takes
+    # milliseconds, so without this sleep the draft lands in the same second and
+    # reads as stale. One second, only when a draft is requested.
+    sleep 1
+    mkdir -p "$(dirname "$STUB_DRAFT")"
+    cat "$STUB_DRAFT_SRC" > "$STUB_DRAFT"
+fi
+# Leg B (marker omitted from a successful run): the stub creates plan files in
+# $PLANS_DIR directly and leaves no draft. No sleep is needed for the first —
+# leg B gates on the plan-dir diff, not mtime — but the SECOND file must be
+# strictly newer, because "newest wins" is what case 8 exists to pin.
+if [ -n "${STUB_PLANFILE:-}" ]; then
+    mkdir -p "$(dirname "$STUB_PLANFILE")"
+    cat "$STUB_PLANFILE_SRC" > "$STUB_PLANFILE"
+fi
+if [ -n "${STUB_PLANFILE2:-}" ]; then
+    sleep 1
+    cat "$STUB_PLANFILE2_SRC" > "$STUB_PLANFILE2"
+fi
 printf 'Done — the plan is written and check-plan is clean.\n'
 [ -n "${STUB_TAIL:-}" ] && printf '%s\n' "$STUB_TAIL"
 exit 0
@@ -83,10 +120,129 @@ run_case() {
     rm -f "$runner"
 }
 
+# Every recovery case starts from an empty plan dir. That wipe is `rm -f` against
+# a glob, so it is routed through one guarded helper rather than repeated: if
+# $PLANS were ever empty the bare form is `rm -f /*.md`, and if it resolved to the
+# real ~/claude-plans it would delete live, unqueued, un-backed-up plans. $PLANS
+# is a $TMP subdirectory (existing harness, lines 32-36); assert that before
+# deleting anything.
+plans_reset() {
+    case "$PLANS" in
+        "$TMP"/*) ;;
+        *) echo "test-plan-now: refusing to wipe \$PLANS='$PLANS' — not under \$TMP" >&2
+           exit 1 ;;
+    esac
+    rm -f "$PLANS"/*.md; rm -rf "$PLANS/.drafts"; mkdir -p "$PLANS/.drafts"
+}
+
+# run_case_recovery <draft-src-or-empty> <draft-slug> [stale] → transcript
+# Fires plan-now with the slug-bearing prompt, no PLAN_FILE: tail, and (unless
+# empty) a draft the stub writes mid-run under $PLANS/.drafts/<slug>.draft.md.
+run_case_recovery() {
+    local src="$1" slug="$2" stale="${3:-}"
+    plans_reset
+    local dry runner draft=""
+    [ -n "$src" ] && draft="$PLANS/.drafts/$slug.draft.md"
+    dry=$(PLAN_NOW_DRY_RUN=1 PLAN_NOW_CLAUDE="$STUB" PLAN_NOW_PLANS_DIR="$PLANS" \
+              "$PLAN_NOW" --implement "$RECOVERY_PROMPT" 2>&1)
+    runner=$(printf '%s\n' "$dry" | sed -n 's/^  runner: //p')
+    [ -x "$runner" ] || { printf 'no runner:\n%s\n' "$dry"; return 1; }
+    if [ -n "$draft" ] && [ "$stale" = stale ]; then
+        # Written up front and back-dated, so the stub must not rewrite it.
+        mkdir -p "$(dirname "$draft")"; cat "$src" > "$draft"
+        touch -t 202001010000 "$draft"
+        STUB_NO_PLAN=1 STUB_TAIL="" bash "$runner" 2>&1
+    else
+        STUB_NO_PLAN=1 STUB_TAIL="" STUB_DRAFT="$draft" STUB_DRAFT_SRC="$src" \
+            bash "$runner" 2>&1
+    fi
+    rm -f "$runner"
+}
+
+# run_case_recovery_plan <prompt> <src1> <name1> [<src2> <name2>] → transcript
+# Leg B's shape: no draft anywhere, no PLAN_FILE: tail, and the stub creates
+# <name1> (and optionally a strictly-newer <name2>) directly in $PLANS. The
+# prompt is the first argument because one case needs the slugless one.
+run_case_recovery_plan() {
+    local prompt="$1" src1="$2" name1="$3" src2="${4:-}" name2="${5:-}"
+    plans_reset
+    local dry runner
+    dry=$(PLAN_NOW_DRY_RUN=1 PLAN_NOW_CLAUDE="$STUB" PLAN_NOW_PLANS_DIR="$PLANS" \
+              "$PLAN_NOW" --implement "$prompt" 2>&1)
+    runner=$(printf '%s\n' "$dry" | sed -n 's/^  runner: //p')
+    [ -x "$runner" ] || { printf 'no runner:\n%s\n' "$dry"; return 1; }
+    STUB_NO_PLAN=1 STUB_TAIL="" \
+        STUB_PLANFILE="${name1:+$PLANS/$name1}" STUB_PLANFILE_SRC="$src1" \
+        STUB_PLANFILE2="${name2:+$PLANS/$name2}" STUB_PLANFILE2_SRC="$src2" \
+        bash "$runner" 2>&1
+    rm -f "$runner"
+}
+
 want()    { case "$2" in *"$3"*) ok "$1" ;; *) fail "$1 — expected to see: $3" ;; esac; }
 want_no() { case "$2" in *"$3"*) fail "$1 — should NOT have seen: $3" ;; *) ok "$1" ;; esac; }
 
 P="$PLANS/demo-slug.md"
+
+GOOD_DRAFT="$TMP/good.draft.md"
+cat > "$GOOD_DRAFT" <<'FIXTURE_EOF'
+# demo-slug — a throwaway plan for bin/test-plan-now
+<!-- PLAN OUTLINE (loop scaffold; dropped at Step 5):
+1. Phase 1: touch one comment
+2. Critical Files
+3. Verification Matrix
+-->
+---
+title: "test-plan-now recovery fixture"
+slug: demo-slug
+branch: demo-slug
+base: master
+commit_type: "chore"
+auto_merge: false
+impl_model: sonnet
+last_verified: 2026-07-29
+---
+
+## Phase 1: Adjust one comment in `bin/plan-now`
+
+**Tier:** Sonnet — at run model.
+
+Anchor (bin/plan-now, line 210) — match this line and extend the comment above it:
+
+```
+# CLAUDE_HEADLESS=1 marks the run unattended (skills branch on it).
+```
+
+Reuse the existing heredoc; no new helper, no new file.
+
+### Verification
+
+`bash -n bin/plan-now` exits 0; negative leg below.
+
+## Critical Files
+
+- `bin/plan-now` (the only file this fixture claims to touch)
+
+## Verification Matrix
+
+| # | What to verify | Test type | Timing | Location |
+|---|---|---|---|---|
+| 1 | `bin/plan-now` still parses | CLI-executable | post-impl | `bash -n bin/plan-now` |
+| 2 | negative: no stray marker text added | CLI-executable | post-impl | `grep -c PLAN_FILE bin/plan-now` |
+
+## Automouse Hold Justification
+
+Intrinsic: this fixture exists only inside `bin/test-plan-now` and must never arm auto-merge.
+FIXTURE_EOF
+
+PARTIAL_DRAFT="$TMP/partial.draft.md"
+printf '# stub\n' > "$PARTIAL_DRAFT"
+
+# Leg B needs a plan file that PASSES check-plan. Rather than author and maintain
+# a second ~50-line fixture in promoted form, case 1 hands us one: it promotes
+# GOOD_DRAFT with the real promote_draft and then asserts check-plan passed, so
+# a copy taken there is clean by construction and can never drift from the
+# promoter. It must live outside $PLANS — every recovery runner wipes $PLANS/*.md.
+GOOD_PLAN="$TMP/good.plan.md"
 
 echo "── identification: the shapes a model actually emits ──"
 
@@ -125,6 +281,110 @@ out=$(STUB_NO_PLAN=1 run_case "$P" "PLAN_FILE: $P")
 want "marker naming a nonexistent file is rejected" "$out" "named a file that does not exist"
 want "marker naming a nonexistent file → unconfirmed" "$out" "RESULT unconfirmed"
 
+echo "── draft recovery: a backgrounded architect must not cost the whole run ──"
+
+# 1. Recovery success.
+out=$(run_case_recovery "$GOOD_DRAFT" demo-slug)
+want "fresh draft under this run's slug is recovered"     "$out" "RESULT degraded (recovered)"
+want "the recovery names its source draft"                "$out" "recovered from:"
+want "the promoted plan is announced"                     "$out" "plan -> $P"
+want "recovery is not silently queued under --implement"  "$out" "NOT queued"
+[ -f "$P" ] && ok "promoted plan exists on disk" || fail "promoted plan missing at $P"
+grep -q '^---$' <(head -1 "$P") && ok "frontmatter was hoisted to line 1" \
+    || fail "line 1 of $P is not '---' — the hoist did not fire"
+[ -f "$PLANS/.drafts/demo-slug.draft.md" ] \
+    && fail "draft should be deleted after a passing check-plan" \
+    || ok "draft removed once check-plan passed"
+# Harvest the leg-B fixture here and nowhere else: $P was just written by the real
+# promoter and check-plan passed on it above, so this copy is clean by
+# construction. It must be taken before case 2, whose runner wipes $PLANS/*.md.
+cp "$P" "$GOOD_PLAN"
+
+# 2. Stale draft — same slug, old mtime.
+out=$(run_case_recovery "$GOOD_DRAFT" demo-slug stale)
+want    "stale draft is not adopted"          "$out" "RESULT unconfirmed"
+want_no "stale draft does not report recovery" "$out" "degraded (recovered)"
+[ -f "$P" ] && fail "stale draft must not be promoted" || ok "stale draft left in place"
+
+# 3. No draft — the wording must not have drifted.
+out=$(run_case_recovery "" demo-slug)
+want "no draft → verbatim line 1" "$out" \
+     "plan-now: RESULT unconfirmed — the run printed no usable 'PLAN_FILE:' line,"
+want "no draft → verbatim line 2" "$out" \
+     "plan-now: so its plan cannot be identified, check-plan was NOT run, and nothing was queued."
+want "no draft → verbatim closer" "$out" "plan-now: read the transcript above."
+want_no "no draft → no recovery chatter" "$out" "recovery"
+
+# 4. Partial draft that cannot pass check-plan.
+out=$(run_case_recovery "$PARTIAL_DRAFT" demo-slug)
+want    "partial draft reports an attempted recovery" "$out" "RESULT degraded (recovery attempted)"
+want    "a failed recovery is not queued"             "$out" "NOT queued"
+want_no "a failed recovery is not reported as recovered" "$out" "RESULT degraded (recovered)"
+want    "the draft is kept for a human"               "$out" "The draft is kept at"
+[ -f "$PLANS/.drafts/demo-slug.draft.md" ] && ok "failed recovery keeps its draft" \
+    || fail "draft was deleted despite a failing check-plan"
+
+# 5. Peer slug — a fresh draft that belongs to somebody else.
+out=$(run_case_recovery "$GOOD_DRAFT" other-slug)
+want    "a peer run's draft is never adopted" "$out" "RESULT unconfirmed"
+want_no "a peer run's draft is not promoted"  "$out" "degraded (recovered)"
+want    "an unattributable fresh draft is at least reported" "$out" "cannot be attributed to it"
+[ -f "$PLANS/other-slug.md" ] && fail "peer draft must not be promoted" \
+    || ok "peer draft left untouched"
+
+# 6. Regression: a valid marker still wins, and recovery never preempts it.
+out=$(run_case "$P" "PLAN_FILE: $P")
+want    "REGRESSION: marker path still identifies the plan" "$out" "plan-now: new plan -> $P"
+want_no "REGRESSION: marker path never enters recovery"     "$out" "recovery"
+
+echo "── marker-omission recovery (leg B): a run that succeeded and forgot PLAN_FILE: ──"
+
+# 7. Leg B success. No draft anywhere; the run created its own plan file and
+#    printed a clean closing message without the marker.
+out=$(run_case_recovery_plan "$RECOVERY_PROMPT" "$GOOD_PLAN" demo-slug.md)
+want    "leg B adopts this run's own plan file"          "$out" "RESULT degraded (recovered)"
+want    "leg B names itself in the log"                  "$out" "recovery B —"
+want    "leg B announces the adopted plan"               "$out" "plan -> $P"
+want_no "leg B invents no source draft"                  "$out" "recovered from:"
+want_no "leg B never claims a draft was promoted"        "$out" "recovery A"
+want    "leg B is not silently queued under --implement" "$out" "NOT queued"
+[ -f "$P" ] && ok "the adopted plan is left on disk untouched" || fail "adopted plan vanished"
+
+# 8. THE TRAP — the whole reason leg B exists in this shape. One run, two files:
+#    a SUPERSEDED <slug>.md and the live, newer <slug>-3.md. Measured on the real
+#    2026-07-29 12:57 run, the superseded file PASSES check-plan, so check-plan
+#    cannot break the tie and an oldest-or-arbitrary pick would confirm — and
+#    under --queue implement — a stale plan. Newest must win.
+out=$(run_case_recovery_plan "$RECOVERY_PROMPT" "$GOOD_PLAN" demo-slug.md \
+                             "$GOOD_PLAN" demo-slug-3.md)
+want    "the newest slug match is adopted"        "$out" "plan -> $PLANS/demo-slug-3.md"
+want_no "the superseded sibling is NOT adopted"   "$out" "plan -> $P"
+want    "the trap case still reports recovered"   "$out" "RESULT degraded (recovered)"
+
+# 9. A file this run created is NOT enough — the basename must be this run's slug
+#    as <slug>.md or <slug>-<n>.md. `demo-slug-extra.md` is what a bare
+#    <slug>*.md glob would wrongly swallow.
+out=$(run_case_recovery_plan "$RECOVERY_PROMPT" "$GOOD_PLAN" demo-slug-extra.md)
+want    "a prefix-matching peer slug is never adopted"   "$out" "RESULT unconfirmed"
+want_no "a prefix-matching peer reports no recovery"     "$out" "degraded (recovered)"
+want    "the pre-existing best-effort guess still prints" "$out" "best-effort guess"
+
+# 10. No slug in the prompt → no identity → the verdict must not change at all.
+#     This is the majority shape of real prompts, so it is the regression that
+#     matters most.
+out=$(run_case_recovery_plan "$NOSLUG_PROMPT" "$GOOD_PLAN" demo-slug.md)
+want    "a slugless prompt falls through verbatim" "$out" \
+        "plan-now: RESULT unconfirmed — the run printed no usable 'PLAN_FILE:' line,"
+want    "a slugless prompt keeps the verbatim closer" "$out" "plan-now: read the transcript above."
+want_no "a slugless prompt attempts no leg B"      "$out" "recovery B"
+
+# 11. Adopted plan that fails check-plan → attempted, never queued, and no draft
+#     is claimed to be kept, because leg B never had one.
+out=$(run_case_recovery_plan "$RECOVERY_PROMPT" "$PARTIAL_DRAFT" demo-slug.md)
+want    "a failing adopted plan reports an attempt" "$out" "RESULT degraded (recovery attempted)"
+want    "a failing adopted plan is not queued"      "$out" "NOT queued"
+want_no "leg B claims no draft it never had"        "$out" "The draft is kept at"
+
 echo "── the coda still tells the model where to put it ──"
 
 dry=$(PLAN_NOW_DRY_RUN=1 PLAN_NOW_CLAUDE="$STUB" PLAN_NOW_PLANS_DIR="$PLANS" \
@@ -139,6 +399,9 @@ want "coda demands the last line" "$coda" "last line"
 # Tolerant parsing is a backstop for prose drift, not a licence to move the
 # instruction: under text mode an early-only marker is unreachable, full stop.
 want "coda explains why an earlier print is discarded" "$coda" "discarded"
+want "coda forbids backgrounding sub-agents"  "$coda" "run_in_background"
+want "coda demands foreground sub-agents"     "$coda" "FOREGROUND"
+want "coda keeps Agent backticked" "$coda" '`Agent`'
 
 echo
 if [ "$FAILS" -eq 0 ]; then


### PR DESCRIPTION
## Summary

Add automatic draft recovery when a backgrounded plan-architect is terminated. Introduces two independent recovery legs:

- **Leg A**: Recover and promote drafts orphaned in `.drafts/` when the architect was backgrounded and cut off
- **Leg B**: Identify and adopt plans created by successful runs that omitted the `PLAN_FILE:` marker

Also sets `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0` to prevent the harness from terminating background tasks, with recovery as defense-in-depth for residual cases. Changes result status from `unconfirmed` to `degraded (recovered)` for recoverable runs.

## Manual Testing

No manual testing needed — verified by automated tests.
