### PR TITLE
chore: plan variant resolution — pick highest-numbered <slug>-N.md, --plan override for bin/post-plan-now

### DIFF
--- a/.claude/rules/headless-marker-contract.md
+++ b/.claude/rules/headless-marker-contract.md
@@ -1,6 +1,6 @@
 ---
 description: Headless `claude -p` runners — where a machine-parsed marker must be printed, because text-mode `-p` emits only the model's final message, and how `bin/plan-now` recovers a draft when the marker never arrives. Path-scoped to bin/**, loads only when authoring or editing a runner.
-last_verified: 2026-07-29
+last_verified: 2026-07-30
 paths: "bin/**"
 ---
 
@@ -52,8 +52,9 @@ editing against the table above rather than assuming:
   a file rather than stdout.
 - `bin/automouse-run` — `stream-json --verbose` through `bin/lib/automouse-stream-filter`;
   it *passes* `PLAN_FILE=` into the prompt as input and parses nothing back out.
-- `bin/post-plan-now`, `bin/docfix-run` — derive the plan path from the branch slug in
-  shell; no model output is parsed.
+- `bin/post-plan-now` — passes an optional `--plan <abs-path>` through to the harness (which
+  owns variant resolution in `harness/planfile.py`) and into the fallback prompt; `bin/docfix-run`
+  derives the plan path from the branch slug in shell. Neither parses model output.
 
 `bin/test-plan-now` pins all of this for `plan-now` — the decorated shapes it accepts,
 and the three ways a marker still lands `unconfirmed`. It stubs the model call through

--- a/.claude/rules/workflow-continuity-detail.md
+++ b/.claude/rules/workflow-continuity-detail.md
@@ -1,6 +1,6 @@
 ---
 description: Post-plan engine internals — compiled harness vs. Sonnet skill fallback, what `--auto`'s skip gate does, and where the auto-merge arming decision is made. Lazy companion to workflow-continuity.md; loads only when a post-plan surface is in play.
-last_verified: 2026-07-28
+last_verified: 2026-07-30
 paths:
   - ".claude/skills/post-plan/SKILL.md"
   - ".claude/skills/ship/SKILL.md"
@@ -45,5 +45,7 @@ human signoff.
 
 ## No deadlock
 
-`/post-plan` resolves the plan from the branch slug, so no handoff file is needed, and the
-detached child reparents under launchd and clears its own plan-gate independently.
+`/post-plan` resolves the **highest-numbered** plan variant for the branch slug (`<slug>-3.md`
+beats `<slug>-2.md` beats `<slug>.md`; a non-numeric suffix like `-shared-context.md` is never a
+variant), so no handoff file is needed, and the detached child reparents under launchd and clears
+its own plan-gate independently. Override the selection with `bin/post-plan-now --plan <abs-path>`.

--- a/.claude/skills/post-plan/SKILL.md
+++ b/.claude/skills/post-plan/SKILL.md
@@ -5,7 +5,7 @@ disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
   - Skill
-last_verified: 2026-07-27
+last_verified: 2026-07-30
 ---
 
 # Post-Plan Orchestrator
@@ -66,11 +66,25 @@ rm -f /tmp/claude-plan-active-$PPID
 Then locate the plan backing this branch so later phases can verify the implementation against its intent. The plan is the spec; phases 4–6 check conformance to it.
 
 ```bash
-# Authoritative in automouse mode: the handoff JSON's plan_file (the postplan prompt passes its path).
-# Interactive fallback: branch slug -> ~/claude-plans/<slug>.md.
+# Authoritative when a path was handed to this run (automouse handoff JSON's plan_file, or
+# `bin/post-plan-now --plan <abs-path>`): use that path verbatim and skip the derivation below.
+# Otherwise derive from the branch slug, HIGHEST-NUMBERED variant first — /plan's own loop
+# writes <slug>-2.md, <slug>-3.md when bin/check-plan rejects a draft, and the superseded
+# <slug>.md stays on disk and still passes check-plan. Mirrors harness/planfile.py::_resolve_variant.
 SLUG=$(git rev-parse --abbrev-ref HEAD)
-PLAN_FILE=""
-[ -f "$HOME/claude-plans/$SLUG.md" ] && PLAN_FILE="$HOME/claude-plans/$SLUG.md"
+PLAN_FILE=""; BEST=-1
+for f in "$HOME/claude-plans/$SLUG.md" "$HOME/claude-plans/$SLUG"-*.md; do
+    [ -f "$f" ] || continue
+    stem=${f##*/}; stem=${stem%.md}
+    if [ "$stem" = "$SLUG" ]; then v=0
+    else
+        v=${stem#"$SLUG"-}
+        case "$v" in ''|*[!0-9]*) continue ;;   # -shared-context, -1a-trading-pins: not a revision
+        esac
+    fi
+    [ "$v" -gt "$BEST" ] && { BEST=$v; PLAN_FILE=$f; }
+done
+[ "$BEST" -gt 0 ] && echo "PLAN_VARIANT_SELECTED=$PLAN_FILE (highest-numbered; pass --plan <abs-path> to override)"
 if [ -n "$PLAN_FILE" ]; then
     echo "PLAN_FOUND=$PLAN_FILE"
     grep -qiE '^\s*\|.*Test type' "$PLAN_FILE" && echo "HAS_MATRIX=true" || echo "HAS_MATRIX=false"

--- a/bin/post-plan-now
+++ b/bin/post-plan-now
@@ -132,7 +132,7 @@ GATE_CLOSE=""
 ENGINE="Sonnet 4.6 /post-plan skill session"
 if [ "${POST_PLAN_SKILL:-0}" != "1" ] && [ -x "$HARNESS/run" ]; then
     FALLBACK_FN="$(declare -f should_fallback); "
-    PLAN_ARG="${PLAN_OVERRIDE:+ --plan \\\"$PLAN_OVERRIDE\\\"}"
+    PLAN_ARG="${PLAN_OVERRIDE:+ --plan \"$PLAN_OVERRIDE\"}"
     HARNESS_SEG="CLAUDE_HEADLESS=1 caffeinate -s \"$HARNESS/run\" isolated \"$ROOT\" \"$HARNESS/out/live-$SLUG-$TS\" --live${PLAN_ARG}; rc=\$?; "
     GATE_OPEN="if should_fallback \"\$rc\"; then "
     GATE_CLOSE="; elif [ \"\$rc\" = 3 ]; then echo \"post-plan-now: harness exited 3 (rebase-conflict fail-closed sentinel). SKIPPING the /post-plan skill fallback; a human must resolve the stacked-branch rebase conflict, then re-run bin/post-plan-now. See $LOG.\"; fi"

--- a/bin/post-plan-now
+++ b/bin/post-plan-now
@@ -49,7 +49,24 @@ should_fallback() { case "$1" in 0|3) return 1 ;; *) return 0 ;; esac; }
 set -euo pipefail
 
 AUTO=0
-[ "${1:-}" = "--auto" ] && AUTO=1
+PLAN_OVERRIDE=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --auto)   AUTO=1 ; shift ;;
+        --plan)   [ $# -ge 2 ] || { echo "post-plan-now: --plan requires a path argument" >&2; exit 1; }
+                  PLAN_OVERRIDE="$2" ; shift 2 ;;
+        --plan=*) PLAN_OVERRIDE="${1#--plan=}" ; shift ;;
+        *)        echo "post-plan-now: unknown argument '$1' (accepts --auto, --plan <path>)" >&2
+                  exit 1 ;;
+    esac
+done
+
+if [ -n "$PLAN_OVERRIDE" ]; then
+    [ -f "$PLAN_OVERRIDE" ] \
+        || { echo "post-plan-now: --plan '$PLAN_OVERRIDE' does not exist — aborting." >&2; exit 1; }
+    # launchd runs the job from a different cwd; the plist needs an absolute path.
+    PLAN_OVERRIDE="$(cd "$(dirname "$PLAN_OVERRIDE")" && pwd)/$(basename "$PLAN_OVERRIDE")"
+fi
 
 ROOT=$(git rev-parse --show-toplevel 2>/dev/null) \
     || { echo "post-plan-now: not inside a git repo." >&2; exit 1; }
@@ -62,7 +79,7 @@ case "$SLUG" in
         exit 1 ;;
 esac
 
-PLAN_FILE="$HOME/claude-plans/$SLUG.md"
+PLAN_FILE="${PLAN_OVERRIDE:-$HOME/claude-plans/$SLUG.md}"
 
 # --auto is the impl agent's automatic closing action. One gate applies only here;
 # a bare (human) invocation always fires, because running it by hand IS the
@@ -90,14 +107,18 @@ if git diff --quiet && git diff --cached --quiet \
 fi
 
 [ -f "$PLAN_FILE" ] \
-    || echo "post-plan-now: warn — no plan at $PLAN_FILE; /post-plan will run plan-blind." >&2
+    || echo "post-plan-now: warn — no plan at $PLAN_FILE; /post-plan will run plan-blind. Pass --plan <abs-path> to name one explicitly." >&2
 
 TS=$(date +%Y%m%d-%H%M%S)
 LOG="/tmp/post-plan-now-$SLUG-$TS.log"
 LABEL="com.ibl5.postplan-now-$SLUG-$TS"
 PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
 
-PROMPT="Invoke the /post-plan skill now on the current git branch. Resolve the plan from the branch slug per the skill Phase 1, then execute every phase. No human is present: never ask questions or wait for input — make the safe choice and continue."
+if [ -n "$PLAN_OVERRIDE" ]; then
+    PROMPT="Invoke the /post-plan skill now on the current git branch. Use this exact plan file for Phase 1: $PLAN_OVERRIDE — do NOT derive the plan from the branch slug. Then execute every phase. No human is present: never ask questions or wait for input — make the safe choice and continue."
+else
+    PROMPT="Invoke the /post-plan skill now on the current git branch. Resolve the plan from the branch slug per the skill Phase 1 (highest-numbered \`<slug>-N.md\` variant when several exist), then execute every phase. No human is present: never ask questions or wait for input — make the safe choice and continue."
+fi
 
 # Compiled-harness engine (see header). The launchd job runs the harness, captures its exit code,
 # and escalates to the skill session ONLY when should_fallback permits it. Exit 3 (rebase-conflict
@@ -111,7 +132,8 @@ GATE_CLOSE=""
 ENGINE="Sonnet 4.6 /post-plan skill session"
 if [ "${POST_PLAN_SKILL:-0}" != "1" ] && [ -x "$HARNESS/run" ]; then
     FALLBACK_FN="$(declare -f should_fallback); "
-    HARNESS_SEG="CLAUDE_HEADLESS=1 caffeinate -s \"$HARNESS/run\" isolated \"$ROOT\" \"$HARNESS/out/live-$SLUG-$TS\" --live; rc=\$?; "
+    PLAN_ARG="${PLAN_OVERRIDE:+ --plan \\\"$PLAN_OVERRIDE\\\"}"
+    HARNESS_SEG="CLAUDE_HEADLESS=1 caffeinate -s \"$HARNESS/run\" isolated \"$ROOT\" \"$HARNESS/out/live-$SLUG-$TS\" --live${PLAN_ARG}; rc=\$?; "
     GATE_OPEN="if should_fallback \"\$rc\"; then "
     GATE_CLOSE="; elif [ \"\$rc\" = 3 ]; then echo \"post-plan-now: harness exited 3 (rebase-conflict fail-closed sentinel). SKIPPING the /post-plan skill fallback; a human must resolve the stacked-branch rebase conflict, then re-run bin/post-plan-now. See $LOG.\"; fi"
     ENGINE="compiled post-plan harness (fails CLOSED on rebase conflict; falls back to the skill on other failures)"

--- a/tools/postplan-harness/harness/planfile.py
+++ b/tools/postplan-harness/harness/planfile.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import re
+import sys
 
 from .state import PlanInfo
 
@@ -163,15 +164,51 @@ def parse_critical_files(content: str) -> list[tuple]:
     return out
 
 
+def _resolve_variant(slug: str, base_dir: str, info: PlanInfo) -> str:
+    """Highest-numbered plan variant for `slug` in `base_dir`.
+
+    Variant shape is exactly `{slug}-N.md`: one or more digits and nothing else
+    before `.md`. The bare `slug.md` is variant 0 (lowest). No variant found ->
+    the bare path, byte-identical to pre-variant behaviour (no stderr, no fields).
+    """
+    bare = os.path.join(base_dir, f"{slug}.md")
+    pattern = re.compile(rf"^{re.escape(slug)}-(\d+)\.md$")
+    try:
+        entries = os.listdir(base_dir)
+    except OSError:
+        return bare
+    variants = [(int(m.group(1)), os.path.join(base_dir, m.string))
+                for m in (pattern.match(n) for n in entries) if m
+                and os.path.isfile(os.path.join(base_dir, m.string))]
+    if not variants:
+        return bare
+    candidates = ([(0, bare)] if os.path.isfile(bare) else []) + variants
+    candidates.sort(key=lambda c: c[0])
+    _, selected = candidates[-1]
+    names = [os.path.basename(p) for _, p in candidates]
+    print(
+        f"post-plan: WARNING — {len(candidates)} plan variants for slug '{slug}':\n"
+        f"  candidates: {', '.join(names)}\n"
+        f"  SELECTED:   {os.path.basename(selected)} (highest numbered)\n"
+        f"  override:   bin/post-plan-now --plan <abs-path>",
+        file=sys.stderr)
+    info.variant_selection = "highest"
+    info.rejected = [os.path.basename(p) for _, p in candidates if p != selected]
+    return selected
+
+
 def locate_plan(slug: str, plans_dir: str | None = None, explicit_path: str | None = None,
                 content_override: str | None = None) -> PlanInfo:
-    """Authoritative explicit path (automouse handoff) first, else slug derivation."""
+    """Authoritative explicit path (automouse handoff) first, else variant-aware slug derivation."""
     info = PlanInfo()
     content = content_override
     if content is None:
-        path = explicit_path or os.path.join(
-            plans_dir or os.environ.get("PLANS_DIR")
-            or os.path.expanduser("~/claude-plans"), f"{slug}.md")
+        if explicit_path:
+            path = explicit_path
+        else:
+            base_dir = (plans_dir or os.environ.get("PLANS_DIR")
+                        or os.path.expanduser("~/claude-plans"))
+            path = _resolve_variant(slug, base_dir, info)
         if not os.path.isfile(path):
             return info
         info.path = path

--- a/tools/postplan-harness/harness/state.py
+++ b/tools/postplan-harness/harness/state.py
@@ -96,6 +96,8 @@ class PlanInfo:
     truly_manual_rows: list[str] = field(default_factory=list)
     security_section: str = ""
     reuse_section: str = ""
+    variant_selection: Optional[str] = None            # "highest" when multi-variant selection ran
+    rejected: list[str] = field(default_factory=list)  # basenames of non-selected candidates
 
 
 @dataclass
@@ -197,4 +199,9 @@ class RunResult:
         d = asdict(self)
         if self.classification:
             d["classification"].pop("filtered_diff", None)  # keep result.json small
+        if d.get("plan"):                       # unambiguous slug → keep result.json byte-identical
+            if not d["plan"].get("variant_selection"):
+                d["plan"].pop("variant_selection", None)
+            if not d["plan"].get("rejected"):
+                d["plan"].pop("rejected", None)
         return json.dumps(d, indent=1, default=str)

--- a/tools/postplan-harness/runner.py
+++ b/tools/postplan-harness/runner.py
@@ -41,7 +41,8 @@ from harness.adapters.verify import LiveVerify, ReplayVerify, aggregate
 
 def run(fixture: dict | None, out_dir: str, llm, *, mode: str = "replay",
         worktree: str | None = None, headless: bool = True,
-        plans_dir: str | None = None, live: bool = False) -> RunResult:
+        plans_dir: str | None = None, live: bool = False,
+        explicit_path: str | None = None) -> RunResult:
     os.makedirs(out_dir, exist_ok=True)
     ledger = llm.ledger
     audit: list[str] = []
@@ -61,7 +62,7 @@ def run(fixture: dict | None, out_dir: str, llm, *, mode: str = "replay",
         slug = git.branch()
         gh = LiveGh(out_dir, worktree, slug) if live else RecordingGh(out_dir)
         verifier = LiveVerify(worktree)
-        plan = locate_plan(slug, plans_dir=plans_dir)
+        plan = locate_plan(slug, plans_dir=plans_dir, explicit_path=explicit_path)
 
     res = RunResult(terminal=TerminalState.FAILED, slug=slug, plan=plan,
                     ledger=ledger, audit=audit)
@@ -259,9 +260,13 @@ def main() -> int:
     ap.add_argument("--live", action="store_true",
                     help="INSTALLED mode (isolated only): push to origin, execute "
                          "allowlisted gh mutations, watch CI")
+    ap.add_argument("--plan", help="explicit plan file path (isolated only): overrides "
+                                   "slug-derived variant selection")
     args = ap.parse_args()
     if args.live and args.mode != "isolated":
         ap.error("--live is only valid with --mode isolated")
+    if args.plan and args.mode != "isolated":
+        ap.error("--plan is only valid with --mode isolated")
 
     fixture = None
     if args.mode == "replay":
@@ -280,7 +285,7 @@ def main() -> int:
         llm = ClaudeCli(ledger)
 
     res = run(fixture, args.out, llm, mode=args.mode, worktree=args.worktree,
-              headless=not args.interactive, live=args.live)
+              headless=not args.interactive, live=args.live, explicit_path=args.plan)
     t = ledger.totals()
     print(f"terminal={res.terminal.value} phase5={res.phase5} "
           f"armed={bool(res.arm and res.arm.armed)} findings={len(res.findings)}")

--- a/tools/postplan-harness/tests/test_planfile.py
+++ b/tools/postplan-harness/tests/test_planfile.py
@@ -1,4 +1,7 @@
+import contextlib
+import io
 import os
+import pytest
 import re
 import subprocess
 import sys
@@ -8,6 +11,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from harness import conformance
 from harness.planfile import (EXEMPT_RE, frontmatter_auto_merge_false, locate_plan,
                               parse_critical_files, parse_matrix)
+from harness.state import PlanInfo, RunResult
 
 PLAN = """---
 status: ready
@@ -233,3 +237,177 @@ def test_lib_pattern_sync():
     assert m, "CF_EXEMPT_PATTERN not found in " + LIB
     ere = m.group(1).replace("[(]", r"\(").replace("[)]", r"\)")
     assert EXEMPT_RE.pattern.replace("(?:", "(") == ere
+
+
+# ---------------------------------------------------------------------------
+# Variant-resolution specs (Phases 1, 2, 3, 4, 6)
+# ---------------------------------------------------------------------------
+
+def _mkplans(tmp_path, *names):
+    """Create plan files; return the dir as str for plans_dir=."""
+    for n in names:
+        (tmp_path / n).write_text("---\nauto_merge: false\n---\n# " + n + "\n")
+    return str(tmp_path)
+
+
+def test_variant_single_plan_is_byte_identical(tmp_path):
+    plans_dir = _mkplans(tmp_path, "my-slug.md")
+    info = locate_plan("my-slug", plans_dir=plans_dir)
+    assert info.found
+    assert info.path == str(tmp_path / "my-slug.md")
+    assert getattr(info, "variant_selection", None) is None
+    assert getattr(info, "rejected", []) == []
+
+
+def test_variant_highest_of_three(tmp_path):
+    plans_dir = _mkplans(tmp_path, "my-slug.md", "my-slug-2.md", "my-slug-3.md")
+    info = locate_plan("my-slug", plans_dir=plans_dir)
+    assert info.path.endswith("my-slug-3.md")
+
+
+def test_variant_numeric_not_lexical(tmp_path):
+    plans_dir = _mkplans(tmp_path, "my-slug.md", "my-slug-2.md", "my-slug-10.md")
+    info = locate_plan("my-slug", plans_dir=plans_dir)
+    assert info.path.endswith("my-slug-10.md"), "lexical sort picked %s" % info.path
+
+
+def test_variant_shared_context_excluded(tmp_path):
+    plans_dir = _mkplans(tmp_path, "my-slug.md", "my-slug-shared-context.md")
+    info = locate_plan("my-slug", plans_dir=plans_dir)
+    assert info.path.endswith("my-slug.md")
+    assert "my-slug-shared-context.md" not in getattr(info, "rejected", [])
+    assert getattr(info, "variant_selection", None) is None
+
+
+def test_variant_sibling_unit_excluded(tmp_path):
+    plans_dir = _mkplans(tmp_path, "my-slug.md", "my-slug-1-unit.md",
+                         "my-slug-1a-trading-pins.md")
+    info = locate_plan("my-slug", plans_dir=plans_dir)
+    assert info.path.endswith("my-slug.md")
+    assert getattr(info, "variant_selection", None) is None
+
+
+def test_variant_explicit_path_wins(tmp_path):
+    plans_dir = _mkplans(tmp_path, "my-slug.md", "my-slug-2.md", "my-slug-3.md")
+    info = locate_plan("my-slug", plans_dir=plans_dir,
+                       explicit_path=str(tmp_path / "my-slug.md"))
+    assert info.path == str(tmp_path / "my-slug.md")
+    assert getattr(info, "variant_selection", None) is None
+
+
+def test_variant_no_plan_at_all(tmp_path):
+    info = locate_plan("nonexistent", plans_dir=str(tmp_path))
+    assert not info.found
+    assert info.path == ""
+
+
+def test_variant_warning_goes_to_stderr(tmp_path):
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        info = locate_plan("my-slug",
+                           plans_dir=_mkplans(tmp_path, "my-slug.md", "my-slug-2.md"))
+    err = buf.getvalue()
+    assert "my-slug.md" in err
+    assert "my-slug-2.md" in err
+    assert any("SELECTED" in ln and "my-slug-2.md" in ln for ln in err.splitlines())
+    assert "--plan" in err
+
+    # silence assertion: single plan emits nothing
+    tmp2 = tmp_path / "single"
+    tmp2.mkdir()
+    buf2 = io.StringIO()
+    with contextlib.redirect_stderr(buf2):
+        locate_plan("my-slug", plans_dir=_mkplans(tmp2, "my-slug.md"))
+    assert buf2.getvalue() == ""
+
+
+def test_variant_selection_fields_populated(tmp_path):
+    plans_dir = _mkplans(tmp_path, "my-slug.md", "my-slug-3.md")
+    info = locate_plan("my-slug", plans_dir=plans_dir)
+    assert info.variant_selection == "highest"
+    assert "my-slug.md" in info.rejected
+
+
+# Phase 2 — to_json() strip test
+def test_to_json_strips_empty_variant_fields():
+    from harness.state import Classification
+    res = RunResult(terminal="shipped-held", slug="x",
+                    plan=PlanInfo(found=True, path="x.md"))
+    d = __import__("json").loads(res.to_json())
+    assert "variant_selection" not in d["plan"]
+    assert "rejected" not in d["plan"]
+
+    res.plan.variant_selection = "highest"
+    res.plan.rejected = ["x.md"]
+    d2 = __import__("json").loads(res.to_json())
+    assert d2["plan"]["variant_selection"] == "highest"
+    assert d2["plan"]["rejected"] == ["x.md"]
+
+    res2 = RunResult(terminal="failed", slug="y", plan=None)
+    out = res2.to_json()
+    assert not out or __import__("json").loads(out)["plan"] is None
+
+
+# Phase 3 boundary tests
+def test_variant_bare_missing_highest_still_wins(tmp_path):
+    plans_dir = _mkplans(tmp_path, "my-slug-2.md")
+    info = locate_plan("my-slug", plans_dir=plans_dir)
+    assert info.found
+    assert info.path.endswith("my-slug-2.md")
+    assert info.variant_selection == "highest"
+    assert info.rejected == []
+
+
+def test_variant_unreadable_dir_is_plan_blind(tmp_path):
+    info = locate_plan("s", plans_dir=str(tmp_path / "gone"))
+    assert not info.found
+
+
+def test_variant_regex_special_chars_in_slug(tmp_path):
+    plans_dir = _mkplans(tmp_path, "feat.v2+x.md", "feat.v2+x-2.md",
+                         "featXv2Yx-3.md")
+    info = locate_plan("feat.v2+x", plans_dir=plans_dir)
+    assert info.path.endswith("feat.v2+x-2.md")
+    assert not info.path.endswith("featXv2Yx-3.md")
+
+
+# Phase 4 — runner wiring assertion
+def test_runner_threads_explicit_path():
+    runner_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "runner.py")
+    src = open(runner_path).read()
+    assert "explicit_path=explicit_path" in src
+    assert "explicit_path=args.plan" in src
+
+
+def test_runner_plan_requires_isolated_mode():
+    runner_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "runner.py")
+    r = subprocess.run(
+        ["python3", runner_path, "--mode", "replay", "--plan", "/tmp/x.md",
+         "--fixture", "/dev/null"],
+        capture_output=True, text=True)
+    assert r.returncode == 2
+    assert "--plan is only valid with --mode isolated" in r.stderr
+
+
+# Phase 6 — corpus regression
+def test_corpus_regression_jsb_native_docs_repo():
+    """The measured 2026-07-29 failure: v1 selected where v3 was the live contract."""
+    real_dir = os.path.expanduser("~/claude-plans")
+    v3 = os.path.join(real_dir, "jsb-native-docs-repo-3.md")
+    if not os.path.isfile(v3):
+        pytest.skip("corpus fixture jsb-native-docs-repo-3.md not present (CI / fresh clone)")
+
+    info = locate_plan("jsb-native-docs-repo", plans_dir=real_dir)
+    assert info.found
+    assert info.path == v3, "expected v3, got %s" % info.path
+    assert info.variant_selection == "highest"
+    assert "jsb-native-docs-repo.md" in info.rejected
+    assert "jsb-native-docs-repo-2.md" in info.rejected
+
+    cf = [p for p, _ann, _ex in info.critical_files]
+    assert "bin/check-docs" not in cf, \
+        "v3 rejects bin/check-docs (Alternatives Considered); only v1 lists it as Critical"
+    assert "ibl5/docs/decisions/0097-jsb-native-docs-repo.md" not in cf, \
+        "v3 renamed the ADR to 0097-jsb-native-private-docs-repo.md; only v1 has the old slug"

--- a/tools/postplan-harness/tests/test_post_plan_now_fallback.py
+++ b/tools/postplan-harness/tests/test_post_plan_now_fallback.py
@@ -32,17 +32,11 @@ def test_plist_wiring_regression():
 
 
 def test_plan_override_missing_file_aborts(tmp_path):
-    import glob
-    before = set(glob.glob(str(tmp_path / "com.ibl5.postplan-now-*.plist")))
     r = subprocess.run(
         ["bash", "bin/post-plan-now", "--plan", "/nonexistent-plan.md"],
         capture_output=True, text=True, cwd=REPO)
     assert r.returncode == 1
     assert "does not exist — aborting" in r.stderr
-    after = set(glob.glob(
-        os.path.expanduser("~/Library/LaunchAgents/com.ibl5.postplan-now-*.plist")))
-    assert not (after - set(glob.glob(
-        os.path.expanduser("~/Library/LaunchAgents/com.ibl5.postplan-now-*.plist"))))
 
 
 def test_plan_arg_errors():
@@ -76,22 +70,12 @@ def test_plan_override_valid_path_passes_validation(tmp_path):
     plan = tmp_path / "myplan.md"
     plan.write_text("---\nauto_merge: false\n---\n# My Plan\n")
     r = subprocess.run(
-        ["bash", "bin/post-plan-now", "--plan", str(plan)],
-        capture_output=True, text=True, cwd=REPO)
+        ["bash", PPN, "--plan", str(plan)],
+        capture_output=True, text=True, cwd=str(tmp_path))
+    assert r.returncode == 1
     assert "does not exist — aborting" not in r.stderr
+    assert "not inside a git repo" in r.stderr
 
-
-def test_plist_wiring_regression_new():
-    src = open(PPN).read()
-    assert "--live || " not in src               # old unconditional fallback chain removed
-    assert "should_fallback" in src              # fallback now gated by the tested function
-    assert r"rc=\$?" in src                       # harness exit code captured for the gate
-    assert r'\"\$rc\" = 3' in src                 # fail-closed notice is rc=3-only (elif)
-    # New wiring assertions
-    assert "PLAN_ARG" in src
-    assert "--live${PLAN_ARG}" in src
-    assert "${PLAN_OVERRIDE:-$HOME/claude-plans/$SLUG.md}" in src
-    assert "do NOT derive the plan from the branch slug" in src
 
 
 def test_skill_block_matches_resolver(tmp_path):
@@ -122,13 +106,16 @@ def test_skill_block_matches_resolver(tmp_path):
         + '\necho "PLAN_FILE=$PLAN_FILE"\n'
         + '\necho "BEST=$BEST"\n'
     )
-    # Override claude-plans to our tmp dir
+    # Override claude-plans to our tmp dir and fix SLUG so git rev-parse doesn't clobber it
     script = script.replace(
         '"$HOME/claude-plans/$SLUG.md"',
         f'"{tmp_path!s}/$SLUG.md"'
     ).replace(
         '"$HOME/claude-plans/$SLUG"-*.md',
         f'"{tmp_path!s}/$SLUG"-*.md'
+    ).replace(
+        'SLUG=$(git rev-parse --abbrev-ref HEAD)',
+        'SLUG=s'
     )
     r = subprocess.run(["bash", "-c", script], capture_output=True, text=True, env=env)
     assert r.returncode == 0, r.stderr

--- a/tools/postplan-harness/tests/test_post_plan_now_fallback.py
+++ b/tools/postplan-harness/tests/test_post_plan_now_fallback.py
@@ -24,3 +24,146 @@ def test_plist_wiring_regression():
     assert "should_fallback" in src              # fallback now gated by the tested function
     assert r"rc=\$?" in src                       # harness exit code captured for the gate
     assert r'\"\$rc\" = 3' in src                 # fail-closed notice is rc=3-only (elif)
+    # New wiring assertions
+    assert "PLAN_ARG" in src
+    assert "--live${PLAN_ARG}" in src
+    assert "${PLAN_OVERRIDE:-$HOME/claude-plans/$SLUG.md}" in src
+    assert "do NOT derive the plan from the branch slug" in src
+
+
+def test_plan_override_missing_file_aborts(tmp_path):
+    import glob
+    before = set(glob.glob(str(tmp_path / "com.ibl5.postplan-now-*.plist")))
+    r = subprocess.run(
+        ["bash", "bin/post-plan-now", "--plan", "/nonexistent-plan.md"],
+        capture_output=True, text=True, cwd=REPO)
+    assert r.returncode == 1
+    assert "does not exist — aborting" in r.stderr
+    after = set(glob.glob(
+        os.path.expanduser("~/Library/LaunchAgents/com.ibl5.postplan-now-*.plist")))
+    assert not (after - set(glob.glob(
+        os.path.expanduser("~/Library/LaunchAgents/com.ibl5.postplan-now-*.plist"))))
+
+
+def test_plan_arg_errors():
+    r1 = subprocess.run(
+        ["bash", "bin/post-plan-now", "--plan"],
+        capture_output=True, text=True, cwd=REPO)
+    assert r1.returncode == 1
+    assert "--plan requires a path argument" in r1.stderr
+
+    r2 = subprocess.run(
+        ["bash", "bin/post-plan-now", "--pln", "/tmp/x.md"],
+        capture_output=True, text=True, cwd=REPO)
+    assert r2.returncode == 1
+    assert "unknown argument" in r2.stderr
+
+
+def test_arg_order_independent(tmp_path):
+    for args in (
+        ["--auto", "--plan", "/nonexistent.md"],
+        ["--plan", "/nonexistent.md", "--auto"],
+        ["--plan=/nonexistent.md"],
+    ):
+        r = subprocess.run(["bash", "bin/post-plan-now"] + args,
+                           capture_output=True, text=True, cwd=REPO)
+        assert r.returncode == 1
+        assert "does not exist — aborting" in r.stderr, \
+            f"args {args}: got {r.stderr!r}"
+
+
+def test_plan_override_valid_path_passes_validation(tmp_path):
+    plan = tmp_path / "myplan.md"
+    plan.write_text("---\nauto_merge: false\n---\n# My Plan\n")
+    r = subprocess.run(
+        ["bash", "bin/post-plan-now", "--plan", str(plan)],
+        capture_output=True, text=True, cwd=REPO)
+    assert "does not exist — aborting" not in r.stderr
+
+
+def test_plist_wiring_regression_new():
+    src = open(PPN).read()
+    assert "--live || " not in src               # old unconditional fallback chain removed
+    assert "should_fallback" in src              # fallback now gated by the tested function
+    assert r"rc=\$?" in src                       # harness exit code captured for the gate
+    assert r'\"\$rc\" = 3' in src                 # fail-closed notice is rc=3-only (elif)
+    # New wiring assertions
+    assert "PLAN_ARG" in src
+    assert "--live${PLAN_ARG}" in src
+    assert "${PLAN_OVERRIDE:-$HOME/claude-plans/$SLUG.md}" in src
+    assert "do NOT derive the plan from the branch slug" in src
+
+
+def test_skill_block_matches_resolver(tmp_path):
+    """SKILL.md Phase 1 shell block and locate_plan agree on same corpus."""
+    import sys as _sys
+    _sys.path.insert(0, os.path.join(REPO, "tools", "postplan-harness"))
+    from harness.planfile import locate_plan
+
+    plans = tmp_path
+    for name in ("s.md", "s-shared-context.md", "s-2.md"):
+        (plans / name).write_text("---\nauto_merge: false\n---\n# " + name + "\n")
+
+    skill_md = os.path.join(REPO, ".claude", "skills", "post-plan", "SKILL.md")
+    skill_src = open(skill_md).read()
+    # Extract the resolution shell block between the two bash fences in Phase 1
+    import re
+    m = re.search(r"```bash\n(# Authoritative.*?PLAN_VARIANT_SELECTED.*?\n)```", skill_src, re.S)
+    assert m, "SKILL.md Phase 1 shell block not found"
+    shell_block = m.group(1)
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path.parent)
+    env["SLUG"] = "s"
+    script = (
+        f"cd {REPO!r}\n"
+        f'mkdir -p "{tmp_path!s}"\n'
+        + shell_block
+        + '\necho "PLAN_FILE=$PLAN_FILE"\n'
+        + '\necho "BEST=$BEST"\n'
+    )
+    # Override claude-plans to our tmp dir
+    script = script.replace(
+        '"$HOME/claude-plans/$SLUG.md"',
+        f'"{tmp_path!s}/$SLUG.md"'
+    ).replace(
+        '"$HOME/claude-plans/$SLUG"-*.md',
+        f'"{tmp_path!s}/$SLUG"-*.md'
+    )
+    r = subprocess.run(["bash", "-c", script], capture_output=True, text=True, env=env)
+    assert r.returncode == 0, r.stderr
+    # Skill should pick s-2.md (highest)
+    assert "s-2.md" in r.stdout, f"skill output: {r.stdout!r}"
+
+    # Resolver should also pick s-2.md
+    info = locate_plan("s", plans_dir=str(tmp_path))
+    assert info.path.endswith("s-2.md"), f"resolver picked: {info.path}"
+
+
+def test_skill_block_plan_blind(tmp_path):
+    """SKILL.md shell block on empty plans dir prints nothing, leaves PLAN_FILE empty."""
+    skill_md = os.path.join(REPO, ".claude", "skills", "post-plan", "SKILL.md")
+    skill_src = open(skill_md).read()
+    import re
+    m = re.search(r"```bash\n(# Authoritative.*?PLAN_VARIANT_SELECTED.*?\n)```", skill_src, re.S)
+    assert m, "SKILL.md Phase 1 shell block not found"
+    shell_block = m.group(1)
+
+    plans_dir = str(tmp_path / "empty-plans")
+    os.makedirs(plans_dir, exist_ok=True)
+    script = (
+        "SLUG=no-such-slug\n"
+        + shell_block.replace(
+            '"$HOME/claude-plans/$SLUG.md"',
+            f'"{plans_dir}/$SLUG.md"'
+        ).replace(
+            '"$HOME/claude-plans/$SLUG"-*.md',
+            f'"{plans_dir}/$SLUG"-*.md'
+        )
+        + '\necho "PLAN_FILE=${PLAN_FILE:-}"\n'
+        + 'if [ -z "${PLAN_FILE:-}" ]; then echo "PLAN_FOUND=none"; fi\n'
+    )
+    r = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    assert "PLAN_VARIANT_SELECTED" not in r.stdout
+    assert "PLAN_FOUND=none" in r.stdout


### PR DESCRIPTION
## Summary

Adds plan variant resolution to the postplan harness and `bin/post-plan-now`:

- **Harness (`planfile.py`):** `_resolve_variant()` picks the highest-numbered `<slug>-N.md` when multiple variants exist for a branch slug. Variant 0 is the bare `<slug>.md`. Emits a stderr warning listing all candidates + the selected one.
- **`bin/post-plan-now`:** Adds `--plan <abs-path>` flag to override the slug-derived path. The automouse/headless prompt embeds the path so the skill session skips slug derivation entirely.
- **Skill (`SKILL.md`):** Phase 1 documents the highest-numbered variant selection and the `--plan` override.
- **Rules:** Updates `workflow-continuity-detail.md` and `headless-marker-contract.md` to reflect the new variant behavior.
- **Tests:** Full coverage in `test_planfile.py` (variant selection logic) and `test_post_plan_now_fallback.py` (CLI flag).

Mirrors `harness/planfile.py::_resolve_variant` in the SKILL.md Phase 1 bash block so skill and harness stay in sync.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
