### PR TITLE
chore: add unattended CI-failure autofix to bug-pipeline-tick

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -765,6 +765,8 @@ jobs:
         run: bin/test-bug-pipeline-issue
       - name: bin/test-bug-pipeline-hunt
         run: bin/test-bug-pipeline-hunt
+      - name: bin/test-bug-pipeline-ci-autofix
+        run: bin/test-bug-pipeline-ci-autofix
       - name: bin/test-sim-recap-tick
         run: bin/test-sim-recap-tick
       - name: bin/test-plan-now

--- a/bin/bug-pipeline-ci-autofix-prompt
+++ b/bin/bug-pipeline-ci-autofix-prompt
@@ -1,0 +1,57 @@
+You are the IBL5 CI AUTOFIX AGENT — an autonomous agent for fixing CI failures on a
+basketball-league PHP app. No human is present. Your entire job is to:
+1. Read the CI failure log and the PR diff.
+2. Identify the failing test/assertion as file:line.
+3. If git status --short is dirty, commit that work FIRST with exactly:
+   chore: commit idle worktree changes before CI autofix (idle >{{idle_secs}}s)
+   If that commit fails (e.g., a pre-commit hook rejects it), write result with
+   "result":"abort","reason":"uncommitted changes prevented staging" and STOP.
+4. Make the MINIMAL code fix and commit it separately.
+5. Write the result file and exit.
+
+Your worktree is: {{worktree}}
+PR number: {{pr_number}}
+Failing checks: {{failing_checks}}
+CI failure log: {{ci_log_path}}
+PR diff: {{diff_path}}
+Result file: {{result_file}}
+
+════════════════════════════════════════════════════════════════════════════════
+HARD LIMITS — you have NO ship authority
+════════════════════════════════════════════════════════════════════════════════
+NEVER: git push, git checkout --, git stash, git clean, run gh (any subcommand),
+open or merge a pull request, acquire credentials, access external services.
+bin/phpstan may be run if present; it is NEVER a prerequisite.
+
+════════════════════════════════════════════════════════════════════════════════
+CHECK-DOCS RULE — bump last_verified only on files the PR ALREADY touches
+════════════════════════════════════════════════════════════════════════════════
+If a bin/check-docs failure appears, bump last_verified: ONLY on .md files that
+the PR's own diff already modifies. NEVER bump last_verified on untouched docs to
+satisfy a gate — that is the drive-by-bump anti-pattern and it will be reverted.
+
+════════════════════════════════════════════════════════════════════════════════
+VR BASELINE FAILURES — use the update-baselines label, not hand-committed PNGs
+════════════════════════════════════════════════════════════════════════════════
+If Visual Regression fails on a PR that adds a new vr-manifest.ts row (first run,
+no baseline exists), the fix is applying the update-baselines label to the PR — NOT
+hand-committing PNG files scraped from a CI artifact. Those bytes are rendered
+outside the baseline container and will produce wrong baselines. Write result
+"no_change" with reason "VR baseline: apply update-baselines label" and stop.
+
+════════════════════════════════════════════════════════════════════════════════
+OUTPUT CONTRACT — write EXACTLY this file, then exit
+════════════════════════════════════════════════════════════════════════════════
+Write {{result_file}} as a single JSON object:
+
+{
+  "result": "fixed|no_change|abort",
+  "commit_sha": "<sha or null>",
+  "failing_checks": ["<name>"],
+  "changes": [{"file": "<path>", "line": <n>, "description": "<one line>"}],
+  "reason": "<one-line explanation>"
+}
+
+result "fixed": minimal fix committed, CI should now pass.
+result "no_change": failure appears transient or requires non-code action; no commit.
+result "abort": could not safely proceed (hook rejected, unresolvable conflict, etc).

--- a/bin/bug-pipeline-ci-autofix-prompt
+++ b/bin/bug-pipeline-ci-autofix-prompt
@@ -2,10 +2,10 @@ You are the IBL5 CI AUTOFIX AGENT — an autonomous agent for fixing CI failures
 basketball-league PHP app. No human is present. Your entire job is to:
 1. Read the CI failure log and the PR diff.
 2. Identify the failing test/assertion as file:line.
-3. If git status --short is dirty, commit that work FIRST with exactly:
-   chore: commit idle worktree changes before CI autofix (idle >{{idle_secs}}s)
-   If that commit fails (e.g., a pre-commit hook rejects it), write result with
-   "result":"abort","reason":"uncommitted changes prevented staging" and STOP.
+3. If git status --short is dirty, DO NOT commit it — it is a human's unfinished
+   work, not yours. Write result with
+   "result":"abort","reason":"worktree dirty — refusing to commit work I did not author"
+   and STOP.
 4. Make the MINIMAL code fix and commit it separately.
 5. Write the result file and exit.
 
@@ -20,7 +20,8 @@ Result file: {{result_file}}
 HARD LIMITS — you have NO ship authority
 ════════════════════════════════════════════════════════════════════════════════
 NEVER: git push, git checkout --, git stash, git clean, run gh (any subcommand),
-open or merge a pull request, acquire credentials, access external services.
+open or merge a pull request, acquire credentials, access external services,
+git add files you did not modify, or commit pre-existing uncommitted changes.
 bin/phpstan may be run if present; it is NEVER a prerequisite.
 
 ════════════════════════════════════════════════════════════════════════════════

--- a/bin/bug-pipeline-tick
+++ b/bin/bug-pipeline-tick
@@ -1152,7 +1152,7 @@ CI_EOF
 
     if [ "$CI_AUTOFIX_DRY_RUN" = "1" ]; then
         ci_log "would-dispatch model=$model PR #$best_pr attempt $attempt failing=$best_failing"
-        ci_lock_release; return 0
+        ci_lock_release; return 1
     fi
 
     local ci_log_path diff_path result_file
@@ -1166,7 +1166,7 @@ CI_EOF
     rm -f "$result_file" 2>/dev/null || true
     local prompt_rendered
     prompt_rendered="$(mktemp "${wt_root}/.bug-pipeline/prompt.XXXXXX" 2>/dev/null)" || \
-        { ci_log "PR #$best_pr: cannot create prompt tempfile"; ci_lock_release; return 0; }
+        { ci_log "PR #$best_pr: cannot create prompt tempfile"; ci_lock_release; return 1; }
     ci_render_prompt "$best_pr" "$best_branch" "$wt_root" "$best_failing" \
         "$ci_log_path" "$diff_path" "$result_file" > "$prompt_rendered"
 
@@ -1305,8 +1305,9 @@ main() {
     fi
 
     # ── CI-autofix pass (ADR-0097): opportunistic — runs only when no bug hunt ran ──
-    # Returns 0 iff a fix agent was dispatched; caller ends the tick to enforce one spawn
-    # per tick. Deferred until after maybe_hunt so bug hunting always takes priority.
+    # Returns 0 only when a fix agent was dispatched (caller ends the tick — one spawn/tick).
+    # Returns 1 on every other path (kill switch, dry-run, no eligible PR) so the bug-report
+    # loop still runs. Deferred until after maybe_hunt so bug hunting always takes priority.
     if ci_autofix_main; then
         return 0
     fi

--- a/bin/bug-pipeline-tick
+++ b/bin/bug-pipeline-tick
@@ -1084,10 +1084,11 @@ ci_budget_state() {
 
 # ci_autofix_main — detect red PRs, acquire lock, gate (budget/wt/idle/head),
 # dispatch at most one fix agent per tick, or call giveup when ceiling reached.
-# Never aborts a tick: every failure path logs and returns 0.
+# Returns 0 ONLY when a fix agent was dispatched (caller ends the tick).
+# Returns 1 on every non-dispatch path so the tick falls through to the bug-report loop.
 ci_autofix_main() {
     [ "$CI_AUTOFIX_ENABLED" = "1" ] || {
-        ci_log "kill switch off — skipping CI-autofix"; return 0; }
+        ci_log "kill switch off — skipping CI-autofix"; return 1; }
 
     local red_prs
     red_prs="$(bpgh_pr_failing_checks 2>/dev/null || true)"
@@ -1123,23 +1124,23 @@ CI_EOF
 
     [ -n "$best_pr" ] || { ci_log "no eligible PR found this tick"; return 1; }
 
-    ci_lock_acquire || return 0
+    ci_lock_acquire || return 1
 
     # Re-resolve worktree: it may have disappeared since the scan.
     wt_root="$(ci_wt_for_branch "$best_branch" 2>/dev/null || true)"
     if [ -z "$wt_root" ]; then
         ci_log "PR #$best_pr: worktree vanished after lock"
-        ci_lock_release; return 0
+        ci_lock_release; return 1
     fi
 
     if ! ci_wt_is_idle "$wt_root"; then
         ci_log "PR #$best_pr: worktree not idle — skipping"
-        ci_lock_release; return 0
+        ci_lock_release; return 1
     fi
 
     if ! ci_wt_head_matches "$wt_root" "$best_sha"; then
         ci_log "PR #$best_pr: worktree HEAD does not include PR head $best_sha — skipping"
-        ci_lock_release; return 0
+        ci_lock_release; return 1
     fi
 
     local attempt model wt_appdir

--- a/bin/bug-pipeline-tick
+++ b/bin/bug-pipeline-tick
@@ -71,6 +71,22 @@ WT_BASE="${BUG_PIPELINE_WT_BASE:-$(dirname "$REPO_ROOT")/IBL5-worktrees}"
 # The CODE repo (for `gh pr view` in the reconcile pass) — distinct from the private issue repo.
 BUG_PIPELINE_CODE_REPO="${BUG_PIPELINE_CODE_REPO:-a-jay85/IBL5}"
 HUNT_ATTEMPT_CAP="${BUG_PIPELINE_HUNT_ATTEMPT_CAP:-2}"
+# ── CI-autofix seams (ADR-0097) — all default to production; tests override ────
+CI_AUTOFIX_ENABLED="${BUG_PIPELINE_CI_AUTOFIX_ENABLED:-1}"          # 0 = kill switch, before detection
+CI_AUTOFIX_DRY_RUN="${BUG_PIPELINE_CI_AUTOFIX_DRY_RUN:-0}"          # 1 = detect+gate+log, spawn/post/write nothing
+CI_AUTOFIX_IDLE_SECS="${BUG_PIPELINE_CI_AUTOFIX_IDLE_SECS:-3600}"
+CI_AUTOFIX_ATTEMPT_CAP="${BUG_PIPELINE_CI_AUTOFIX_ATTEMPT_CAP:-3}"
+CI_AUTOFIX_BACKOFF_SECS="${BUG_PIPELINE_CI_AUTOFIX_BACKOFF_SECS:-1800}"
+CI_AUTOFIX_LEDGER="${BUG_PIPELINE_CI_AUTOFIX_LEDGER:-$HOME/.claude/logs/ci-autofix-ledger.json}"
+CI_AUTOFIX_LOG="${BUG_PIPELINE_CI_AUTOFIX_LOG:-$HOME/.claude/logs/ci-autofix.log}"
+CI_AUTOFIX_LOCK="${BUG_PIPELINE_CI_AUTOFIX_LOCK:-$HOME/.claude/logs/ci-autofix.lock}"
+CI_AUTOFIX_TIMEOUT_SECS="${BUG_PIPELINE_CI_AUTOFIX_TIMEOUT:-1800}"
+CI_AUTOFIX_SONNET_MODEL="${BUG_PIPELINE_CI_AUTOFIX_SONNET_MODEL:-claude-sonnet-4-6}"
+CI_AUTOFIX_OPUS_MODEL="${BUG_PIPELINE_CI_AUTOFIX_OPUS_MODEL:-claude-opus-4-8}"
+CI_AUTOFIX_PROMPT_FILE="${BUG_PIPELINE_CI_AUTOFIX_PROMPT:-$SCRIPT_DIR/bug-pipeline-ci-autofix-prompt}"
+CI_AUTOFIX_WT_REPO="${BUG_PIPELINE_CI_AUTOFIX_WT_REPO:-$REPO_ROOT}"
+mkdir -p "$(dirname "$CI_AUTOFIX_LEDGER")" 2>/dev/null || true
+mkdir -p "$(dirname "$CI_AUTOFIX_LOG")" 2>/dev/null || true
 mkdir -p "$(dirname "$HUNT_LOG")" 2>/dev/null || true
 
 export GH_BIN BUG_PIPELINE_ISSUE_REPO
@@ -569,6 +585,175 @@ run_hunter_agent() { # wt_appdir model prompt_file run_name run_log
         > "$5" 2>&1
 }
 
+# ── CI-autofix dispatch helpers (ADR-0097, Phase 5) ──────────────────────────
+
+# ci_select_model <pr> <failing_names> — choose Sonnet or Opus for this attempt.
+# Escalation-class checks always use Opus regardless of attempt count.
+ci_select_model() {
+    local pr="$1" failing="$2"
+    local attempt
+    attempt="$(ci_ledger_get "$pr" attempts 0)"
+    attempt=$(( attempt + 1 ))   # next attempt number (ledger stores completed attempts)
+    case "$failing" in
+        *mutation*|*engine*|*golden*|*migration*)
+            printf '%s\n' "$CI_AUTOFIX_OPUS_MODEL"; return 0 ;;
+    esac
+    if [ "$attempt" -le 2 ]; then
+        printf '%s\n' "$CI_AUTOFIX_SONNET_MODEL"
+    else
+        printf '%s\n' "$CI_AUTOFIX_OPUS_MODEL"
+    fi
+}
+
+# ci_collect_failure_log <pr> <wt_root> <failing_names> <out_file>
+# Best-effort: fetch gh pr checks state for the first failing check name.
+# Makes a gh call (logged by stub; inspected by r-dispatch-3).
+ci_collect_failure_log() {
+    local pr="$1" wt_root="$2" failing="$3" out_file="$4"
+    bpgh_code_repo_available || { printf '(gh not available)\n' > "$out_file"; return 0; }
+    local first_check
+    first_check="$(printf '%s' "$failing" | cut -d, -f1)"
+    local run_state
+    run_state="$("$GH_BIN" pr checks "$pr" --repo "$BUG_PIPELINE_CODE_REPO" \
+                     --json name,state \
+                     --jq ".[] | select(.name == \"$first_check\") | .state" \
+                     2>/dev/null || true)"
+    printf 'Check: %s\nState: %s\n' "$first_check" "${run_state:-unknown}" > "$out_file"
+    return 0
+}
+
+# ci_collect_diff <wt_root> <out_file>
+# Best-effort: dump a diff of the worktree against origin/master.
+ci_collect_diff() {
+    local wt_root="$1" out_file="$2"
+    git -C "$wt_root" fetch --quiet origin master 2>/dev/null || true
+    git -C "$wt_root" diff origin/master...HEAD 2>/dev/null > "$out_file" || true
+    [ -s "$out_file" ] || printf '(no diff vs origin/master)\n' > "$out_file"
+    return 0
+}
+
+# ci_render_prompt <pr> <branch> <wt_root> <failing_names> <ci_log_path> <diff_path> <result_file>
+# Bash-param substitution only — NO sed/eval (injection defense for untrusted failing_names).
+ci_render_prompt() {
+    local pr="$1" branch="$2" wt_root="$3" failing="$4"
+    local ci_log_path="$5" diff_path="$6" result_file="$7"
+    local t _p
+    t="$(cat "$CI_AUTOFIX_PROMPT_FILE" 2>/dev/null || printf '(prompt template missing)\n')"
+    # Use intermediate variable for each placeholder — bash misparses ${ //{{...}}/} when the
+    # inner } is seen as closing the outer ${}, so ${t//$_p/val} is the safe form.
+    _p='{{worktree}}';        t="${t//$_p/$wt_root}"
+    _p='{{pr_number}}';       t="${t//$_p/$pr}"
+    _p='{{failing_checks}}';  t="${t//$_p/$failing}"
+    _p='{{ci_log_path}}';     t="${t//$_p/$ci_log_path}"
+    _p='{{diff_path}}';       t="${t//$_p/$diff_path}"
+    _p='{{result_file}}';     t="${t//$_p/$result_file}"
+    _p='{{idle_secs}}';       t="${t//$_p/$CI_AUTOFIX_IDLE_SECS}"
+    printf '%s\n' "$t"
+}
+
+# ── CI-autofix apply (ADR-0097, Phase 6) ─────────────────────────────────────
+
+# ci_apply_result <pr> <branch> <wt_root> <attempt> <failing_names> <head_sha>
+# Trusted exit: read agent verdict, validate commit, push, post comment.
+# Every failure path logs and returns 0 — never aborts the tick.
+ci_apply_result() {
+    local pr="$1" branch="$2" wt_root="$3" attempt="$4" failing_names="$5" head_sha="$6"
+    local result_file="$wt_root/.bug-pipeline/ci-autofix-result.json"
+    local now; now="$(date +%s)"
+    local cap="$CI_AUTOFIX_ATTEMPT_CAP"
+
+    [ "$CI_AUTOFIX_DRY_RUN" = "1" ] && {
+        ci_log "dry-run: ci_apply_result skipped for PR #$pr"; return 0; }
+
+    local result_verdict commit_sha reason changes_desc
+    result_verdict="abort"; commit_sha=""; reason=""; changes_desc=""
+    if [ ! -s "$result_file" ]; then
+        reason="no verdict written (agent timed out or crashed)"
+    else
+        result_verdict="$(jq -r '.result // "abort"' "$result_file" 2>/dev/null || echo "abort")"
+        commit_sha="$(jq -r '.commit_sha // ""' "$result_file" 2>/dev/null || echo "")"
+        reason="$(jq -r '.reason // ""' "$result_file" 2>/dev/null || echo "")"
+        changes_desc="$(jq -r '(.changes // []) | .[0] | if . then "\(.file // ""):line \(.line // "?") — \(.description // "")" else "" end' \
+                        "$result_file" 2>/dev/null || echo "")"
+    fi
+
+    if [ "$result_verdict" = "fixed" ]; then
+        if [ -z "$commit_sha" ] || \
+           ! git -C "$wt_root" cat-file -e "${commit_sha}^{commit}" 2>/dev/null; then
+            result_verdict="abort"
+            reason="${reason:-agent reported a commit that does not exist: $commit_sha}"
+        elif git -C "$wt_root" merge-base --is-ancestor HEAD "$head_sha" 2>/dev/null; then
+            # HEAD did not advance past the PR head (no new commit)
+            result_verdict="abort"
+            reason="${reason:-HEAD did not advance past PR head (no new commit)}"
+        else
+            local push_body change_line=""
+            [ -n "$changes_desc" ] && change_line="
+**Change:** $changes_desc"
+            if git -C "$wt_root" push origin "HEAD:$branch" 2>/dev/null; then
+                local published_sha
+                published_sha="$(git -C "$wt_root" rev-parse HEAD 2>/dev/null || echo "$commit_sha")"
+                ci_ledger_put "$pr" attempts "$attempt" \
+                    last_attempt_epoch "$now" \
+                    head_sha_at_start "$published_sha"
+                push_body="$(printf '🔧 CI autofix attempt %s/%s — fix published\n\n**Failing:** %s\n**Fix commit:** %s%s\n\n_Automated by bug-pipeline-tick (ADR-0097). Review and merge if correct._' \
+                    "$attempt" "$cap" "$failing_names" "$published_sha" "$change_line")"
+                bpgh_pr_comment "$pr" "$push_body"
+                ci_log "PR #$pr: published fix at $published_sha (attempt $attempt)"
+                return 0
+            else
+                result_verdict="abort"
+                reason="push rejected — remote moved (rebase/push race)"
+                ci_ledger_put "$pr" attempts "$attempt" last_attempt_epoch "$now"
+                push_body="$(printf '⚠️ CI autofix attempt %s/%s — push rejected\n\n**Failing:** %s\n**Reason:** %s\n\n_Automated by bug-pipeline-tick. Next tick will re-evaluate._' \
+                    "$attempt" "$cap" "$failing_names" "$reason")"
+                bpgh_pr_comment "$pr" "$push_body"
+                ci_log "PR #$pr: push rejected at attempt $attempt ($reason)"
+                return 0
+            fi
+        fi
+    fi
+
+    local comment_body
+    case "$result_verdict" in
+        no_change)
+            ci_ledger_put "$pr" attempts "$attempt" \
+                last_attempt_epoch "$now" head_sha_at_start "$head_sha"
+            comment_body="$(printf 'ℹ️ CI autofix attempt %s/%s — no change needed\n\n**Failing:** %s\n**Reason:** %s\n\n_Automated by bug-pipeline-tick. Checks may be green or require manual fix._' \
+                "$attempt" "$cap" "$failing_names" "${reason:-checks appear green}")"
+            bpgh_pr_comment "$pr" "$comment_body"
+            ci_log "PR #$pr: no_change at attempt $attempt"
+            ;;
+        abort|*)
+            ci_ledger_put "$pr" attempts "$attempt" last_attempt_epoch "$now"
+            comment_body="$(printf '⚠️ CI autofix attempt %s/%s — not applied\n\n**Failing:** %s\n**Reason:** %s\n\n_Automated by bug-pipeline-tick. Nothing was published; local commits are intact._' \
+                "$attempt" "$cap" "$failing_names" "${reason:-unknown}")"
+            bpgh_pr_comment "$pr" "$comment_body"
+            ci_log "PR #$pr: abort at attempt $attempt (${reason:-unknown})"
+            ;;
+    esac
+    return 0
+}
+
+# ── CI-autofix giveup (ADR-0097, Phase 7) ────────────────────────────────────
+
+# ci_autofix_giveup <pr> <failing_names>
+# Post one ⛔ ceiling comment — idempotent via ceiling_notified ledger flag.
+ci_autofix_giveup() {
+    local pr="$1" failing_names="$2"
+    [ "$CI_AUTOFIX_DRY_RUN" = "1" ] && {
+        ci_log "dry-run: giveup skipped for PR #$pr"; return 0; }
+    local already; already="$(ci_ledger_get "$pr" ceiling_notified false)"
+    [ "$already" = "true" ] && return 0
+    local cap="$CI_AUTOFIX_ATTEMPT_CAP"
+    bpgh_pr_comment "$pr" \
+        "$(printf '⛔ CI autofix giving up after %s attempt(s)\n\n**Failing:** %s\n\n_Automated by bug-pipeline-tick (ADR-0097). All autofix attempts exhausted — manual fix required._' \
+            "$cap" "$failing_names")"
+    ci_ledger_put "$pr" ceiling_notified true
+    ci_log "PR #$pr: giveup posted after $cap attempts"
+    return 0
+}
+
 # Render the hunter prompt with the claimed row's data. Untrusted report/transcript
 # are substituted by bash param-expansion (NEVER sed/eval) — the template wraps them
 # in <report>/<transcript> blocks and frames them strictly as data (prompt-injection defense).
@@ -766,6 +951,248 @@ drive_hunt_row() { # claimed_row_json
     done
 }
 
+# ── CI-autofix worktree gate (ADR-0097, Phase 4) ─────────────────────────────
+
+# ci_wt_for_branch <branch> — print the worktree root for the given branch, return 1 if absent.
+# Uses CI_AUTOFIX_WT_REPO so tests can point at a scratch repo.
+ci_wt_for_branch() {
+    local branch="$1" wt_root=""
+    local line
+    while IFS= read -r line; do
+        case "$line" in
+            "worktree "*) wt_root="${line#worktree }" ;;
+            "branch refs/heads/$branch")
+                printf '%s\n' "$wt_root"; return 0 ;;
+        esac
+    done < <(git -C "$CI_AUTOFIX_WT_REPO" worktree list --porcelain 2>/dev/null)
+    return 1
+}
+
+# ci_wt_is_idle <wt_root> — returns 0 if no tracked files were modified within CI_AUTOFIX_IDLE_SECS.
+ci_wt_is_idle() {
+    local wt_root="$1" hit
+    hit="$(find "$wt_root" \
+             \( -name .git -o -name node_modules -o -name vendor \
+                -o -name .bug-pipeline -o -name storage -o -name coverage \) -prune -o \
+             -type f -mmin "-$(( CI_AUTOFIX_IDLE_SECS / 60 ))" -print -quit 2>/dev/null)"
+    [ -z "$hit" ]
+}
+
+# ci_wt_head_matches <wt_root> <head_sha> — returns 0 if head_sha is an ancestor of (or equal to) HEAD.
+ci_wt_head_matches() {
+    local wt_root="$1" head_sha="$2"
+    git -C "$wt_root" merge-base --is-ancestor "$head_sha" HEAD 2>/dev/null
+}
+
+# ── CI-autofix ledger / lock / log helpers (ADR-0097, Phase 3) ───────────────
+
+# ci_jq_ok — true if jq is available (gates all ledger read/write).
+ci_jq_ok() { command -v jq >/dev/null 2>&1; }
+
+# ci_log <message> — append timestamped line to CI_AUTOFIX_LOG.
+ci_log() {
+    printf '[%s] ci-autofix: %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$*" >> "$CI_AUTOFIX_LOG" 2>/dev/null || true
+}
+
+# ci_lock_acquire — mkdir-based single-flight lock; returns 0 on success, 1 if held.
+# Cleans stale locks (older than CI_AUTOFIX_TIMEOUT_SECS) before retrying.
+ci_lock_acquire() {
+    if [ -d "$CI_AUTOFIX_LOCK" ]; then
+        local lock_mtime now
+        lock_mtime="$(stat -f '%m' "$CI_AUTOFIX_LOCK" 2>/dev/null || \
+                      stat -c '%Y' "$CI_AUTOFIX_LOCK" 2>/dev/null || echo 0)"
+        now="$(date +%s)"
+        if [ $(( now - lock_mtime )) -gt "$CI_AUTOFIX_TIMEOUT_SECS" ]; then
+            ci_log "ci_lock_acquire: stale lock (age $(( now - lock_mtime ))s) — cleaning"
+            rm -rf "$CI_AUTOFIX_LOCK" 2>/dev/null || true
+        else
+            ci_log "ci_lock_acquire: lock held — skipping tick"
+            return 1
+        fi
+    fi
+    mkdir "$CI_AUTOFIX_LOCK" 2>/dev/null && return 0
+    ci_log "ci_lock_acquire: race — lock acquired by concurrent tick"
+    return 1
+}
+
+# ci_lock_release — remove the lock directory.
+ci_lock_release() {
+    rm -rf "$CI_AUTOFIX_LOCK" 2>/dev/null || true
+}
+
+# ci_ledger_get <pr> <key> [default] — read a key from the PR's ledger entry.
+ci_ledger_get() {
+    local pr="$1" key="$2" default="${3:-}"
+    ci_jq_ok || { printf '%s\n' "$default"; return 0; }
+    [ -s "$CI_AUTOFIX_LEDGER" ] || { printf '%s\n' "$default"; return 0; }
+    local val
+    val="$(jq -r --arg pr "$pr" --arg k "$key" --arg d "$default" \
+            '.[$pr][$k] // $d' "$CI_AUTOFIX_LEDGER" 2>/dev/null || echo "$default")"
+    printf '%s\n' "${val:-$default}"
+}
+
+# ci_ledger_put <pr> <key> <val> [<key> <val> ...] — write key/value pair(s) to the PR entry.
+ci_ledger_put() {
+    local pr="$1"; shift
+    ci_jq_ok || return 0
+    local tmp
+    tmp="$(mktemp "${CI_AUTOFIX_LEDGER}.tmp.XXXXXX" 2>/dev/null)" || return 0
+    local existing="{}"
+    [ -s "$CI_AUTOFIX_LEDGER" ] && \
+        existing="$(jq -r --arg pr "$pr" '.[$pr] // {}' "$CI_AUTOFIX_LEDGER" 2>/dev/null || echo "{}")"
+    while [ "$#" -ge 2 ]; do
+        local k="$1" v="$2"; shift 2
+        if printf '%s' "$v" | grep -qE '^-?[0-9]+$'; then
+            existing="$(printf '%s' "$existing" | \
+                jq --arg k "$k" --argjson v "$v" '.[$k] = $v' 2>/dev/null || echo "$existing")"
+        else
+            existing="$(printf '%s' "$existing" | \
+                jq --arg k "$k" --arg v "$v" '.[$k] = $v' 2>/dev/null || echo "$existing")"
+        fi
+    done
+    local ledger="{}"
+    [ -s "$CI_AUTOFIX_LEDGER" ] && \
+        ledger="$(cat "$CI_AUTOFIX_LEDGER" 2>/dev/null || echo "{}")"
+    printf '%s' "$ledger" | \
+        jq --arg pr "$pr" --argjson e "$existing" '.[$pr] = $e' > "$tmp" 2>/dev/null || \
+        { rm -f "$tmp"; return 0; }
+    mv "$tmp" "$CI_AUTOFIX_LEDGER" 2>/dev/null || { rm -f "$tmp"; return 0; }
+}
+
+# ci_budget_state <pr> <head_sha> — returns "ceiling", "backoff", "eligible", or "disabled".
+# A PR rebased to a new head SHA resets the attempt counter (different commit, fresh start).
+ci_budget_state() {
+    local pr="$1" head_sha="$2"
+    ci_jq_ok || { ci_log "ci_budget_state: jq unavailable — treating as disabled"; printf 'disabled\n'; return 0; }
+    local stored_sha; stored_sha="$(ci_ledger_get "$pr" head_sha_at_start "")"
+    if [ -n "$stored_sha" ] && [ "$stored_sha" != "$head_sha" ]; then
+        printf 'eligible\n'; return 0
+    fi
+    local ceiling_hit; ceiling_hit="$(ci_ledger_get "$pr" ceiling_hit false)"
+    [ "$ceiling_hit" = "true" ] && { printf 'ceiling\n'; return 0; }
+    local attempts; attempts="$(ci_ledger_get "$pr" attempts 0)"
+    [ "$attempts" -ge "$CI_AUTOFIX_ATTEMPT_CAP" ] && { printf 'ceiling\n'; return 0; }
+    local last_epoch; last_epoch="$(ci_ledger_get "$pr" last_attempt_epoch 0)"
+    local now; now="$(date +%s)"
+    if [ $(( now - last_epoch )) -lt "$CI_AUTOFIX_BACKOFF_SECS" ]; then
+        printf 'backoff\n'; return 0
+    fi
+    printf 'eligible\n'; return 0
+}
+
+# ── CI-autofix orchestrator (ADR-0097, Phase 8) ──────────────────────────────
+
+# ci_autofix_main — detect red PRs, acquire lock, gate (budget/wt/idle/head),
+# dispatch at most one fix agent per tick, or call giveup when ceiling reached.
+# Never aborts a tick: every failure path logs and returns 0.
+ci_autofix_main() {
+    [ "$CI_AUTOFIX_ENABLED" = "1" ] || {
+        ci_log "kill switch off — skipping CI-autofix"; return 0; }
+
+    local red_prs
+    red_prs="$(bpgh_pr_failing_checks 2>/dev/null || true)"
+    [ -n "$red_prs" ] || return 1
+
+    local best_pr="" best_branch="" best_sha="" best_failing="" wt_root=""
+    local line rest rest2 num branch sha failing wt budget
+    while IFS= read -r line; do
+        [ -n "${line:-}" ] || continue
+        num="${line%% *}"; rest="${line#* }"
+        branch="${rest%% *}"; rest2="${rest#* }"
+        sha="${rest2%% *}"; failing="${rest2#* }"
+
+        wt="$(ci_wt_for_branch "$branch" 2>/dev/null || true)"
+        if [ -z "$wt" ]; then
+            ci_log "PR #$num ($branch): no local worktree — skipping"
+            continue
+        fi
+
+        budget="$(ci_budget_state "$num" "$sha")"
+        case "$budget" in
+            disabled) ci_log "PR #$num: budget disabled — skipping"; continue ;;
+            ceiling)  ci_autofix_giveup "$num" "$failing"; continue ;;
+            backoff)  ci_log "PR #$num: in backoff window — skipping"; continue ;;
+        esac
+
+        best_pr="$num"; best_branch="$branch"; best_sha="$sha"; best_failing="$failing"
+        wt_root="$wt"
+        break
+    done <<CI_EOF
+$red_prs
+CI_EOF
+
+    [ -n "$best_pr" ] || { ci_log "no eligible PR found this tick"; return 1; }
+
+    ci_lock_acquire || return 0
+
+    # Re-resolve worktree: it may have disappeared since the scan.
+    wt_root="$(ci_wt_for_branch "$best_branch" 2>/dev/null || true)"
+    if [ -z "$wt_root" ]; then
+        ci_log "PR #$best_pr: worktree vanished after lock"
+        ci_lock_release; return 0
+    fi
+
+    if ! ci_wt_is_idle "$wt_root"; then
+        ci_log "PR #$best_pr: worktree not idle — skipping"
+        ci_lock_release; return 0
+    fi
+
+    if ! ci_wt_head_matches "$wt_root" "$best_sha"; then
+        ci_log "PR #$best_pr: worktree HEAD does not include PR head $best_sha — skipping"
+        ci_lock_release; return 0
+    fi
+
+    local attempt model wt_appdir
+    attempt="$(ci_ledger_get "$best_pr" attempts 0)"
+    attempt=$(( attempt + 1 ))
+    model="$(ci_select_model "$best_pr" "$best_failing")"
+    wt_appdir="$wt_root/ibl5"
+    ci_log "dispatching PR #$best_pr ($best_branch) attempt $attempt/$CI_AUTOFIX_ATTEMPT_CAP model=$model"
+
+    if [ "$CI_AUTOFIX_DRY_RUN" = "1" ]; then
+        ci_log "would-dispatch model=$model PR #$best_pr attempt $attempt failing=$best_failing"
+        ci_lock_release; return 0
+    fi
+
+    local ci_log_path diff_path result_file
+    ci_log_path="$wt_root/.bug-pipeline/ci-failure.log"
+    diff_path="$wt_root/.bug-pipeline/ci-autofix-diff.patch"
+    result_file="$wt_root/.bug-pipeline/ci-autofix-result.json"
+    mkdir -p "$wt_root/.bug-pipeline" 2>/dev/null || true
+    ci_collect_failure_log "$best_pr" "$wt_root" "$best_failing" "$ci_log_path"
+    ci_collect_diff "$wt_root" "$diff_path"
+
+    rm -f "$result_file" 2>/dev/null || true
+    local prompt_rendered
+    prompt_rendered="$(mktemp "${wt_root}/.bug-pipeline/prompt.XXXXXX" 2>/dev/null)" || \
+        { ci_log "PR #$best_pr: cannot create prompt tempfile"; ci_lock_release; return 0; }
+    ci_render_prompt "$best_pr" "$best_branch" "$wt_root" "$best_failing" \
+        "$ci_log_path" "$diff_path" "$result_file" > "$prompt_rendered"
+
+    bpgh_pr_comment "$best_pr" \
+        "$(printf '⏳ CI autofix attempt %s/%s dispatched (model: %s)\n\nFailing: %s\nETA: ~%s min\n\n_Automated by bug-pipeline-tick (ADR-0097)_' \
+            "$attempt" "$CI_AUTOFIX_ATTEMPT_CAP" "$model" "$best_failing" \
+            "$(( CI_AUTOFIX_TIMEOUT_SECS / 60 ))")"
+
+    local run_log
+    run_log="$(mktemp "${wt_root}/.bug-pipeline/run.XXXXXX" 2>/dev/null)" || run_log="/dev/null"
+    run_under_starved_env "$wt_appdir" \
+        timeout "$CI_AUTOFIX_TIMEOUT_SECS" \
+            "$CLAUDE_BIN" -p "$(cat "$prompt_rendered")" \
+                --dangerously-skip-permissions \
+                --model "$model" \
+                --effort high \
+                --output-format stream-json --verbose \
+                --name "ci-autofix-pr-$best_pr-attempt-$attempt" \
+        > "$run_log" 2>&1 || true
+    cat "$run_log" >> "$CI_AUTOFIX_LOG" 2>/dev/null || true
+    rm -f "$prompt_rendered" "$run_log" 2>/dev/null || true
+
+    ci_apply_result "$best_pr" "$best_branch" "$wt_root" "$attempt" "$best_failing" "$best_sha"
+    ci_lock_release
+    return 0
+}
+
 # Top-level hunt pass (Phase 2): reclaim a crashed hunt / claim the next ripe queued bug and
 # drive it. Independent of the enumerator — a lone classified bug yields [] from the enumerator
 # yet must still be hunted. Returns 0 iff a hunt was driven (caller ends the tick — one/tick).
@@ -873,6 +1300,13 @@ main() {
     # One hunt per tick: a claimed hunt runs foreground to completion, then the tick ends —
     # overlapping ticks can't double-hunt the same row (single-flight invariant 1).
     if maybe_hunt; then
+        return 0
+    fi
+
+    # ── CI-autofix pass (ADR-0097): opportunistic — runs only when no bug hunt ran ──
+    # Returns 0 iff a fix agent was dispatched; caller ends the tick to enforce one spawn
+    # per tick. Deferred until after maybe_hunt so bug hunting always takes priority.
+    if ci_autofix_main; then
         return 0
     fi
 

--- a/bin/bug-pipeline-tick
+++ b/bin/bug-pipeline-tick
@@ -71,9 +71,9 @@ WT_BASE="${BUG_PIPELINE_WT_BASE:-$(dirname "$REPO_ROOT")/IBL5-worktrees}"
 # The CODE repo (for `gh pr view` in the reconcile pass) — distinct from the private issue repo.
 BUG_PIPELINE_CODE_REPO="${BUG_PIPELINE_CODE_REPO:-a-jay85/IBL5}"
 HUNT_ATTEMPT_CAP="${BUG_PIPELINE_HUNT_ATTEMPT_CAP:-2}"
-# ── CI-autofix seams (ADR-0097) — all default to production; tests override ────
+# ── CI-autofix seams (ADR-0099) — all default to production; tests override ────
 CI_AUTOFIX_ENABLED="${BUG_PIPELINE_CI_AUTOFIX_ENABLED:-1}"          # 0 = kill switch, before detection
-CI_AUTOFIX_DRY_RUN="${BUG_PIPELINE_CI_AUTOFIX_DRY_RUN:-0}"          # 1 = detect+gate+log, spawn/post/write nothing
+CI_AUTOFIX_DRY_RUN="${BUG_PIPELINE_CI_AUTOFIX_DRY_RUN:-1}"          # DEFAULT 1 (soak): detect+gate+log, spawn/post/write nothing. Set 0 to go live.
 CI_AUTOFIX_IDLE_SECS="${BUG_PIPELINE_CI_AUTOFIX_IDLE_SECS:-3600}"
 CI_AUTOFIX_ATTEMPT_CAP="${BUG_PIPELINE_CI_AUTOFIX_ATTEMPT_CAP:-3}"
 CI_AUTOFIX_BACKOFF_SECS="${BUG_PIPELINE_CI_AUTOFIX_BACKOFF_SECS:-1800}"
@@ -83,6 +83,7 @@ CI_AUTOFIX_LOCK="${BUG_PIPELINE_CI_AUTOFIX_LOCK:-$HOME/.claude/logs/ci-autofix.l
 CI_AUTOFIX_TIMEOUT_SECS="${BUG_PIPELINE_CI_AUTOFIX_TIMEOUT:-1800}"
 CI_AUTOFIX_SONNET_MODEL="${BUG_PIPELINE_CI_AUTOFIX_SONNET_MODEL:-claude-sonnet-4-6}"
 CI_AUTOFIX_OPUS_MODEL="${BUG_PIPELINE_CI_AUTOFIX_OPUS_MODEL:-claude-opus-4-8}"
+CI_AUTOFIX_LOG_MAX_BYTES="${BUG_PIPELINE_CI_AUTOFIX_LOG_MAX_BYTES:-40000}"  # tail cap on the fetched CI job log
 CI_AUTOFIX_PROMPT_FILE="${BUG_PIPELINE_CI_AUTOFIX_PROMPT:-$SCRIPT_DIR/bug-pipeline-ci-autofix-prompt}"
 CI_AUTOFIX_WT_REPO="${BUG_PIPELINE_CI_AUTOFIX_WT_REPO:-$REPO_ROOT}"
 mkdir -p "$(dirname "$CI_AUTOFIX_LEDGER")" 2>/dev/null || true
@@ -585,7 +586,7 @@ run_hunter_agent() { # wt_appdir model prompt_file run_name run_log
         > "$5" 2>&1
 }
 
-# ── CI-autofix dispatch helpers (ADR-0097, Phase 5) ──────────────────────────
+# ── CI-autofix dispatch helpers (ADR-0099, Phase 5) ──────────────────────────
 
 # ci_select_model <pr> <failing_names> — choose Sonnet or Opus for this attempt.
 # Escalation-class checks always use Opus regardless of attempt count.
@@ -605,20 +606,47 @@ ci_select_model() {
     fi
 }
 
-# ci_collect_failure_log <pr> <wt_root> <failing_names> <out_file>
-# Best-effort: fetch gh pr checks state for the first failing check name.
-# Makes a gh call (logged by stub; inspected by r-dispatch-3).
+# ci_collect_failure_log <pr> <head_sha> <failing_names> <out_file>
+# Fetch the REAL failing-job log for the PR head SHA and write it to <out_file>.
+#
+# This runs on the TRUSTED tick side, BEFORE run_under_starved_env — the fix agent
+# holds no token and is forbidden from running gh, so if the log is not fetched here
+# the agent gets nothing but a check name and can only guess.
+#
+# Always writes a header first (which PR / SHA / checks), then appends the tail of
+# `gh run view --log-failed`, capped at CI_AUTOFIX_LOG_MAX_BYTES — a full CI log can
+# run to megabytes and the tail is where the failure is.
 ci_collect_failure_log() {
-    local pr="$1" wt_root="$2" failing="$3" out_file="$4"
-    bpgh_code_repo_available || { printf '(gh not available)\n' > "$out_file"; return 0; }
+    local pr="$1" head_sha="$2" failing="$3" out_file="$4"
     local first_check
     first_check="$(printf '%s' "$failing" | cut -d, -f1)"
-    local run_state
-    run_state="$("$GH_BIN" pr checks "$pr" --repo "$BUG_PIPELINE_CODE_REPO" \
-                     --json name,state \
-                     --jq ".[] | select(.name == \"$first_check\") | .state" \
-                     2>/dev/null || true)"
-    printf 'Check: %s\nState: %s\n' "$first_check" "${run_state:-unknown}" > "$out_file"
+    printf 'PR: #%s\nHead: %s\nFailing checks: %s\n\n' "$pr" "$head_sha" "$failing" > "$out_file"
+
+    bpgh_code_repo_available || {
+        printf '(gh not available — no CI log)\n' >> "$out_file"; return 0; }
+
+    local run_id
+    run_id="$("$GH_BIN" run list --repo "$BUG_PIPELINE_CODE_REPO" \
+                  --commit "$head_sha" --limit 20 \
+                  --json databaseId,conclusion \
+                  --jq '[.[] | select(.conclusion == "failure")] | first | .databaseId' \
+                  2>/dev/null | tr -dc '0-9')"
+    if [ -z "$run_id" ]; then
+        printf '(no failed workflow run for %s — "%s" may be a non-Actions check)\n' \
+            "$head_sha" "$first_check" >> "$out_file"
+        return 0
+    fi
+
+    local raw
+    raw="$("$GH_BIN" run view "$run_id" --repo "$BUG_PIPELINE_CODE_REPO" \
+               --log-failed 2>/dev/null || true)"
+    if [ -z "$raw" ]; then
+        printf '(run %s log unavailable)\n' "$run_id" >> "$out_file"
+        return 0
+    fi
+    printf -- '--- gh run view %s --log-failed (tail, max %s bytes) ---\n' \
+        "$run_id" "$CI_AUTOFIX_LOG_MAX_BYTES" >> "$out_file"
+    printf '%s\n' "$raw" | tail -c "$CI_AUTOFIX_LOG_MAX_BYTES" >> "$out_file"
     return 0
 }
 
@@ -647,11 +675,10 @@ ci_render_prompt() {
     _p='{{ci_log_path}}';     t="${t//$_p/$ci_log_path}"
     _p='{{diff_path}}';       t="${t//$_p/$diff_path}"
     _p='{{result_file}}';     t="${t//$_p/$result_file}"
-    _p='{{idle_secs}}';       t="${t//$_p/$CI_AUTOFIX_IDLE_SECS}"
     printf '%s\n' "$t"
 }
 
-# ── CI-autofix apply (ADR-0097, Phase 6) ─────────────────────────────────────
+# ── CI-autofix apply (ADR-0099, Phase 6) ─────────────────────────────────────
 
 # ci_apply_result <pr> <branch> <wt_root> <attempt> <failing_names> <head_sha>
 # Trusted exit: read agent verdict, validate commit, push, post comment.
@@ -696,7 +723,7 @@ ci_apply_result() {
                 ci_ledger_put "$pr" attempts "$attempt" \
                     last_attempt_epoch "$now" \
                     head_sha_at_start "$published_sha"
-                push_body="$(printf '🔧 CI autofix attempt %s/%s — fix published\n\n**Failing:** %s\n**Fix commit:** %s%s\n\n_Automated by bug-pipeline-tick (ADR-0097). Review and merge if correct._' \
+                push_body="$(printf '🔧 CI autofix attempt %s/%s — fix published\n\n**Failing:** %s\n**Fix commit:** %s%s\n\n_Automated by bug-pipeline-tick (ADR-0099). Review and merge if correct._' \
                     "$attempt" "$cap" "$failing_names" "$published_sha" "$change_line")"
                 bpgh_pr_comment "$pr" "$push_body"
                 ci_log "PR #$pr: published fix at $published_sha (attempt $attempt)"
@@ -735,7 +762,7 @@ ci_apply_result() {
     return 0
 }
 
-# ── CI-autofix giveup (ADR-0097, Phase 7) ────────────────────────────────────
+# ── CI-autofix giveup (ADR-0099, Phase 7) ────────────────────────────────────
 
 # ci_autofix_giveup <pr> <failing_names>
 # Post one ⛔ ceiling comment — idempotent via ceiling_notified ledger flag.
@@ -747,7 +774,7 @@ ci_autofix_giveup() {
     [ "$already" = "true" ] && return 0
     local cap="$CI_AUTOFIX_ATTEMPT_CAP"
     bpgh_pr_comment "$pr" \
-        "$(printf '⛔ CI autofix giving up after %s attempt(s)\n\n**Failing:** %s\n\n_Automated by bug-pipeline-tick (ADR-0097). All autofix attempts exhausted — manual fix required._' \
+        "$(printf '⛔ CI autofix giving up after %s attempt(s)\n\n**Failing:** %s\n\n_Automated by bug-pipeline-tick (ADR-0099). All autofix attempts exhausted — manual fix required._' \
             "$cap" "$failing_names")"
     ci_ledger_put "$pr" ceiling_notified true
     ci_log "PR #$pr: giveup posted after $cap attempts"
@@ -951,7 +978,7 @@ drive_hunt_row() { # claimed_row_json
     done
 }
 
-# ── CI-autofix worktree gate (ADR-0097, Phase 4) ─────────────────────────────
+# ── CI-autofix worktree gate (ADR-0099, Phase 4) ─────────────────────────────
 
 # ci_wt_for_branch <branch> — print the worktree root for the given branch, return 1 if absent.
 # Uses CI_AUTOFIX_WT_REPO so tests can point at a scratch repo.
@@ -969,13 +996,28 @@ ci_wt_for_branch() {
 }
 
 # ci_wt_is_idle <wt_root> — returns 0 if no tracked files were modified within CI_AUTOFIX_IDLE_SECS.
+# find's -mmin takes whole minutes, so the seconds seam is floored to at least 1: integer
+# division would turn any sub-minute idle window into `-mmin -0`, which matches nothing and
+# would report EVERY worktree idle — the gate inverting itself silently.
 ci_wt_is_idle() {
-    local wt_root="$1" hit
+    local wt_root="$1" hit mins
+    mins=$(( CI_AUTOFIX_IDLE_SECS / 60 ))
+    [ "$mins" -ge 1 ] || mins=1
     hit="$(find "$wt_root" \
              \( -name .git -o -name node_modules -o -name vendor \
                 -o -name .bug-pipeline -o -name storage -o -name coverage \) -prune -o \
-             -type f -mmin "-$(( CI_AUTOFIX_IDLE_SECS / 60 ))" -print -quit 2>/dev/null)"
+             -type f -mmin "-$mins" -print -quit 2>/dev/null)"
     [ -z "$hit" ]
+}
+
+# ci_wt_is_clean <wt_root> — returns 0 only when the worktree has no uncommitted changes.
+# Paired with ci_wt_is_idle: "idle" only means nothing was touched recently, so an abandoned
+# dirty tree passes it. The fix agent must never commit work it did not author, so a dirty
+# tree blocks dispatch here rather than relying on the prompt to hold the line.
+ci_wt_is_clean() {
+    local wt_root="$1" dirty
+    dirty="$(git -C "$wt_root" status --porcelain 2>/dev/null)"
+    [ -z "$dirty" ]
 }
 
 # ci_wt_head_matches <wt_root> <head_sha> — returns 0 if head_sha is an ancestor of (or equal to) HEAD.
@@ -984,7 +1026,7 @@ ci_wt_head_matches() {
     git -C "$wt_root" merge-base --is-ancestor "$head_sha" HEAD 2>/dev/null
 }
 
-# ── CI-autofix ledger / lock / log helpers (ADR-0097, Phase 3) ───────────────
+# ── CI-autofix ledger / lock / log helpers (ADR-0099, Phase 3) ───────────────
 
 # ci_jq_ok — true if jq is available (gates all ledger read/write).
 ci_jq_ok() { command -v jq >/dev/null 2>&1; }
@@ -1080,7 +1122,7 @@ ci_budget_state() {
     printf 'eligible\n'; return 0
 }
 
-# ── CI-autofix orchestrator (ADR-0097, Phase 8) ──────────────────────────────
+# ── CI-autofix orchestrator (ADR-0099, Phase 8) ──────────────────────────────
 
 # ci_autofix_main — detect red PRs, acquire lock, gate (budget/wt/idle/head),
 # dispatch at most one fix agent per tick, or call giveup when ceiling reached.
@@ -1138,6 +1180,11 @@ CI_EOF
         ci_lock_release; return 1
     fi
 
+    if ! ci_wt_is_clean "$wt_root"; then
+        ci_log "PR #$best_pr: worktree dirty — refusing to dispatch onto uncommitted work"
+        ci_lock_release; return 1
+    fi
+
     if ! ci_wt_head_matches "$wt_root" "$best_sha"; then
         ci_log "PR #$best_pr: worktree HEAD does not include PR head $best_sha — skipping"
         ci_lock_release; return 1
@@ -1160,7 +1207,7 @@ CI_EOF
     diff_path="$wt_root/.bug-pipeline/ci-autofix-diff.patch"
     result_file="$wt_root/.bug-pipeline/ci-autofix-result.json"
     mkdir -p "$wt_root/.bug-pipeline" 2>/dev/null || true
-    ci_collect_failure_log "$best_pr" "$wt_root" "$best_failing" "$ci_log_path"
+    ci_collect_failure_log "$best_pr" "$best_sha" "$best_failing" "$ci_log_path"
     ci_collect_diff "$wt_root" "$diff_path"
 
     rm -f "$result_file" 2>/dev/null || true
@@ -1171,7 +1218,7 @@ CI_EOF
         "$ci_log_path" "$diff_path" "$result_file" > "$prompt_rendered"
 
     bpgh_pr_comment "$best_pr" \
-        "$(printf '⏳ CI autofix attempt %s/%s dispatched (model: %s)\n\nFailing: %s\nETA: ~%s min\n\n_Automated by bug-pipeline-tick (ADR-0097)_' \
+        "$(printf '⏳ CI autofix attempt %s/%s dispatched (model: %s)\n\nFailing: %s\nETA: ~%s min\n\n_Automated by bug-pipeline-tick (ADR-0099)_' \
             "$attempt" "$CI_AUTOFIX_ATTEMPT_CAP" "$model" "$best_failing" \
             "$(( CI_AUTOFIX_TIMEOUT_SECS / 60 ))")"
 
@@ -1304,7 +1351,7 @@ main() {
         return 0
     fi
 
-    # ── CI-autofix pass (ADR-0097): opportunistic — runs only when no bug hunt ran ──
+    # ── CI-autofix pass (ADR-0099): opportunistic — runs only when no bug hunt ran ──
     # Returns 0 only when a fix agent was dispatched (caller ends the tick — one spawn/tick).
     # Returns 1 on every other path (kill switch, dry-run, no eligible PR) so the bug-report
     # loop still runs. Deferred until after maybe_hunt so bug hunting always takes priority.

--- a/bin/lib/bug-pipeline-gh.sh
+++ b/bin/lib/bug-pipeline-gh.sh
@@ -148,3 +148,69 @@ bpgh_assign() {
     "$GH_BIN" issue edit "$issue" --repo "$BUG_PIPELINE_ISSUE_REPO" --add-assignee "$login" 2>/dev/null || true
     return 0
 }
+
+# bpgh_code_repo_available — true when BUG_PIPELINE_CODE_REPO and gh are both present.
+bpgh_code_repo_available() {
+    [ -n "${BUG_PIPELINE_CODE_REPO:-}" ] && command -v "$GH_BIN" >/dev/null 2>&1
+}
+
+# bpgh_pr_comment <pr_number> <body> — post a comment on a code-repo PR (best-effort).
+bpgh_pr_comment() {
+    local pr="$1" body="$2"
+    bpgh_code_repo_available || return 0
+    [ -n "$pr" ] && [ "$pr" != "null" ] || return 0
+    "$GH_BIN" pr comment "$pr" --repo "$BUG_PIPELINE_CODE_REPO" --body "$body" 2>/dev/null \
+        || _bpgh_log "bpgh_pr_comment: failed commenting on PR #$pr (best-effort)"
+    return 0
+}
+
+# bpgh_pr_failing_checks — emit one line per open, non-draft PR with settled red checks.
+#
+# Output format (one line per PR): NUM BRANCH HEAD_SHA failing_name,...
+#   Names are LAST — GitHub check names may contain spaces.
+#
+# Skips PRs with CONFLICTING/DIRTY/empty merge state (fail-closed phantom-dispatch guard).
+# Skips PRs with any PENDING check (not settled).
+# Excludes human-signoff check (case-insensitive grep — not in jq; stub bypasses jq).
+# No writes, no comments, no claude — detection only.
+bpgh_pr_failing_checks() {
+    bpgh_code_repo_available || return 0
+    local prs
+    prs="$("$GH_BIN" pr list --repo "$BUG_PIPELINE_CODE_REPO" --state open --limit 50 \
+             --json number,headRefName,headRefOid,isDraft \
+             --jq '.[] | select(.isDraft == false) | "\(.number) \(.headRefName) \(.headRefOid)"' \
+             2>/dev/null)" || {
+        _bpgh_log "bpgh_pr_failing_checks: pr list failed (best-effort)"; return 0; }
+    [ -n "$prs" ] || return 0
+    local num branch sha ms checks pending failing
+    while IFS=' ' read -r num branch sha; do
+        [ -n "${num:-}" ] || continue
+        ms="$("$GH_BIN" pr view "$num" --repo "$BUG_PIPELINE_CODE_REPO" \
+                --json mergeable,mergeStateStatus \
+                --jq '[.mergeable,.mergeStateStatus]|@tsv' \
+                2>/dev/null || true)"
+        case "$ms" in
+          *CONFLICTING*|*DIRTY*|"")
+              _bpgh_log "bpgh_pr_failing_checks: PR #$num merge state '${ms:-unreadable}' — checks unreliable, skipping"
+              continue ;;
+        esac
+        checks="$("$GH_BIN" pr checks "$num" --repo "$BUG_PIPELINE_CODE_REPO" \
+                    --json name,state \
+                    --jq '.[] | "\(.state) \(.name)"' 2>/dev/null || true)"
+        [ -n "$checks" ] || continue
+        # Exclude human-signoff at shell level (case-insensitive); stub bypasses jq
+        checks="$(printf '%s\n' "$checks" | grep -viE 'human.?sign.?off' || true)"
+        [ -n "$checks" ] || continue
+        pending="$(printf '%s\n' "$checks" | grep -c '^PENDING ' 2>/dev/null || echo 0)"
+        if [ "${pending:-0}" -gt 0 ]; then
+            _bpgh_log "bpgh_pr_failing_checks: PR #$num has $pending pending check(s) — not settled, skipping"
+            continue
+        fi
+        failing="$(printf '%s\n' "$checks" | sed -n 's/^FAILURE //p' | paste -sd, -)"
+        [ -n "$failing" ] || continue
+        printf '%s %s %s %s\n' "$num" "$branch" "$sha" "$failing"
+    done <<INNER_EOF
+$prs
+INNER_EOF
+    return 0
+}

--- a/bin/lib/bug-pipeline-test-stubs.sh
+++ b/bin/lib/bug-pipeline-test-stubs.sh
@@ -240,6 +240,9 @@ SH
     export BUG_PIPELINE_CODE_REPO="test/code-fake"
     mkdir -p "$STUB/wt"
     # ── CI-autofix seams (ADR-0097) ──────────────────────────────────────────────
+    # Default DISABLED so the six existing suites (tick/classify/feature/park/issue/hunt)
+    # don't emit gh pr list calls. test-bug-pipeline-ci-autofix overrides to 1 after bpt_setup.
+    export BUG_PIPELINE_CI_AUTOFIX_ENABLED=0
     export BUG_PIPELINE_CI_AUTOFIX_LEDGER="$STUB/ledger.json"
     export BUG_PIPELINE_CI_AUTOFIX_LOG="$STUB/ci-autofix.log"
     export BUG_PIPELINE_CI_AUTOFIX_LOCK="$STUB/ci-autofix.lock"

--- a/bin/lib/bug-pipeline-test-stubs.sh
+++ b/bin/lib/bug-pipeline-test-stubs.sh
@@ -74,6 +74,21 @@ if [ "${STUB_HUNT_MODE:-0}" = 1 ]; then
     [ -f "$STUB/make-dirty" ] && printf 'hunter edit\n' >> "$PWD/hunted.txt"
     exit 0
 fi
+if [ "${STUB_CI_AUTOFIX_MODE:-0}" = 1 ]; then
+    # CI-autofix agent stub: write a preset result to the first matching worktree.
+    # STUB_CI_AUTOFIX_RESULT sets the JSON; default = no_change (safe, never pushes).
+    result="${STUB_CI_AUTOFIX_RESULT}"
+    # Two-step default avoids ${var:-{...}} brace-counting bug: bash closes ${...}
+    # at the first unescaped } in the default value, appending a stray } to the result.
+    [ -z "$result" ] && result='{"result":"no_change","commit_sha":null,"changes":[],"reason":"stub"}'
+    for wt_candidate in "$STUB"/wt/*/; do
+        [ -d "$wt_candidate" ] || continue
+        mkdir -p "$wt_candidate/.bug-pipeline"
+        printf '%s' "$result" > "$wt_candidate/.bug-pipeline/ci-autofix-result.json"
+        break
+    done
+    exit 0
+fi
 # Simulate a successful /plan run: drop a new plan file into PLANS_DIR.
 case "$*" in
   */plan\ *|*"/plan "*) [ "${STUB_MAKE_PLAN:-0}" = 1 ] && : > "$BUG_PIPELINE_PLANS_DIR/new-feature-plan.md" ;;
@@ -109,6 +124,11 @@ echo "GH $*" >> "$STUB/calls.log"
 printf '%s\n' "$@" >> "$STUB/gh.args.log"   # one arg per line — proves title is a single argv element
 case "$*" in
   *"issue create"*) [ "${GH_FAIL:-0}" = 1 ] && exit 1; echo "https://github.com/${BUG_PIPELINE_ISSUE_REPO}/issues/${STUB_ISSUE_NUMBER:-4242}" ;;
+  *"pr list"*headRefOid*)
+      # CI-autofix detection path: --json number,headRefName,headRefOid,isDraft
+      # driver's --jq already applied → emit pre-filtered "NUM BRANCH SHA" lines
+      [ "${GH_FAIL:-0}" = 1 ] && exit 1
+      cat "$STUB/gh-pr-list-ci.out" 2>/dev/null || true ;;
   *"pr list"*)
       [ "${GH_FAIL:-0}" = 1 ] && exit 1
       # Vary output by --head so a case can encode "this head has no PR, but the legacy
@@ -121,6 +141,18 @@ case "$*" in
           cat "$STUB/gh-pr-list.out" 2>/dev/null || true   # driver's --jq already applied → emit the final value
       fi
       ;;
+  *"pr checks"*)
+      # CI-autofix: fixture lines are pre-filtered "STATE name" (stub bypasses jq)
+      pr_num=""; prev=""
+      for a in "$@"; do [ "$prev" = "checks" ] && pr_num="$a"; prev="$a"; done
+      cat "$STUB/gh-pr-checks-${pr_num:-0}.out" 2>/dev/null || true ;;
+  *"pr comment"*)
+      # Best-effort — gh.log already records the full call including body; nothing else needed
+      : ;;
+  *"pr view"*mergeStateStatus*)
+      # CI-autofix conflict precheck: STUB_PR_VIEW_FAIL=1 simulates unreadable state (exit 1 → ms="")
+      [ "${STUB_PR_VIEW_FAIL:-0}" = 1 ] && exit 1
+      printf '%s\t%s\n' "${STUB_MERGEABLE:-MERGEABLE}" "${STUB_MERGE_STATE:-CLEAN}" ;;
   *"pr view"*)      [ "${GH_FAIL:-0}" = 1 ] && exit 1; cat "$STUB/gh-pr-view.out" 2>/dev/null || true ;;
   *) [ "${GH_FAIL:-0}" = 1 ] && exit 1; : ;;
 esac
@@ -207,6 +239,21 @@ SH
     export BUG_PIPELINE_HUNT_LOG="$STUB/hunt.log"
     export BUG_PIPELINE_CODE_REPO="test/code-fake"
     mkdir -p "$STUB/wt"
+    # ── CI-autofix seams (ADR-0097) ──────────────────────────────────────────────
+    export BUG_PIPELINE_CI_AUTOFIX_LEDGER="$STUB/ledger.json"
+    export BUG_PIPELINE_CI_AUTOFIX_LOG="$STUB/ci-autofix.log"
+    export BUG_PIPELINE_CI_AUTOFIX_LOCK="$STUB/ci-autofix.lock"
+    export BUG_PIPELINE_CI_AUTOFIX_IDLE_SECS=1
+    export BUG_PIPELINE_CI_AUTOFIX_BACKOFF_SECS=0
+    # fake-repo: minimal git repo so ci_wt_for_branch has a real worktree list to walk
+    mkdir -p "$STUB/fake-repo"
+    git -C "$STUB/fake-repo" init -q 2>/dev/null || true
+    git -C "$STUB/fake-repo" config user.email t@t 2>/dev/null || true
+    git -C "$STUB/fake-repo" config user.name t 2>/dev/null || true
+    printf 'x\n' > "$STUB/fake-repo/f"
+    git -C "$STUB/fake-repo" add -A 2>/dev/null || true
+    git -C "$STUB/fake-repo" commit -qm base 2>/dev/null || true
+    export BUG_PIPELINE_CI_AUTOFIX_WT_REPO="$STUB/fake-repo"
     trap 'rm -rf "$STUB"' EXIT
 }
 
@@ -217,11 +264,18 @@ bpt_reset() {
           "$STUB"/claim-next-resume.out "$STUB"/list-pr-open.out "$STUB"/plans/*.md \
           "$STUB"/result*.json "$STUB"/envfail* "$STUB"/make-dirty \
           "$STUB"/verdicts "$STUB"/verdict-idx \
-          "$STUB"/gh-pr-list.out "$STUB"/gh-pr-list-*.out "$STUB"/gh-pr-view.out 2>/dev/null
+          "$STUB"/gh-pr-list.out "$STUB"/gh-pr-list-*.out "$STUB"/gh-pr-view.out \
+          "$STUB"/gh-pr-list-ci.out "$STUB"/gh-pr-checks-*.out \
+          "$STUB"/ledger.json 2>/dev/null
     rm -rf "$STUB"/wt/* 2>/dev/null
+    # ci-autofix.lock is a directory (mkdir-based); rm -f silently fails on it
+    rm -rf "$STUB"/ci-autofix.lock 2>/dev/null
+    # prune worktrees from fake-repo added by ci-autofix wire tests
+    git -C "$STUB/fake-repo" worktree prune 2>/dev/null || true
     printf '[]' > "$STUB/actionable.json"
     unset GH_FAIL STUB_THREAD_ID STUB_MESSAGE_ID STUB_ISSUE_NUMBER WT_NEW_FAIL STUB_CREATE_THREAD_FAIL \
-          CLAIM_NEXT_RC LIST_ACTIVE_RC
+          CLAIM_NEXT_RC LIST_ACTIVE_RC \
+          STUB_MERGE_STATE STUB_MERGEABLE STUB_PR_VIEW_FAIL
 }
 
 bpt_set_actionable()  { printf '%s' "$1" > "$STUB/actionable.json"; }
@@ -243,6 +297,11 @@ bpt_envfail()          { : > "$STUB/envfail${1:+-$1}"; }                      # 
 bpt_set_gh_pr_list()   { printf '%s' "$1" > "$STUB/gh-pr-list.out"; }
 bpt_set_gh_pr_list_for() { printf '%s' "$2" > "$STUB/gh-pr-list-$1.out"; }   # <head> <value>
 bpt_set_gh_pr_view()   { printf '%s' "$1" > "$STUB/gh-pr-view.out"; }
+# ── CI-autofix fixture setters ─────────────────────────────────────────────────
+# bpt_set_gh_pr_list_ci <lines> — set "NUM BRANCH SHA" lines for headRefOid detection
+bpt_set_gh_pr_list_ci()  { printf '%s\n' "$1" > "$STUB/gh-pr-list-ci.out"; }
+# bpt_set_gh_pr_checks_for <pr_num> <lines> — pre-filtered "STATE name" lines for a PR
+bpt_set_gh_pr_checks_for() { printf '%s\n' "$2" > "$STUB/gh-pr-checks-$1.out"; }
 # bpt_count <name> <want> <file>  — assert a stub log has exactly <want> non-blank lines
 # (grep -c prints 0 and exits 1 on no-match, so read its stdout and default empty→0; no `|| echo`).
 bpt_count() { local got; got="$(grep -c . "$3" 2>/dev/null)"; bpt_expect_eq "$1" "$2" "${got:-0}"; }

--- a/bin/lib/bug-pipeline-test-stubs.sh
+++ b/bin/lib/bug-pipeline-test-stubs.sh
@@ -146,6 +146,13 @@ case "$*" in
       pr_num=""; prev=""
       for a in "$@"; do [ "$prev" = "checks" ] && pr_num="$a"; prev="$a"; done
       cat "$STUB/gh-pr-checks-${pr_num:-0}.out" 2>/dev/null || true ;;
+  *"run list"*)
+      # CI-autofix log fetch: driver's --jq already applied → emit the bare run id
+      [ "${GH_FAIL:-0}" = 1 ] && exit 1
+      cat "$STUB/gh-run-list.out" 2>/dev/null || true ;;
+  *"run view"*log-failed*)
+      [ "${GH_FAIL:-0}" = 1 ] && exit 1
+      cat "$STUB/gh-run-log.out" 2>/dev/null || true ;;
   *"pr comment"*)
       # Best-effort — gh.log already records the full call including body; nothing else needed
       : ;;
@@ -239,7 +246,7 @@ SH
     export BUG_PIPELINE_HUNT_LOG="$STUB/hunt.log"
     export BUG_PIPELINE_CODE_REPO="test/code-fake"
     mkdir -p "$STUB/wt"
-    # ── CI-autofix seams (ADR-0097) ──────────────────────────────────────────────
+    # ── CI-autofix seams (ADR-0099) ──────────────────────────────────────────────
     # Default DISABLED so the six existing suites (tick/classify/feature/park/issue/hunt)
     # don't emit gh pr list calls. test-bug-pipeline-ci-autofix overrides to 1 after bpt_setup.
     export BUG_PIPELINE_CI_AUTOFIX_ENABLED=0
@@ -305,6 +312,9 @@ bpt_set_gh_pr_view()   { printf '%s' "$1" > "$STUB/gh-pr-view.out"; }
 bpt_set_gh_pr_list_ci()  { printf '%s\n' "$1" > "$STUB/gh-pr-list-ci.out"; }
 # bpt_set_gh_pr_checks_for <pr_num> <lines> — pre-filtered "STATE name" lines for a PR
 bpt_set_gh_pr_checks_for() { printf '%s\n' "$2" > "$STUB/gh-pr-checks-$1.out"; }
+# bpt_set_gh_run_log <run_id> <log_text> — CI-autofix log fetch: the run id `gh run list`
+# resolves to, and the body `gh run view --log-failed` returns for it.
+bpt_set_gh_run_log() { printf '%s\n' "$1" > "$STUB/gh-run-list.out"; printf '%s\n' "$2" > "$STUB/gh-run-log.out"; }
 # bpt_count <name> <want> <file>  — assert a stub log has exactly <want> non-blank lines
 # (grep -c prints 0 and exits 1 on no-match, so read its stdout and default empty→0; no `|| echo`).
 bpt_count() { local got; got="$(grep -c . "$3" 2>/dev/null)"; bpt_expect_eq "$1" "$2" "${got:-0}"; }

--- a/bin/test-bug-pipeline-ci-autofix
+++ b/bin/test-bug-pipeline-ci-autofix
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-bug-pipeline-ci-autofix — unattended CI-failure autofix (ADR-0097)
+#
+# Covers: detection, ledger gates, dispatch, apply-result, giveup, wiring
+# (ci_autofix runs after maybe_hunt), and trust-split (SECURITY — LAST).
+#
+# Run: bin/test-bug-pipeline-ci-autofix  (exit 0 = all pass, 1 = a case failed)
+
+set -u
+# shellcheck source=bin/lib/bug-pipeline-test-stubs.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib/bug-pipeline-test-stubs.sh"
+DRIVER="$(cd "$(dirname "$0")" && pwd)/bug-pipeline-tick"
+
+bpt_setup
+
+# Add a git worktree to the fake-repo so ci_wt_for_branch can resolve a branch.
+# Reuses an existing branch on subsequent calls (after bpt_reset prunes the worktree).
+bpt_add_wt() {
+    local branch="$1"
+    if git -C "$STUB/fake-repo" rev-parse --verify "refs/heads/$branch" >/dev/null 2>&1; then
+        git -C "$STUB/fake-repo" worktree add "$STUB/wt/$branch" "$branch" >/dev/null 2>&1 || true
+    else
+        git -C "$STUB/fake-repo" worktree add "$STUB/wt/$branch" -b "$branch" >/dev/null 2>&1 || true
+    fi
+    mkdir -p "$STUB/wt/$branch/ibl5"
+    # Age all tracked files so ci_wt_is_idle sees an idle worktree.
+    # Without this, macOS APFS nanosecond timestamps cause -mmin -0 to spuriously
+    # match freshly-created worktree files, blocking dispatch in tests.
+    find "$STUB/wt/$branch" -not -path "*/.git/*" -type f \
+        -exec touch -t 200001010000 {} + 2>/dev/null || true
+    git -C "$STUB/wt/$branch" rev-parse HEAD 2>/dev/null
+}
+
+# Run bpgh_pr_failing_checks in a subshell (sources only the gh lib — no full driver).
+# Prints whatever the function emits to stdout.
+GH_LIB="$(cd "$(dirname "$0")" && pwd)/lib/bug-pipeline-gh.sh"
+bpt_detect() {
+    BUG_PIPELINE_CODE_REPO="test/code-fake" \
+    GH_BIN="$STUB/bin/gh" \
+        bash -c 'source "$1"; bpgh_pr_failing_checks' bpt-unit-shim \
+        "$GH_LIB" 2>/dev/null
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# DETECTION ROWS — unit-test bpgh_pr_failing_checks via subshell
+# ═══════════════════════════════════════════════════════════════════
+
+# r-detect-1 — settled FAILURE → line emitted (basic path)
+bpt_reset
+bpt_set_gh_pr_list_ci "42 feature-tests abc123"
+bpt_set_gh_pr_checks_for 42 "SUCCESS lint
+FAILURE phpunit"
+out="$(bpt_detect)"
+bpt_expect_eq "r-detect-1: FAILURE emitted" "42 feature-tests abc123 phpunit" "$out"
+
+# r-detect-2 — any PENDING check → PR skipped (not settled)
+bpt_reset
+bpt_set_gh_pr_list_ci "42 feature-tests abc123"
+bpt_set_gh_pr_checks_for 42 "PENDING phpunit
+FAILURE lint"
+out="$(bpt_detect)"
+bpt_expect_eq "r-detect-2: PENDING → skip (not settled)" "" "$out"
+
+# r-detect-3 — only human-signoff failing → excluded, no output
+bpt_reset
+bpt_set_gh_pr_list_ci "42 feature-tests abc123"
+bpt_set_gh_pr_checks_for 42 "FAILURE human-sign-off"
+out="$(bpt_detect)"
+bpt_expect_eq "r-detect-3: human-signoff only → skip" "" "$out"
+
+# r-detect-4 — CONFLICTING merge state → skip (phantom-dispatch guard)
+bpt_reset
+bpt_set_gh_pr_list_ci "42 feature-tests abc123"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+export STUB_MERGE_STATE=CONFLICTING
+out="$(bpt_detect)"
+unset STUB_MERGE_STATE
+bpt_expect_eq "r-detect-4: CONFLICTING → skip" "" "$out"
+
+# r-detect-5 — unreadable merge state (gh pr view fails) → skip (fail-closed)
+bpt_reset
+bpt_set_gh_pr_list_ci "42 feature-tests abc123"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+export STUB_PR_VIEW_FAIL=1
+out="$(bpt_detect)"
+# STUB_PR_VIEW_FAIL unset inside bpt_reset on next call; unset here for safety
+unset STUB_PR_VIEW_FAIL
+bpt_expect_eq "r-detect-5: unreadable merge state → skip (fail-closed)" "" "$out"
+
+# ═══════════════════════════════════════════════════════════════════
+# DISPATCH ROWS — integration via bpt_run
+# ═══════════════════════════════════════════════════════════════════
+
+# r-dispatch-1 — no red PRs → ci_autofix returns 1, tick falls through to empty-tick exit
+bpt_reset
+bpt_run
+bpt_expect_eq "r-dispatch-1: exit 0" 0 "$BPT_RC"
+bpt_file_absent "$STUB/ci-autofix.log" "r-dispatch-1: no CI-autofix log on empty red-pr set"
+bpt_log_has "$STUB" tick.out "no actionable rows" "r-dispatch-1: fell through to empty-tick exit"
+
+# r-dispatch-2 — kill switch off → logged, tick exits 0 via ci_autofix returning 0
+bpt_reset
+bpt_set_gh_pr_list_ci "42 feature-tests abc123"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+export BUG_PIPELINE_CI_AUTOFIX_ENABLED=0
+bpt_run
+unset BUG_PIPELINE_CI_AUTOFIX_ENABLED
+bpt_expect_eq "r-dispatch-2: exit 0" 0 "$BPT_RC"
+bpt_log_has "$STUB" ci-autofix.log "kill switch off" "r-dispatch-2: kill switch logged"
+bpt_file_absent "$STUB/claude.log" "r-dispatch-2: no claude spawned with kill switch off"
+
+# r-dispatch-3 — dry-run mode → "would-dispatch" in log, no claude spawned
+bpt_reset
+sha="$(bpt_add_wt "fix-dryrun")"
+bpt_set_gh_pr_list_ci "42 fix-dryrun $sha"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+export BUG_PIPELINE_CI_AUTOFIX_DRY_RUN=1
+bpt_run
+unset BUG_PIPELINE_CI_AUTOFIX_DRY_RUN
+bpt_expect_eq "r-dispatch-3: exit 0" 0 "$BPT_RC"
+bpt_log_has "$STUB" ci-autofix.log "would-dispatch" "r-dispatch-3: dry-run logs would-dispatch"
+bpt_file_absent "$STUB/claude.log" "r-dispatch-3: no claude spawned in dry-run"
+
+# r-dispatch-4 — PR branch has no local worktree → skipped, no dispatch
+bpt_reset
+bpt_set_gh_pr_list_ci "42 no-such-branch abc123"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+bpt_run
+bpt_expect_eq "r-dispatch-4: exit 0" 0 "$BPT_RC"
+bpt_log_has "$STUB" ci-autofix.log "no local worktree" "r-dispatch-4: no-worktree branch skipped"
+bpt_file_absent "$STUB/claude.log" "r-dispatch-4: no claude on missing worktree"
+
+# ═══════════════════════════════════════════════════════════════════
+# LEDGER ROWS — ledger-gated dispatch (integration via bpt_run)
+# ═══════════════════════════════════════════════════════════════════
+
+# r-ledger-1 — new sha resets attempts when ledger stored old sha (ceiling → eligible)
+bpt_reset
+sha="$(bpt_add_wt "fix-ledger")"
+bpt_set_gh_pr_list_ci "55 fix-ledger $sha"
+bpt_set_gh_pr_checks_for 55 "FAILURE phpunit"
+printf '{"55":{"attempts":3,"head_sha_at_start":"old-sha-xyz"}}' > "$STUB/ledger.json"
+bpt_run
+bpt_expect_eq "r-ledger-1: exit 0" 0 "$BPT_RC"
+bpt_log_has "$STUB" ci-autofix.log "dispatching PR #55" "r-ledger-1: new sha resets budget → dispatch"
+
+# ═══════════════════════════════════════════════════════════════════
+# APPLY-RESULT ROWS — verdict handling (integration via bpt_run)
+# ═══════════════════════════════════════════════════════════════════
+
+# r-apply-1 — no_change result → ledger written, gh comment posted, Sonnet on attempt 1
+bpt_reset
+sha="$(bpt_add_wt "fix-apply1")"
+bpt_set_gh_pr_list_ci "42 fix-apply1 $sha"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+export STUB_CI_AUTOFIX_MODE=1
+export STUB_CI_AUTOFIX_RESULT='{"result":"no_change","commit_sha":null,"changes":[],"reason":"checks appear green"}'
+bpt_run
+unset STUB_CI_AUTOFIX_MODE STUB_CI_AUTOFIX_RESULT
+bpt_expect_eq "r-apply-1: exit 0" 0 "$BPT_RC"
+bpt_log_has "$STUB" ci-autofix.log "no_change at attempt 1" "r-apply-1: no_change logged"
+bpt_log_has "$STUB" gh.log "pr comment" "r-apply-1: gh comment posted"
+bpt_log_has "$STUB" claude.log "--model claude-sonnet-4-6" "r-apply-1: Sonnet used on attempt 1"
+
+# r-apply-2 — no result file (agent crash/timeout) → abort path, comment posted
+bpt_reset
+sha="$(bpt_add_wt "fix-apply2")"
+bpt_set_gh_pr_list_ci "42 fix-apply2 $sha"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+# STUB_CI_AUTOFIX_MODE NOT set → stub exits 0 without writing result file
+bpt_run
+bpt_expect_eq "r-apply-2: exit 0" 0 "$BPT_RC"
+bpt_log_has "$STUB" ci-autofix.log "abort at attempt 1" "r-apply-2: abort logged on missing result"
+bpt_log_has "$STUB" gh.log "pr comment" "r-apply-2: gh comment posted on abort"
+
+# r-apply-3 — mutation check → Opus regardless of attempt count
+bpt_reset
+sha="$(bpt_add_wt "fix-apply3")"
+bpt_set_gh_pr_list_ci "42 fix-apply3 $sha"
+bpt_set_gh_pr_checks_for 42 "FAILURE mutation-tests"
+bpt_run
+bpt_expect_eq "r-apply-3: exit 0" 0 "$BPT_RC"
+bpt_log_has "$STUB" claude.log "--model claude-opus-4-8" "r-apply-3: Opus on mutation check regardless of attempt"
+
+# ═══════════════════════════════════════════════════════════════════
+# GIVEUP ROWS — attempt ceiling / idempotent ⛔ comment
+# ═══════════════════════════════════════════════════════════════════
+
+# r-giveup-1 — attempts at ceiling → ⛔ giveup comment posted
+bpt_reset
+sha="$(bpt_add_wt "fix-giveup")"
+bpt_set_gh_pr_list_ci "42 fix-giveup $sha"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+printf '{"42":{"attempts":3,"head_sha_at_start":"%s"}}' "$sha" > "$STUB/ledger.json"
+bpt_run
+bpt_expect_eq "r-giveup-1: exit 0" 0 "$BPT_RC"
+bpt_log_has "$STUB" ci-autofix.log "giveup posted" "r-giveup-1: giveup logged after ceiling"
+bpt_log_has "$STUB" gh.log "pr comment 42" "r-giveup-1: ⛔ comment posted on ceiling"
+
+# r-giveup-2 — ceiling_notified=true → no second comment (idempotent)
+bpt_reset
+sha="$(bpt_add_wt "fix-giveup")"
+bpt_set_gh_pr_list_ci "42 fix-giveup $sha"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+printf '{"42":{"attempts":3,"head_sha_at_start":"%s","ceiling_notified":true}}' "$sha" \
+    > "$STUB/ledger.json"
+bpt_run
+bpt_expect_eq "r-giveup-2: exit 0" 0 "$BPT_RC"
+bpt_log_lacks "$STUB" ci-autofix.log "giveup posted" "r-giveup-2: no second giveup comment (ceiling_notified)"
+
+# ═══════════════════════════════════════════════════════════════════
+# WIRING ROWS — ordering: hunt takes priority; positive dispatch control
+# ═══════════════════════════════════════════════════════════════════
+
+# r-wire-1 — maybe_hunt claims a bug → ci_autofix_main NEVER runs (hunt first)
+bpt_reset
+export STUB_HUNT_MODE=1
+CLAIM='{"id":"7","status":"hunting","class":"bug","thread_id":"880000000000000001","issue_number":"4242","original_text":"the trade button is broken","hunt_attempts":0}'
+bpt_set_claim "$CLAIM"
+bpt_set_result '{"verdict":"fixed"}'; bpt_hunt_dirty
+bpt_set_gh_pr_list_ci "42 feature-tests abc123"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+bpt_run
+unset STUB_HUNT_MODE
+bpt_expect_eq "r-wire-1: exit 0" 0 "$BPT_RC"
+bpt_log_has "$STUB" tick.out "claimed bug 7 into hunting" "r-wire-1: hunt ran"
+bpt_file_absent "$STUB/ci-autofix.log" "r-wire-1: ci_autofix_main never ran (hunt took priority)"
+
+# r-wire-2 — single-flight: dispatching ci-autofix ends the tick (return 0 propagates up)
+bpt_reset
+sha="$(bpt_add_wt "fix-wire2")"
+bpt_set_gh_pr_list_ci "42 fix-wire2 $sha"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+export STUB_CI_AUTOFIX_MODE=1
+export STUB_CI_AUTOFIX_RESULT='{"result":"no_change","commit_sha":null,"changes":[],"reason":"stub"}'
+bpt_run
+unset STUB_CI_AUTOFIX_MODE STUB_CI_AUTOFIX_RESULT
+bpt_expect_eq "r-wire-2: exit 0" 0 "$BPT_RC"
+bpt_log_has "$STUB" ci-autofix.log "dispatching PR #42" "r-wire-2: dispatch logged (ci_autofix ran)"
+bpt_log_lacks "$STUB" tick.out "no actionable rows" "r-wire-2: tick ended at ci_autofix, never reached empty-tick"
+
+# r-wire-3 (positive control) — claude.log non-empty proves agent was actually spawned
+bpt_reset
+sha="$(bpt_add_wt "fix-wire3")"
+bpt_set_gh_pr_list_ci "42 fix-wire3 $sha"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+export STUB_CI_AUTOFIX_MODE=1
+export STUB_CI_AUTOFIX_RESULT='{"result":"no_change","commit_sha":null,"changes":[],"reason":"stub"}'
+bpt_run
+unset STUB_CI_AUTOFIX_MODE STUB_CI_AUTOFIX_RESULT
+if [ -s "$STUB/claude.log" ]; then
+    bpt_ok "r-wire-3: claude.log non-empty (agent spawned)"
+else
+    bpt_fail "r-wire-3: claude.log absent or empty — fix agent was not spawned"
+fi
+
+# ═══════════════════════════════════════════════════════════════════
+# TRUST-SPLIT ROW — ★ SECURITY (exercised, ALWAYS LAST)
+# ci-autofix re-uses run_under_starved_env from the hunter — verify the
+# seam strips GH_TOKEN, SSH_AUTH_SOCK, ANTHROPIC_API_KEY, and that a real
+# push to an auth-required remote fails. Mirrors Row 9 of test-bug-pipeline-hunt.
+# ═══════════════════════════════════════════════════════════════════
+
+export GIT_TERMINAL_PROMPT=0
+# shellcheck disable=SC1090
+source "$DRIVER"
+
+R_TRUST="$(mktemp -d)"
+git -C "$R_TRUST" init -q
+git -C "$R_TRUST" config user.email t@t; git -C "$R_TRUST" config user.name t
+printf 'x\n' > "$R_TRUST/f"; git -C "$R_TRUST" add -A; git -C "$R_TRUST" commit -qm x
+
+tok="$(run_under_starved_env "$R_TRUST" sh -c 'printf %s "$GH_TOKEN$GITHUB_TOKEN"')"
+bpt_expect_eq "r-trust: GH_TOKEN/GITHUB_TOKEN blank in starved env" "" "$tok"
+
+sock="$(run_under_starved_env "$R_TRUST" sh -c 'printf %s "${SSH_AUTH_SOCK:-}"')"
+bpt_expect_eq "r-trust: SSH_AUTH_SOCK empty in starved env" "" "$sock"
+
+apikey="$(run_under_starved_env "$R_TRUST" sh -c 'printf %s "${ANTHROPIC_API_KEY:-}"')"
+bpt_expect_eq "r-trust: ANTHROPIC_API_KEY blank in starved env" "" "$apikey"
+
+# EXERCISE: a real push to an auth-required remote must FAIL (no reachable credential)
+if timeout 30 run_under_starved_env "$R_TRUST" \
+        git push https://github.com/ibl5-pipeline-nonexistent/repo.git HEAD:refs/heads/x \
+        >/dev/null 2>&1; then
+    bpt_fail "r-trust: git push under starved env unexpectedly SUCCEEDED"
+else
+    bpt_ok "r-trust: git push under starved env fails (no token/keychain/SSH cred)"
+fi
+
+if command -v gh >/dev/null 2>&1; then
+    if timeout 30 run_under_starved_env "$R_TRUST" gh pr create --fill >/dev/null 2>&1; then
+        bpt_fail "r-trust: gh pr create under starved env unexpectedly SUCCEEDED"
+    else
+        bpt_ok "r-trust: gh pr create under starved env fails (no token)"
+    fi
+else
+    bpt_ok "r-trust: gh not installed — git-push vector suffices"
+fi
+
+rm -rf "$R_TRUST"
+
+echo "----"
+if [ "$FAILED" -eq 0 ]; then echo "ALL PASS"; else echo "SOME FAILED"; fi
+exit "$FAILED"

--- a/bin/test-bug-pipeline-ci-autofix
+++ b/bin/test-bug-pipeline-ci-autofix
@@ -14,6 +14,8 @@ source "$(cd "$(dirname "$0")" && pwd)/lib/bug-pipeline-test-stubs.sh"
 DRIVER="$(cd "$(dirname "$0")" && pwd)/bug-pipeline-tick"
 
 bpt_setup
+# Override the bpt_setup default (ENABLED=0) — CI autofix must be active for this suite.
+export BUG_PIPELINE_CI_AUTOFIX_ENABLED=1
 
 # Add a git worktree to the fake-repo so ci_wt_for_branch can resolve a branch.
 # Reuses an existing branch on subsequent calls (after bpt_reset prunes the worktree).

--- a/bin/test-bug-pipeline-ci-autofix
+++ b/bin/test-bug-pipeline-ci-autofix
@@ -100,7 +100,7 @@ bpt_expect_eq "r-dispatch-1: exit 0" 0 "$BPT_RC"
 bpt_file_absent "$STUB/ci-autofix.log" "r-dispatch-1: no CI-autofix log on empty red-pr set"
 bpt_log_has "$STUB" tick.out "no actionable rows" "r-dispatch-1: fell through to empty-tick exit"
 
-# r-dispatch-2 — kill switch off → logged, tick exits 0 via ci_autofix returning 0
+# r-dispatch-2 — kill switch off → logged, ci_autofix returns 1 (tick falls through to empty-tick exit)
 bpt_reset
 bpt_set_gh_pr_list_ci "42 feature-tests abc123"
 bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"

--- a/bin/test-bug-pipeline-ci-autofix
+++ b/bin/test-bug-pipeline-ci-autofix
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
 #
-# bin/test-bug-pipeline-ci-autofix — unattended CI-failure autofix (ADR-0097)
+# bin/test-bug-pipeline-ci-autofix — unattended CI-failure autofix (ADR-0099)
 #
 # Covers: detection, ledger gates, dispatch, apply-result, giveup, wiring
 # (ci_autofix runs after maybe_hunt), and trust-split (SECURITY — LAST).
@@ -16,6 +16,11 @@ DRIVER="$(cd "$(dirname "$0")" && pwd)/bug-pipeline-tick"
 bpt_setup
 # Override the bpt_setup default (ENABLED=0) — CI autofix must be active for this suite.
 export BUG_PIPELINE_CI_AUTOFIX_ENABLED=1
+# The driver DEFAULTS to dry-run (ship-safety soak). Dry-run returns before rendering the
+# prompt, spawning claude, or commenting — so without this override every dispatch/apply/
+# giveup row below would silently become a no-op and still pass. Rows that mean to test the
+# dry-run path set it to 1 themselves and reset it to 0 (never `unset`) afterwards.
+export BUG_PIPELINE_CI_AUTOFIX_DRY_RUN=0
 
 # Add a git worktree to the fake-repo so ci_wt_for_branch can resolve a branch.
 # Reuses an existing branch on subsequent calls (after bpt_reset prunes the worktree).
@@ -27,9 +32,9 @@ bpt_add_wt() {
         git -C "$STUB/fake-repo" worktree add "$STUB/wt/$branch" -b "$branch" >/dev/null 2>&1 || true
     fi
     mkdir -p "$STUB/wt/$branch/ibl5"
-    # Age all tracked files so ci_wt_is_idle sees an idle worktree.
-    # Without this, macOS APFS nanosecond timestamps cause -mmin -0 to spuriously
-    # match freshly-created worktree files, blocking dispatch in tests.
+    # Age all tracked files so ci_wt_is_idle sees an idle worktree. The suite runs with
+    # CI_AUTOFIX_IDLE_SECS=1, which the driver clamps to a 1-minute `-mmin` window, so
+    # freshly-created worktree files are inside it and would block every dispatch row.
     find "$STUB/wt/$branch" -not -path "*/.git/*" -type f \
         -exec touch -t 200001010000 {} + 2>/dev/null || true
     git -C "$STUB/wt/$branch" rev-parse HEAD 2>/dev/null
@@ -120,7 +125,7 @@ bpt_set_gh_pr_list_ci "42 fix-dryrun $sha"
 bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
 export BUG_PIPELINE_CI_AUTOFIX_DRY_RUN=1
 bpt_run
-unset BUG_PIPELINE_CI_AUTOFIX_DRY_RUN
+export BUG_PIPELINE_CI_AUTOFIX_DRY_RUN=0
 bpt_expect_eq "r-dispatch-3: exit 0" 0 "$BPT_RC"
 bpt_log_has "$STUB" ci-autofix.log "would-dispatch" "r-dispatch-3: dry-run logs would-dispatch"
 bpt_file_absent "$STUB/claude.log" "r-dispatch-3: no claude spawned in dry-run"
@@ -133,6 +138,103 @@ bpt_run
 bpt_expect_eq "r-dispatch-4: exit 0" 0 "$BPT_RC"
 bpt_log_has "$STUB" ci-autofix.log "no local worktree" "r-dispatch-4: no-worktree branch skipped"
 bpt_file_absent "$STUB/claude.log" "r-dispatch-4: no claude on missing worktree"
+
+# r-dispatch-5 — DEFAULT (seam unset) is dry-run: the ship-safety default, asserted directly.
+# If someone flips the driver default back to live, this row fails.
+bpt_reset
+sha="$(bpt_add_wt "fix-default")"
+bpt_set_gh_pr_list_ci "42 fix-default $sha"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+unset BUG_PIPELINE_CI_AUTOFIX_DRY_RUN
+bpt_run
+export BUG_PIPELINE_CI_AUTOFIX_DRY_RUN=0
+bpt_expect_eq "r-dispatch-5: exit 0" 0 "$BPT_RC"
+bpt_log_has "$STUB" ci-autofix.log "would-dispatch" "r-dispatch-5: unset seam defaults to dry-run"
+bpt_file_absent "$STUB/claude.log" "r-dispatch-5: no claude spawned on default settings"
+
+# r-dispatch-6 — dirty worktree → no dispatch. The fix agent must never be pointed at a tree
+# holding someone else's uncommitted work; "idle" alone does not imply "clean".
+bpt_reset
+sha="$(bpt_add_wt "fix-dirty")"
+printf 'a human was mid-edit here\n' > "$STUB/wt/fix-dirty/unfinished.txt"
+# Age it: the idle gate runs BEFORE the clean gate, so a freshly-written file would trip
+# "not idle" and this row would pass for the wrong reason.
+touch -t 200001010000 "$STUB/wt/fix-dirty/unfinished.txt"
+bpt_set_gh_pr_list_ci "42 fix-dirty $sha"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+bpt_run
+rm -f "$STUB/wt/fix-dirty/unfinished.txt"
+bpt_expect_eq "r-dispatch-6: exit 0" 0 "$BPT_RC"
+bpt_log_has "$STUB" ci-autofix.log "worktree dirty" "r-dispatch-6: dirty worktree blocks dispatch"
+bpt_file_absent "$STUB/claude.log" "r-dispatch-6: no claude spawned on dirty worktree"
+
+# r-dispatch-7 — sub-minute IDLE_SECS must NOT read as "always idle". Integer division floors
+# 1s to `-mmin -0`, which matches nothing and inverts the gate; the driver clamps to 1 minute.
+# The recently-edited file is inside the idle window, so this must be reported NOT idle.
+#
+# The edit is backdated 30s ON PURPOSE. `find -mmin -N` compares floor(age_seconds/60) < N,
+# so a 30s-old file matches `-mmin -1` (0 < 1) and never matches `-mmin -0` (0 < 0) — the row
+# then fails deterministically if the clamp is removed. A touched-NOW file is the wrong probe:
+# APFS nanosecond mtimes can land a hair in the future, making age negative, and `-mmin -0`
+# then matches (-1 < 0) on macOS but not on Linux CI — the row would pass on this machine with
+# the clamp deleted, which is exactly the vacuous negative control this comment exists to stop.
+bpt_reset
+sha="$(bpt_add_wt "fix-idlefloor")"
+printf 'just edited\n' > "$STUB/wt/fix-idlefloor/ibl5/live.txt"
+git -C "$STUB/wt/fix-idlefloor" add ibl5/live.txt >/dev/null 2>&1
+git -C "$STUB/wt/fix-idlefloor" commit -qm "live edit" >/dev/null 2>&1
+# 30 seconds ago, portably. BSD `touch -t` and GNU `touch -d` disagree on relative time
+# strings, and BSD `date -r <epoch>` vs GNU `date -d @<epoch>` disagree on epoch input —
+# so try the BSD form and fall back to the GNU form. Both print LOCAL time, which is what
+# `touch -t` expects; do not introduce -u on one side only.
+_ago=$(( $(date +%s) - 30 ))
+_stamp="$(date -r "$_ago" +%Y%m%d%H%M.%S 2>/dev/null || date -d "@$_ago" +%Y%m%d%H%M.%S)"
+touch -t "$_stamp" "$STUB/wt/fix-idlefloor/ibl5/live.txt"
+bpt_set_gh_pr_list_ci "42 fix-idlefloor $sha"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+bpt_run
+bpt_expect_eq "r-dispatch-7: exit 0" 0 "$BPT_RC"
+bpt_log_has "$STUB" ci-autofix.log "not idle" "r-dispatch-7: sub-minute IDLE_SECS clamps to 1min, gate holds"
+bpt_file_absent "$STUB/claude.log" "r-dispatch-7: no claude spawned on a live worktree"
+
+# ═══════════════════════════════════════════════════════════════════
+# FAILURE-LOG ROWS — the agent must receive the REAL failing job log
+# ═══════════════════════════════════════════════════════════════════
+
+# r-log-1 — the fetched CI log body reaches .bug-pipeline/ci-failure.log. Asserting only that
+# "a gh call happened" is what let a no-op collector ship green; assert the CONTENT lands.
+bpt_reset
+sha="$(bpt_add_wt "fix-log1")"
+bpt_set_gh_pr_list_ci "42 fix-log1 $sha"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+bpt_set_gh_run_log 987654321 "PHPUnit
+1) Ibl5\\Tests\\TradeTest::testTradeButton
+Failed asserting that false is true.
+/app/ibl5/tests/TradeTest.php:42"
+export STUB_CI_AUTOFIX_MODE=1
+export STUB_CI_AUTOFIX_RESULT='{"result":"no_change","commit_sha":null,"changes":[],"reason":"stub"}'
+bpt_run
+unset STUB_CI_AUTOFIX_MODE STUB_CI_AUTOFIX_RESULT
+bpt_expect_eq "r-log-1: exit 0" 0 "$BPT_RC"
+bpt_log_has "$STUB/wt/fix-log1/.bug-pipeline" ci-failure.log \
+    "Failed asserting that false is true." "r-log-1: real CI log body reaches the agent's log file"
+bpt_log_has "$STUB/wt/fix-log1/.bug-pipeline" ci-failure.log \
+    "/app/ibl5/tests/TradeTest.php:42" "r-log-1: failing file:line survives into the log file"
+bpt_log_has "$STUB" gh.log "run view 987654321" "r-log-1: log fetched via gh run view --log-failed"
+bpt_log_has "$STUB" gh.log "--log-failed" "r-log-1: --log-failed used (failed steps only)"
+
+# r-log-2 — no failed workflow run for the head SHA → header still written, no crash, still dispatches.
+bpt_reset
+sha="$(bpt_add_wt "fix-log2")"
+bpt_set_gh_pr_list_ci "42 fix-log2 $sha"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+bpt_set_gh_run_log "" ""
+bpt_run
+bpt_expect_eq "r-log-2: exit 0" 0 "$BPT_RC"
+bpt_log_has "$STUB/wt/fix-log2/.bug-pipeline" ci-failure.log \
+    "no failed workflow run" "r-log-2: missing run degrades to a note, not a crash"
+bpt_log_has "$STUB/wt/fix-log2/.bug-pipeline" ci-failure.log \
+    "Failing checks: phpunit" "r-log-2: header names the failing check even without a run"
 
 # ═══════════════════════════════════════════════════════════════════
 # LEDGER ROWS — ledger-gated dispatch (integration via bpt_run)

--- a/ibl5/docs/decisions/0099-unattended-ci-failure-autofix.md
+++ b/ibl5/docs/decisions/0099-unattended-ci-failure-autofix.md
@@ -1,0 +1,41 @@
+---
+description: Adds unattended CI-failure autofix to bug-pipeline-tick — detects settled red PRs, dispatches a sandboxed Claude agent to fix and commit, then pushes if the agent reports a fix.
+last_verified: 2026-07-30
+---
+
+# ADR-0097: Unattended CI-Failure Autofix via bug-pipeline-tick
+
+**Status:** Accepted
+**Date:** 2026-07-30
+**Deciders:** A-Jay
+
+## Context
+
+After the bug-pipeline hunter (ADR-0081) was shipping fixes to PRs, the remaining friction was CI failures on those PRs — transient phpunit regressions, mutation tests, golden-file drift — that required a manual push to fix. Each such failure blocked the PR from auto-merging and required manual triage. The hunter itself only ran on newly-assigned bugs; there was no mechanism to retry CI failures on already-open PRs.
+
+## Decision
+
+`bin/bug-pipeline-tick` gains a new `ci_autofix_main` phase that runs after `maybe_hunt`. On each tick it calls `bpgh_pr_failing_checks` to find open, non-draft PRs with settled red checks (no PENDING, excludes human-signoff). For each eligible PR it dispatches a sandboxed `claude -p` agent in the same trust split as the hunter (ADR-0081): the agent runs under `run_under_starved_env`, which zeroes GH_TOKEN, GITHUB_TOKEN, SSH_AUTH_SOCK, ANTHROPIC_API_KEY, and DB credentials. The agent reads a rendered prompt from `bin/bug-pipeline-ci-autofix-prompt`, writes a result JSON to `$wt_root/.bug-pipeline/ci-autofix-result.json`, and exits. If the agent reports `"result":"fixed"` with a valid commit SHA, the driver pushes `HEAD:branch` and posts a PR comment. `no_change` and `abort` verdicts are logged and commented but do not push. An attempt ledger (`CI_AUTOFIX_LEDGER`, default `~/.bug-pipeline/ci-autofix-ledger.json`) gates the attempt cap (default 3) and per-SHA retry semantics. After the cap, a `⛔ ceiling` comment is posted once. The feature is gated by `BUG_PIPELINE_CI_AUTOFIX_DISABLED=1` kill switch and `BUG_PIPELINE_CI_AUTOFIX_DRY_RUN=1` for safe observability.
+
+## Alternatives Considered
+
+- **GitHub Actions bot** — trigger a re-run workflow on red checks. Rejected because: requires write access to GH Actions, and we can't sandbox what that workflow does.
+- **Retry-only (no code change)** — just trigger `gh pr checks --rerun` on transient failures. Rejected because: can't distinguish transient from real failures without reading logs; also misses fixes needed for real test failures.
+- **Separate launchd daemon** — run the autofix as its own plist/daemon. Rejected because: `bug-pipeline-tick` already has the gh seam, trust-split infrastructure, and lock mechanism; duplicating them in a second daemon violates the extend-before-add bar.
+
+## Consequences
+
+- Positive: CI failures on open PRs can be fixed and pushed automatically without manual triage.
+- Positive: Sandboxed via `run_under_starved_env` — the agent cannot push credentials, call gh, or access the DB directly.
+- Positive: Kill switch and dry-run allow safe observability before full enablement.
+- Negative: A bad agent fix gets pushed (though the PR still requires human review before merge, since `auto_merge` is off by default and guarded by the human-signoff check).
+- Negative: One dispatch per tick (not parallel) — ensures the ledger lock is simple and single-flight; means high-PR-count repos could be slow to cycle.
+
+## References
+
+- `bin/bug-pipeline-tick` — driver; `ci_autofix_main`, `ci_dispatch`, `ci_apply_result`, `ci_autofix_giveup`
+- `bin/bug-pipeline-ci-autofix-prompt` — rendered prompt template
+- `bin/lib/bug-pipeline-gh.sh` — `bpgh_pr_failing_checks`, `bpgh_pr_comment`
+- `bin/test-bug-pipeline-ci-autofix` — integration test suite (44 cases)
+- `.github/workflows/tests.yml` — CI wiring for the test suite
+- `ibl5/docs/decisions/0081-hunter-trust-split-starved-env-sandbox.md` — trust-split foundation this builds on

--- a/ibl5/docs/decisions/0099-unattended-ci-failure-autofix.md
+++ b/ibl5/docs/decisions/0099-unattended-ci-failure-autofix.md
@@ -15,7 +15,7 @@ After the bug-pipeline hunter (ADR-0081) was shipping fixes to PRs, the remainin
 
 ## Decision
 
-`bin/bug-pipeline-tick` gains a new `ci_autofix_main` phase that runs after `maybe_hunt`. On each tick it calls `bpgh_pr_failing_checks` to find open, non-draft PRs with settled red checks (no PENDING, excludes human-signoff). For each eligible PR it dispatches a sandboxed `claude -p` agent in the same trust split as the hunter (ADR-0081): the agent runs under `run_under_starved_env`, which zeroes GH_TOKEN, GITHUB_TOKEN, SSH_AUTH_SOCK, ANTHROPIC_API_KEY, and DB credentials. The agent reads a rendered prompt from `bin/bug-pipeline-ci-autofix-prompt`, writes a result JSON to `$wt_root/.bug-pipeline/ci-autofix-result.json`, and exits. If the agent reports `"result":"fixed"` with a valid commit SHA, the driver pushes `HEAD:branch` and posts a PR comment. `no_change` and `abort` verdicts are logged and commented but do not push. An attempt ledger (`CI_AUTOFIX_LEDGER`, default `~/.bug-pipeline/ci-autofix-ledger.json`) gates the attempt cap (default 3) and per-SHA retry semantics. After the cap, a `⛔ ceiling` comment is posted once. The feature is gated by `BUG_PIPELINE_CI_AUTOFIX_DISABLED=1` kill switch and `BUG_PIPELINE_CI_AUTOFIX_DRY_RUN=1` for safe observability.
+`bin/bug-pipeline-tick` gains a new `ci_autofix_main` phase that runs after `maybe_hunt`. On each tick it calls `bpgh_pr_failing_checks` to find open, non-draft PRs with settled red checks (no PENDING, excludes human-signoff). For each eligible PR it dispatches a sandboxed `claude -p` agent in the same trust split as the hunter (ADR-0081): the agent runs under `run_under_starved_env`, which zeroes GH_TOKEN, GITHUB_TOKEN, SSH_AUTH_SOCK, ANTHROPIC_API_KEY, and DB credentials. The agent reads a rendered prompt from `bin/bug-pipeline-ci-autofix-prompt`, writes a result JSON to `$wt_root/.bug-pipeline/ci-autofix-result.json`, and exits. If the agent reports `"result":"fixed"` with a valid commit SHA, the driver pushes `HEAD:branch` and posts a PR comment. `no_change` and `abort` verdicts are logged and commented but do not push. An attempt ledger (`CI_AUTOFIX_LEDGER`, default `~/.bug-pipeline/ci-autofix-ledger.json`) gates the attempt cap (default 3) and per-SHA retry semantics. After the cap, a `⛔ ceiling` comment is posted once. The feature is gated by `BUG_PIPELINE_CI_AUTOFIX_ENABLED=0` kill switch (default `1`) and `BUG_PIPELINE_CI_AUTOFIX_DRY_RUN=1` for safe observability.
 
 ## Alternatives Considered
 
@@ -33,7 +33,7 @@ After the bug-pipeline hunter (ADR-0081) was shipping fixes to PRs, the remainin
 
 ## References
 
-- `bin/bug-pipeline-tick` — driver; `ci_autofix_main`, `ci_dispatch`, `ci_apply_result`, `ci_autofix_giveup`
+- `bin/bug-pipeline-tick` — driver; `ci_autofix_main`, `ci_apply_result`, `ci_autofix_giveup`
 - `bin/bug-pipeline-ci-autofix-prompt` — rendered prompt template
 - `bin/lib/bug-pipeline-gh.sh` — `bpgh_pr_failing_checks`, `bpgh_pr_comment`
 - `bin/test-bug-pipeline-ci-autofix` — integration test suite (44 cases)

--- a/ibl5/docs/decisions/0099-unattended-ci-failure-autofix.md
+++ b/ibl5/docs/decisions/0099-unattended-ci-failure-autofix.md
@@ -1,9 +1,9 @@
 ---
 description: Adds unattended CI-failure autofix to bug-pipeline-tick — detects settled red PRs, dispatches a sandboxed Claude agent to fix and commit, then pushes if the agent reports a fix.
-last_verified: 2026-07-30
+last_verified: 2026-08-09
 ---
 
-# ADR-0097: Unattended CI-Failure Autofix via bug-pipeline-tick
+# ADR-0099: Unattended CI-Failure Autofix via bug-pipeline-tick
 
 **Status:** Accepted
 **Date:** 2026-07-30
@@ -15,7 +15,7 @@ After the bug-pipeline hunter (ADR-0081) was shipping fixes to PRs, the remainin
 
 ## Decision
 
-`bin/bug-pipeline-tick` gains a new `ci_autofix_main` phase that runs after `maybe_hunt`. On each tick it calls `bpgh_pr_failing_checks` to find open, non-draft PRs with settled red checks (no PENDING, excludes human-signoff). For each eligible PR it dispatches a sandboxed `claude -p` agent in the same trust split as the hunter (ADR-0081): the agent runs under `run_under_starved_env`, which zeroes GH_TOKEN, GITHUB_TOKEN, SSH_AUTH_SOCK, ANTHROPIC_API_KEY, and DB credentials. The agent reads a rendered prompt from `bin/bug-pipeline-ci-autofix-prompt`, writes a result JSON to `$wt_root/.bug-pipeline/ci-autofix-result.json`, and exits. If the agent reports `"result":"fixed"` with a valid commit SHA, the driver pushes `HEAD:branch` and posts a PR comment. `no_change` and `abort` verdicts are logged and commented but do not push. An attempt ledger (`CI_AUTOFIX_LEDGER`, default `~/.bug-pipeline/ci-autofix-ledger.json`) gates the attempt cap (default 3) and per-SHA retry semantics. After the cap, a `⛔ ceiling` comment is posted once. The feature is gated by `BUG_PIPELINE_CI_AUTOFIX_ENABLED=0` kill switch (default `1`) and `BUG_PIPELINE_CI_AUTOFIX_DRY_RUN=1` for safe observability.
+`bin/bug-pipeline-tick` gains a new `ci_autofix_main` phase that runs after `maybe_hunt`. On each tick it calls `bpgh_pr_failing_checks` to find open, non-draft PRs with settled red checks (no PENDING, excludes human-signoff). For each eligible PR, two pre-dispatch gates run: `ci_wt_is_idle` confirms no worktree file was modified within `CI_AUTOFIX_IDLE_SECS` (converted to whole minutes for `find -mmin`, clamped to a minimum of 1 — integer division of a sub-minute window would produce `-mmin -0`, which matches nothing and would report every worktree idle); `ci_wt_is_clean` then refuses dispatch if `git status --porcelain` is non-empty, since an abandoned dirty tree passes the idle gate and the agent must never commit work it did not author (the prompt's step 3 aborts on a dirty tree correspondingly). Passing both gates, the tick dispatches a sandboxed `claude -p` agent in the same trust split as the hunter (ADR-0081): the agent runs under `run_under_starved_env`, which zeroes GH_TOKEN, GITHUB_TOKEN, SSH_AUTH_SOCK, ANTHROPIC_API_KEY, and DB credentials. The trusted tick fetches the real failing-job log (via `gh run list --commit <sha>` + `gh run view <run-id> --log-failed`, tail-capped) and hands it to the agent as a file path. The agent reads a rendered prompt from `bin/bug-pipeline-ci-autofix-prompt`, writes a result JSON to `$wt_root/.bug-pipeline/ci-autofix-result.json`, and exits. If the agent reports `"result":"fixed"` with a valid commit SHA, the driver pushes `HEAD:branch` and posts a PR comment. `no_change` and `abort` verdicts are logged and commented but do not push. An attempt ledger (`CI_AUTOFIX_LEDGER`, default `~/.claude/logs/ci-autofix-ledger.json`) gates the attempt cap (default 3) and per-SHA retry semantics. After the cap, a `⛔ ceiling` comment is posted once. The feature is gated by `BUG_PIPELINE_CI_AUTOFIX_ENABLED` (default `1`; set to `0` to disable). The feature ships dry-run-by-default (`BUG_PIPELINE_CI_AUTOFIX_DRY_RUN` defaults to `1`: detect + gate + log only; no claude spawn, no comment, no push); going live requires setting `BUG_PIPELINE_CI_AUTOFIX_DRY_RUN=0` in the tick's environment.
 
 ## Alternatives Considered
 
@@ -27,7 +27,7 @@ After the bug-pipeline hunter (ADR-0081) was shipping fixes to PRs, the remainin
 
 - Positive: CI failures on open PRs can be fixed and pushed automatically without manual triage.
 - Positive: Sandboxed via `run_under_starved_env` — the agent cannot push credentials, call gh, or access the DB directly.
-- Positive: Kill switch and dry-run allow safe observability before full enablement.
+- Positive: Kill switch and dry-run allow safe observability before full enablement. The feature ships dry-run-by-default; going live requires setting `BUG_PIPELINE_CI_AUTOFIX_DRY_RUN=0` in the tick's environment.
 - Negative: A bad agent fix gets pushed (though the PR still requires human review before merge, since `auto_merge` is off by default and guarded by the human-signoff check).
 - Negative: One dispatch per tick (not parallel) — ensures the ledger lock is simple and single-flight; means high-PR-count repos could be slow to cycle.
 
@@ -36,6 +36,6 @@ After the bug-pipeline hunter (ADR-0081) was shipping fixes to PRs, the remainin
 - `bin/bug-pipeline-tick` — driver; `ci_autofix_main`, `ci_apply_result`, `ci_autofix_giveup`
 - `bin/bug-pipeline-ci-autofix-prompt` — rendered prompt template
 - `bin/lib/bug-pipeline-gh.sh` — `bpgh_pr_failing_checks`, `bpgh_pr_comment`
-- `bin/test-bug-pipeline-ci-autofix` — integration test suite (44 cases)
+- `bin/test-bug-pipeline-ci-autofix` — integration test suite (23 rows)
 - `.github/workflows/tests.yml` — CI wiring for the test suite
 - `ibl5/docs/decisions/0081-hunter-trust-split-starved-env-sandbox.md` — trust-split foundation this builds on

--- a/ibl5/docs/decisions/README.md
+++ b/ibl5/docs/decisions/README.md
@@ -1,6 +1,6 @@
 ---
 description: Index of IBL5 Architecture Decision Records (ADRs). Source of truth for every load-bearing decision and its rationale.
-last_verified: 2026-08-05
+last_verified: 2026-08-09
 ---
 
 # IBL5 Architecture Decision Records
@@ -33,6 +33,7 @@ Every load-bearing decision in IBL5 is captured here as a numbered ADR so that f
 | [0096](0096-headless-plan-autofire.md) | `/plan-prompt` auto-fires the planning run headlessly | Accepted | `bin/plan-now` runs the drafted prompt as a detached Sonnet 4.6 `/plan`; user-facing forks pre-resolved in-session, `bin/check-plan` verdict logged; the runner auto-queues for automouse by default, `--implement` opts out. |
 | [0097](0097-single-retrying-host-notification-transport.md) | A single retrying host-side notification transport | Accepted | All host-side Discord sends go through `bin/discord-dm` — retries past a pm2 restart window, spools + exits non-zero rather than dropping a message silently. |
 | [0098](0098-attachment-ingest-trust-boundary.md) | The attachment-ingest trust boundary | Accepted | The pipeline's first attacker-controlled binary ingest path: untrusted bytes/metadata, filenames never form paths, snowflakes stay strings, capped downloads against an https allowlist, cache pruned outside the repo, only a sanitized text reference reaches the model, `--allowedTools ''` untouched. |
+| [0099](0099-unattended-ci-failure-autofix.md) | Unattended CI-failure autofix via `bug-pipeline-tick` | Accepted | Settled red PRs get one credential-starved fix agent per tick, capped at 3 attempts per head SHA; the trusted tick side publishes and comments, never merges and never arms auto-merge. |
 
 ## When an ADR is Required
 


### PR DESCRIPTION
## Summary

Extends `bin/bug-pipeline-tick` with a CI-failure autofix pass (ADR-0099).

**Detection** reads settled red checks via `gh` (zero model spend on idle ticks). Empty result → zero `claude` spawned, ADR-0080 cost guard holds.

**Dispatch** sends one credential-starved fix agent per tick via `run_under_starved_env` (unchanged). The trusted tick side fetches the real failing-job log, publishes, posts a PR comment, and writes a JSON attempt ledger capped at 3 per head SHA. ADR-0081 trust split holds.

**Ships dry-run-by-default.** `BUG_PIPELINE_CI_AUTOFIX_DRY_RUN` defaults to `1` — the pass detects, gates, and logs, but spawns nothing, comments nothing, and pushes nothing. Going live is an explicit `BUG_PIPELINE_CI_AUTOFIX_DRY_RUN=0` in the tick's environment after a soak.

**Never merges, never arms auto-merge, never applies `pipeline-authored`.**

### New files
- `bin/bug-pipeline-ci-autofix-prompt` — prompt template with `{{placeholder}}` tokens
- `bin/test-bug-pipeline-ci-autofix` — seventh `test-bug-pipeline-<facet>` sibling (23 rows)
- `ibl5/docs/decisions/0099-unattended-ci-failure-autofix.md` — ADR

### Changed files
- `bin/bug-pipeline-tick` — env-seam block, ledger helpers, idle + clean gates, real CI-log fetch, dispatch, publish/comment, give-up path, `main()` wiring
- `bin/lib/bug-pipeline-gh.sh` — adds `bpgh_pr_failing_checks`, `bpgh_code_repo_available`, `bpgh_pr_comment`
- `bin/lib/bug-pipeline-test-stubs.sh` — adds `pr checks`/`pr comment`/`pr view mergeStateStatus`/`run list`/`run view --log-failed` stub branches, fixture helpers, seam exports
- `.github/workflows/tests.yml` — wires `bin/test-bug-pipeline-ci-autofix` step
- `ibl5/docs/decisions/README.md` — adds ADR-0099 row

### Key gates added beyond the brief
- **Conflict-state precheck** (REQUIRED AMENDMENT) — reads `mergeable/mergeStateStatus` before `gh pr checks`; CONFLICTING/DIRTY/unreadable → skip before any model spend. Fails closed (empty = skip, not pass).
- **Clean-worktree gate** — `git status --porcelain` non-empty → no dispatch. "Idle" only means nothing was touched recently, so an abandoned dirty tree passes the idle gate; the agent must never commit work it did not author. The prompt's step 3 aborts on a dirty tree as a second layer.
- **Idle gate with a minute floor** — `CI_AUTOFIX_IDLE_SECS` is converted to whole minutes for `find -mmin` and clamped to ≥ 1; integer division of a sub-minute window yields `-mmin -0`, which matches nothing and would silently report *every* worktree idle.
- **Head-match gate** — worktree must be at or ahead of PR head before dispatch.
- **Settled-checks gate** — any PENDING check → skip this PR this tick.
- **Single-flight lock** — `mkdir`-based; stale locks self-heal after `2×timeout`.
- **`BUG_PIPELINE_CI_AUTOFIX_ENABLED=0`** — kill switch, precedes detection.

### Real failure log reaches the agent
The agent holds no token and is forbidden from running `gh`, so the log has to be fetched on the trusted side. `ci_collect_failure_log` resolves the failed workflow run for the PR head SHA (`gh run list --commit`) and writes the tail of `gh run view <id> --log-failed` (capped at `BUG_PIPELINE_CI_AUTOFIX_LOG_MAX_BYTES`, default 40 000) to `.bug-pipeline/ci-failure.log`. Missing run or unavailable log degrades to a note in the header, never a crash.

## Manual Testing

No manual testing needed — the pass is host-side tooling with no user-facing surface, and every path above is covered by `bin/test-bug-pipeline-ci-autofix` (23 rows, including the trust-split rows asserting `git push` / `gh pr create` fail under the starved env). Each new gate was verified by a negative control: reverting the fix in the driver fails exactly the row that guards it.
