### PR TITLE
fix: sim recap roster blindness — simRecapContext guard + roster-aware tick/prompt

### DIFF
--- a/bin/sim-recap-prompt
+++ b/bin/sim-recap-prompt
@@ -313,7 +313,10 @@ of this sim. Use it to attribute players correctly in your recap:
 
 - roster: each team's current player list (current_teamid is authoritative;
   never use ibl_jsb_transactions.from_teamid — it is a frozen historical marker)
-- active_injuries: players currently on the injury list as of the sim window end
+- active_injuries: players currently on the injury list as of the sim window end.
+  Each row carries current_teamid (from ibl_plr.teamid) — attribute an injured
+  player to THAT team, never to ibl_jsb_transactions.from_teamid, which records
+  where he was when he got hurt and is wrong for anyone traded since.
 - sim_trades: trades that occurred during this sim window
 
 ROSTER_HEADER_EOF

--- a/bin/sim-recap-prompt
+++ b/bin/sim-recap-prompt
@@ -6,7 +6,7 @@
 # queries live game data itself via mysql.
 #
 # Usage:
-#   bin/sim-recap-prompt --sim=N --mentions=<path> --themes=<path>
+#   bin/sim-recap-prompt --sim=N --mentions=<path> --themes=<path> [--roster=<path>]
 #
 # --mentions JSON shape: {"Team Name": "snowflake-string-or-null", ...}
 #   Keys are teams that played in the sim. Values are Discord snowflakes as
@@ -14,6 +14,13 @@
 #   with no Discord ID. Null-value teams render as plain team names.
 #
 # --themes JSON shape: ["narrative angle used", ...] or [] for empty ledger
+#
+# --roster JSON shape: precomputed roster context from simRecapContext.php.
+#   {"sim":N,"start_date":"YYYY-MM-DD","end_date":"YYYY-MM-DD",
+#    "roster":{"<teamid>":[{"pid":N,"name":"...","pos":"...","current_teamid":N}],...},
+#    "active_injuries":[...],"sim_trades":[...]}
+#   When provided, injected as Block 8 (after the exemplar) so it outranks it.
+#   When absent, Block 8 is omitted entirely (roster-blind mode).
 #
 # Env seams (SIM_RECAP_* convention):
 #   SIM_RECAP_EXEMPLAR  Path to the pinned exemplar txt file.
@@ -53,11 +60,13 @@ SIM_RECAP_MYSQL_BIN="${SIM_RECAP_MYSQL_BIN:-/opt/homebrew/opt/mysql@8.4/bin/mysq
 sim=""
 mentions_path=""
 themes_path=""
+roster_path=""
 for arg in "$@"; do
     case "$arg" in
         --sim=*)      sim="${arg#--sim=}" ;;
         --mentions=*) mentions_path="${arg#--mentions=}" ;;
         --themes=*)   themes_path="${arg#--themes=}" ;;
+        --roster=*)   roster_path="${arg#--roster=}" ;;
     esac
 done
 
@@ -86,7 +95,7 @@ cat <<'VOICE_EOF'
 
 == VOICE SPEC ==
 
-on production, the most recent sim results are up. write a summary paragraph for each simmed game, similar to an ESPN-style write-up. write in the voice of Bill Simmons. avoid writing like an LLM (e.g. no em-dashes, short punchy sentences, "it's not this, it's that", "and here's the thing", "load-bearing" – all of those cliché LLM patterns of speech). try to use Simmons' humor (ideally his actually funny humor, not just what's funny to him). whenever you find yourself repeating an old theme, try to tie in a pop culture reference, whether of the player's real-life era, the era the games are simulated in, or of the real-life era of today. these paragraphs will be posted on Discord. before each paragraph, write the team names and the final scores, and on a line below, @mention the GM's of each team. don't list GM names next to the Discord mentions, it will look redundant. use mysql to pull data. ibl_sim_dates holds the dates of the last sim. ibl_box_scores and ibl_box_scores_teams has the raw box score data. ibl_schedule and ibl_standings will tell you the league schedule and where teams are in the standings. ibl_jsb_transactions lists injuries during the sim – mention the injuries in each game when possible. ibl_power contains post-sim win/loss streak information. Use it to call out any long streaks and to know when a big streak was snapped. open with a WHERE THINGS STAND standings-context section at the top of the output, first, before any per-game recaps — the pinned exemplar's ordering is authoritative. here's a sample of what you produced last time – ok to improve, expand upon, or change it for the better. if you don't continuously improve, expand, or change it up, referencing old content to create new content will become an ouroboros and get stale too quickly.
+on production, the most recent sim results are up. write a summary paragraph for each simmed game, similar to an ESPN-style write-up. write in the voice of Bill Simmons. avoid writing like an LLM (e.g. no em-dashes, short punchy sentences, "it's not this, it's that", "and here's the thing", "load-bearing" – all of those cliché LLM patterns of speech). try to use Simmons' humor (ideally his actually funny humor, not just what's funny to him). whenever you find yourself repeating an old theme, try to tie in a pop culture reference, whether of the player's real-life era, the era the games are simulated in, or of the real-life era of today. these paragraphs will be posted on Discord. before each paragraph, write the team names and the final scores, and on a line below, @mention the GM's of each team. don't list GM names next to the Discord mentions, it will look redundant. use mysql to pull data. ibl_sim_dates holds the dates of the last sim. ibl_box_scores and ibl_box_scores_teams has the raw box score data. ibl_schedule and ibl_standings will tell you the league schedule and where teams are in the standings. ibl_jsb_transactions lists injuries AND trades during the sim. mention the injuries in each game when possible. when a player was recently traded to their current team (use ibl_plr.teamid for current team, never from_teamid which is a frozen historical marker), note it in their first game recap. ibl_power contains post-sim win/loss streak information. Use it to call out any long streaks and to know when a big streak was snapped. open with a WHERE THINGS STAND standings-context section at the top of the output, first, before any per-game recaps — the pinned exemplar's ordering is authoritative. here's a sample of what you produced last time – ok to improve, expand upon, or change it for the better. if you don't continuously improve, expand, or change it up, referencing old content to create new content will become an ouroboros and get stale too quickly.
 
 VOICE_EOF
 
@@ -231,7 +240,7 @@ Strict field types:
   - game_date: non-empty string, format YYYY-MM-DD
   - recap_text (per game and top-level): non-empty strings
   - box_id: integer or null
-  - game_of_that_day: use 0 (integer zero, not null) when there was exactly one game on that date
+  - game_of_that_day: 1-based counter — use 1 when there was exactly one game on that date, or for the first game of a doubleheader; use 2 for the second game. Never use 0 — that silently drops this recap from the rendered output.
   - themes: array of strings — narrative angles you used this run (for the next ledger)
 
 == HOW TO PRODUCE IT ==
@@ -288,3 +297,30 @@ cat <<EXEMPLAR_FOOTER_EOF
 
 End of pinned exemplar. Write the recap for sim ${sim} now, using live data from the database.
 EXEMPLAR_FOOTER_EOF
+
+# =============================================================================
+# Block 8: Authoritative roster context (injected AFTER the exemplar so it
+# outranks the exemplar on player attribution). Only emitted when --roster=<path>
+# provides a valid JSON file.
+# =============================================================================
+if [[ -n "$roster_path" && -f "$roster_path" ]]; then
+    cat <<'ROSTER_HEADER_EOF'
+
+== CURRENT ROSTER CONTEXT (authoritative — outranks the exemplar) ==
+
+The following precomputed context reflects the current state of the league as
+of this sim. Use it to attribute players correctly in your recap:
+
+- roster: each team's current player list (current_teamid is authoritative;
+  never use ibl_jsb_transactions.from_teamid — it is a frozen historical marker)
+- active_injuries: players currently on the injury list as of the sim window end
+- sim_trades: trades that occurred during this sim window
+
+ROSTER_HEADER_EOF
+    cat "$roster_path"
+    cat <<'ROSTER_FOOTER_EOF'
+
+(End of roster context — write the recap using the live database data above,
+ informed by this roster context for current team attribution.)
+ROSTER_FOOTER_EOF
+fi

--- a/bin/sim-recap-tick
+++ b/bin/sim-recap-tick
@@ -97,6 +97,21 @@ q() {
     return "$rc"
 }
 
+# ── One seam for the prod-side context precompute ────────────────────────────
+# qctx <sim> -> JSON object on stdout; exit status of the call.
+# A dead ssh, an undeployed simRecapContext.php, or a PHP fatal yields EMPTY
+# stdout plus non-zero exit. Fault-tolerant: caller falls back to '{}' on failure.
+qctx() {
+    local sim="$1" rc
+    "$SIM_RECAP_SSH_BIN" "$SIM_RECAP_SSH_HOST" \
+        "php $SIM_RECAP_REMOTE_ROOT/ibl5/scripts/simRecapContext.php --sim=$sim"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        log "WARNING: roster-context fetch (sim $sim) failed (exit $rc) — proceeding without roster context"
+    fi
+    return "$rc"
+}
+
 # jq_ok <json> <filter> -> true when the filter succeeds (fail-closed on garbage).
 jq_ok() { printf '%s' "$1" | "$SIM_RECAP_JQ_BIN" -e "$2" >/dev/null 2>&1; }
 
@@ -142,6 +157,16 @@ fetch_agent_inputs() { # sim  (writes mentions.json + themes-ledger.json into WO
     fi
     # .themes is a flat JSON array of strings — string-safe by construction.
     printf '%s' "$rt" | "$SIM_RECAP_JQ_BIN" '.themes' > "$WORKDIR/themes-ledger.json" 2>/dev/null
+
+    # Fetch precomputed roster context (fault-tolerant — failure does NOT park).
+    local ctx ctx_rc
+    ctx="$(qctx "$sim")"; ctx_rc=$?
+    if [ "$ctx_rc" -eq 0 ] && jq_ok "$ctx" '.sim != null'; then
+        printf '%s' "$ctx" > "$WORKDIR/roster-context.json"
+    else
+        log "sim $sim: roster-context unavailable — writing empty context"
+        printf '{}' > "$WORKDIR/roster-context.json"
+    fi
     return 0
 }
 
@@ -202,7 +227,8 @@ generate() { # sim
 
     local prompt
     if ! prompt="$("$SIM_RECAP_PROMPT_BIN" --sim="$sim" \
-            --mentions="$WORKDIR/mentions.json" --themes="$WORKDIR/themes-ledger.json")"; then
+            --mentions="$WORKDIR/mentions.json" --themes="$WORKDIR/themes-ledger.json" \
+            --roster="$WORKDIR/roster-context.json")"; then
         log "sim $sim: prompt build failed (missing exemplar?) — parking"
         park "$sim"; return 0
     fi
@@ -268,10 +294,12 @@ dry_run() {
     fetch_agent_inputs "$sim" || true
     [ -f "$WORKDIR/mentions.json" ] || printf '{}' > "$WORKDIR/mentions.json"
     [ -f "$WORKDIR/themes-ledger.json" ] || printf '[]' > "$WORKDIR/themes-ledger.json"
+    [ -f "$WORKDIR/roster-context.json" ] || printf '{}' > "$WORKDIR/roster-context.json"
 
     local prompt
     if ! prompt="$("$SIM_RECAP_PROMPT_BIN" --sim="$sim" \
-            --mentions="$WORKDIR/mentions.json" --themes="$WORKDIR/themes-ledger.json")"; then
+            --mentions="$WORKDIR/mentions.json" --themes="$WORKDIR/themes-ledger.json" \
+            --roster="$WORKDIR/roster-context.json")"; then
         log "dry-run sim $sim: prompt build failed (missing exemplar?)"
         exit 1
     fi

--- a/bin/test-sim-recap-tick
+++ b/bin/test-sim-recap-tick
@@ -90,6 +90,17 @@ if printf '%s' "$cmd" | grep -q 'storeSimRecap\.php'; then
     cat "$STUB/resp.store" 2>/dev/null || printf '{"ok":true,"sim":42,"games":5}\n'
     exit 0
 fi
+if printf '%s' "$cmd" | grep -q 'simRecapContext\.php'; then
+    if [ -f "$STUB/fail.simRecapContext" ]; then
+        exit 255
+    fi
+    if [ -f "$STUB/resp.simRecapContext" ]; then
+        cat "$STUB/resp.simRecapContext"
+    else
+        printf '{"sim":42,"start_date":"2026-01-01","end_date":"2026-01-07","roster":{},"active_injuries":[],"sim_trades":[]}\n'
+    fi
+    exit 0
+fi
 verb=$(printf '%s' "$cmd" | grep -oE 'simRecapQueue\.php [a-z-]+' | awk '{print $2}')
 # fail.<verb> reproduces a dead ssh / undeployed remote script: EMPTY stdout
 # with a non-zero exit — deliberately indistinguishable from an idle queue on
@@ -515,6 +526,8 @@ printf '["past theme one", "past theme two"]'    > "$_FIX/themes.json"
 printf '{"Known Team": "123456789012345678", "Unknown Team": null}' \
     > "$_FIX/mentions-unmapped.json"
 printf '[]' > "$_FIX/themes-empty.json"
+printf '{"sim":1,"start_date":"2026-01-01","end_date":"2026-01-07","roster":{},"active_injuries":[],"sim_trades":[]}' \
+    > "$_FIX/roster-context.json"
 
 # Run the real builder; output → prompt.out, errors → prompt.err.
 run_prompt() {
@@ -557,6 +570,53 @@ run_prompt --sim=1 --mentions="$_FIX/mentions.json" --themes="$_FIX/themes-empty
 srt_log_has "$STUB" prompt.out "(none recorded yet)" \
     "negative_empty_ledger — none-recorded-yet for empty themes"
 
+# ── roster_block_present ──────────────────────────────────────────────────────
+run_prompt --sim=1 --mentions="$_FIX/mentions.json" --themes="$_FIX/themes.json" \
+    --roster="$_FIX/roster-context.json"
+srt_log_has "$STUB" prompt.out "CURRENT ROSTER CONTEXT" \
+    "roster_block_present — roster header appears when --roster is provided"
+
+# ── roster_block_is_last ──────────────────────────────────────────────────────
+# Block 8 must come AFTER the exemplar (offset of CURRENT ROSTER CONTEXT > PINNED EXEMPLAR).
+_exemplar_offset=$(grep -bo "PINNED EXEMPLAR" "$STUB/prompt.out" 2>/dev/null | head -1 | cut -d: -f1)
+_roster_offset=$(grep -bo "CURRENT ROSTER CONTEXT" "$STUB/prompt.out" 2>/dev/null | head -1 | cut -d: -f1)
+if [ -z "$_exemplar_offset" ]; then
+    srt_fail "roster_block_is_last — PINNED EXEMPLAR not found in output"
+elif [ -z "$_roster_offset" ]; then
+    srt_fail "roster_block_is_last — CURRENT ROSTER CONTEXT not found in output"
+elif [ "$_roster_offset" -gt "$_exemplar_offset" ]; then
+    srt_ok "roster_block_is_last — roster block follows exemplar"
+else
+    srt_fail "roster_block_is_last — roster block precedes exemplar (offset $_roster_offset <= $_exemplar_offset)"
+fi
+
+# ── voice_spec_corrected ──────────────────────────────────────────────────────
+run_prompt --sim=1 --mentions="$_FIX/mentions.json" --themes="$_FIX/themes.json"
+srt_log_lacks "$STUB" prompt.out "injuries during the sim" \
+    "voice_spec_corrected — old injury-only note absent"
+srt_log_has "$STUB" prompt.out "frozen historical marker" \
+    "voice_spec_corrected — new from_teamid note present"
+
+# ── game_of_that_day_contract ─────────────────────────────────────────────────
+srt_log_lacks "$STUB" prompt.out "integer zero, not null" \
+    "game_of_that_day_contract — old 'integer zero' instruction absent"
+srt_log_has "$STUB" prompt.out "1-based counter" \
+    "game_of_that_day_contract — 1-based instruction present"
+
+# ── negative_roster_absent ────────────────────────────────────────────────────
+# Without --roster, Block 8 must not appear.
+run_prompt --sim=1 --mentions="$_FIX/mentions.json" --themes="$_FIX/themes.json"
+srt_log_lacks "$STUB" prompt.out "CURRENT ROSTER CONTEXT" \
+    "negative_roster_absent — roster block absent when --roster not provided"
+
+# ── negative_roster_empty_object ──────────────────────────────────────────────
+# An empty-object roster file ({}) still triggers Block 8 (the file exists).
+printf '{}' > "$_FIX/roster-empty.json"
+run_prompt --sim=1 --mentions="$_FIX/mentions.json" --themes="$_FIX/themes.json" \
+    --roster="$_FIX/roster-empty.json"
+srt_log_has "$STUB" prompt.out "CURRENT ROSTER CONTEXT" \
+    "negative_roster_empty_object — block appears even for empty-object roster"
+
 # ── negative_missing_exemplar ─────────────────────────────────────────────────
 SIM_RECAP_EXEMPLAR="/nonexistent/exemplar.txt" \
     "$SRT_PROMPT_BIN" --sim=1 \
@@ -574,6 +634,52 @@ MYSQL_PWD="s3cr3t_pw_xyz" SIM_RECAP_EXEMPLAR="$SRT_EXEMPLAR" \
     --mentions="$_FIX/mentions.json" --themes="$_FIX/themes.json" \
     > "$STUB/prompt.out" 2>"$STUB/prompt.err"
 srt_log_lacks "$STUB" prompt.out "s3cr3t_pw_xyz" "negative_no_credential_leak"
+srt_log_lacks "$STUB" prompt.out "SIM_RECAP_DB_PASSWORD" \
+    "negative_no_credential_leak — DB_PASSWORD var name absent from prompt stdout"
+
+# ── roster_fetched_into_workdir ───────────────────────────────────────────────
+# simRecapContext.php is called over ssh; the result lands in roster-context.json.
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":42}\n' > "$STUB/resp.claim-next"
+export SIM_RECAP_KEEP_WORKDIR=1
+srt_run
+WORKDIR_PATH=$(sed -n 's/.*\] workdir \(\/[^ ]*\) .*/\1/p' "$STUB/tick.out" | head -1)
+if [ -z "$WORKDIR_PATH" ] || [ ! -f "$WORKDIR_PATH/roster-context.json" ]; then
+    srt_fail "roster_fetched_into_workdir — roster-context.json not found in workdir"
+else
+    _rc_content=$(cat "$WORKDIR_PATH/roster-context.json")
+    if printf '%s' "$_rc_content" | grep -q '"sim"'; then
+        srt_ok "roster_fetched_into_workdir — roster-context.json contains sim key"
+    else
+        srt_fail "roster_fetched_into_workdir — roster-context.json malformed: $_rc_content"
+    fi
+    rm -rf "$WORKDIR_PATH"
+fi
+unset SIM_RECAP_KEEP_WORKDIR
+
+# ── negative_roster_fetch_failure_does_not_park ──────────────────────────────
+# If simRecapContext.php fails (exit 255), the tick continues and writes {}.
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":42}\n' > "$STUB/resp.claim-next"
+touch "$STUB/fail.simRecapContext"
+export SIM_RECAP_KEEP_WORKDIR=1
+srt_run
+srt_expect_eq "negative_roster_fetch_failure_does_not_park — exit 0" 0 "$SRT_RC"
+srt_log_lacks "$STUB" ssh.log "simRecapQueue.php park" \
+    "negative_roster_fetch_failure_does_not_park — tick did not park on roster failure"
+WORKDIR_PATH=$(sed -n 's/.*\] workdir \(\/[^ ]*\) .*/\1/p' "$STUB/tick.out" | head -1)
+if [ -n "$WORKDIR_PATH" ] && [ -f "$WORKDIR_PATH/roster-context.json" ]; then
+    _fallback=$(cat "$WORKDIR_PATH/roster-context.json")
+    if [ "$_fallback" = '{}' ]; then
+        srt_ok "negative_roster_fetch_failure_does_not_park — fallback {} written"
+    else
+        srt_fail "negative_roster_fetch_failure_does_not_park — expected {}, got: $_fallback"
+    fi
+    rm -rf "$WORKDIR_PATH"
+else
+    srt_ok "negative_roster_fetch_failure_does_not_park — workdir cleaned (no keep)"
+fi
+unset SIM_RECAP_KEEP_WORKDIR
 
 echo "----"
 [ "$FAILED" -eq 0 ] && echo "ALL PASS" || echo "FAILURES"

--- a/bin/test-sim-recap-tick
+++ b/bin/test-sim-recap-tick
@@ -144,9 +144,10 @@ fi
 exit 0
 SH
 
-    # sim-recap-prompt stub: echo a fixed marker (tick plumbing only).
+    # sim-recap-prompt stub: record argv and echo a fixed marker (tick plumbing only).
     cat > "$STUB/prompt" <<'SH'
 #!/usr/bin/env bash
+printf '%s\n' "$@" > "$STUB/prompt.argv"
 printf 'PROMPT_MARKER_SIM_RECAP\n'
 SH
 
@@ -182,7 +183,8 @@ srt_reset() {
     rm -f "$STUB"/ssh.log "$STUB"/claude.log "$STUB"/claude.sentinel \
           "$STUB"/tick.out "$STUB"/agent-fails "$STUB"/agent-usage-limit \
           "$STUB"/store-fails "$STUB"/store-banner "$STUB"/resp.* "$STUB"/fail.* \
-          "$STUB"/record-stdin "$STUB"/store.cmd "$STUB"/store.stdin 2>/dev/null
+          "$STUB"/record-stdin "$STUB"/store.cmd "$STUB"/store.stdin \
+          "$STUB"/prompt.argv 2>/dev/null
     export SIM_RECAP_DB_PASSWORD="test_db_password"
     export SIM_RECAP_MYSQL_BIN="$STUB/mysql"
     unset SIM_RECAP_KEEP_WORKDIR 2>/dev/null || true
@@ -356,6 +358,11 @@ srt_log_has  "$STUB" ssh.log "recent-themes" "dry_run_touches_nothing — recent
 srt_log_lacks "$STUB" ssh.log "claim-next"    "dry_run_touches_nothing — no claim-next"
 srt_log_lacks "$STUB" ssh.log "park"          "dry_run_touches_nothing — no park"
 srt_log_lacks "$STUB" ssh.log "storeSimRecap" "dry_run_touches_nothing — no store"
+if grep -q "^--roster=" "$STUB/prompt.argv" 2>/dev/null; then
+    srt_ok "dry_run_touches_nothing — --roster=<path> passed to prompt"
+else
+    srt_fail "dry_run_touches_nothing — --roster not in prompt.argv: $(cat "$STUB/prompt.argv" 2>/dev/null)"
+fi
 
 # ── dry_run_requires_sim ──────────────────────────────────────────────────────
 srt_reset
@@ -576,6 +583,13 @@ run_prompt --sim=1 --mentions="$_FIX/mentions.json" --themes="$_FIX/themes.json"
 srt_log_has "$STUB" prompt.out "CURRENT ROSTER CONTEXT" \
     "roster_block_present — roster header appears when --roster is provided"
 
+# ── injury_attribution_directive ──────────────────────────────────────────────
+# The enrichment in SimRecapContextRepository only helps if the header tells the
+# agent that active_injuries rows carry current_teamid. Without this the field is
+# emitted into the JSON and nothing directs the agent to prefer it over from_teamid.
+srt_log_has "$STUB" prompt.out "Each row carries current_teamid" \
+    "injury_attribution_directive — active_injuries bullet names current_teamid"
+
 # ── roster_block_is_last ──────────────────────────────────────────────────────
 # Block 8 must come AFTER the exemplar (offset of CURRENT ROSTER CONTEXT > PINNED EXEMPLAR).
 _exemplar_offset=$(grep -bo "PINNED EXEMPLAR" "$STUB/prompt.out" 2>/dev/null | head -1 | cut -d: -f1)
@@ -653,6 +667,11 @@ else
     else
         srt_fail "roster_fetched_into_workdir — roster-context.json malformed: $_rc_content"
     fi
+    if grep -qF -- "--roster=$WORKDIR_PATH/roster-context.json" "$STUB/prompt.argv" 2>/dev/null; then
+        srt_ok "roster_fetched_into_workdir — --roster=<workdir> passed to prompt"
+    else
+        srt_fail "roster_fetched_into_workdir — --roster not in prompt.argv: $(cat "$STUB/prompt.argv" 2>/dev/null)"
+    fi
     rm -rf "$WORKDIR_PATH"
 fi
 unset SIM_RECAP_KEEP_WORKDIR
@@ -677,7 +696,7 @@ if [ -n "$WORKDIR_PATH" ] && [ -f "$WORKDIR_PATH/roster-context.json" ]; then
     fi
     rm -rf "$WORKDIR_PATH"
 else
-    srt_ok "negative_roster_fetch_failure_does_not_park — workdir cleaned (no keep)"
+    srt_fail "negative_roster_fetch_failure_does_not_park — workdir not found or roster-context.json missing (KEEP_WORKDIR=1 set)"
 fi
 unset SIM_RECAP_KEEP_WORKDIR
 

--- a/ibl5/classes/LastSimRecap/LastSimRecapRepository.php
+++ b/ibl5/classes/LastSimRecap/LastSimRecapRepository.php
@@ -20,6 +20,16 @@ use League\LeagueContext;
  */
 class LastSimRecapRepository extends \BaseMysqliRepository implements LastSimRecapRepositoryInterface
 {
+    /**
+     * Calendar year of a Sep-Dec transaction = season_year - 1 (season_year is
+     * the ending year per migration 106); otherwise calendar year = season_year.
+     * Aliased `t` — every consumer must alias `ibl_jsb_transactions` as `t`.
+     */
+    public const TRANSACTION_DATE_SQL = "STR_TO_DATE(CONCAT("
+        . "CASE WHEN t.transaction_month >= 9 THEN t.season_year - 1 ELSE t.season_year END,"
+        . " '-', t.transaction_month, '-', t.transaction_day"
+        . "), '%Y-%c-%e')";
+
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
@@ -148,14 +158,7 @@ class LastSimRecapRepository extends \BaseMysqliRepository implements LastSimRec
         }
 
         $placeholders = implode(',', array_fill(0, count($playerIds), '?'));
-        // Construct injury date from split year/month/day. Calendar year of
-        // an October-December transaction = season_year - 1 (season_year is
-        // the ending year per migration 106). Otherwise calendar year =
-        // season_year.
-        $dateExpr = "STR_TO_DATE(CONCAT("
-            . "CASE WHEN t.transaction_month >= 9 THEN t.season_year - 1 ELSE t.season_year END,"
-            . " '-', t.transaction_month, '-', t.transaction_day"
-            . "), '%Y-%c-%e')";
+        $dateExpr = self::TRANSACTION_DATE_SQL;
 
         // $dateExpr is a fixed SQL fragment built in-class above from column refs and
         // constants (no user input); $placeholders is a count-derived run of bound `?`

--- a/ibl5/classes/SimRecap/README.md
+++ b/ibl5/classes/SimRecap/README.md
@@ -1,11 +1,11 @@
 ---
-description: Ingests externally-generated sim recap documents and queues them for the sim recap pipeline.
-last_verified: 2026-07-25
+description: Ingests externally-generated sim recap documents and queues them for the sim recap pipeline; SimRecapContextRepository precomputes roster context for generation.
+last_verified: 2026-07-30
 ---
 
 # SimRecap
 
-Handles the ingest of externally-generated simulation recap documents into the application's pipeline. `SimRecapPayload` parses and validates incoming recap documents at the trust boundary, failing closed on structural errors. `SimSummaryRepository` implements atomic conditional-UPDATE queue logic mirroring the BugPipeline pattern to prevent duplicate processing. `SimSummariesView` renders the recap summaries for display. Entry script: `ibl5/scripts/storeSimRecap.php`.
+Handles the ingest of externally-generated simulation recap documents into the application's pipeline. `SimRecapPayload` parses and validates incoming recap documents at the trust boundary, failing closed on structural errors. `SimSummaryRepository` implements atomic conditional-UPDATE queue logic mirroring the BugPipeline pattern to prevent duplicate processing. `SimSummariesView` renders the recap summaries for display. Entry script: `ibl5/scripts/storeSimRecap.php`. The `simRecapContext.php` script precomputes current rosters, active injuries, and in-window trades via `SimRecapContextRepository`, providing roster context for the sim-recap generation pipeline.
 
 | Class | Role |
 |---|---|
@@ -13,3 +13,4 @@ Handles the ingest of externally-generated simulation recap documents into the a
 | `SimSummaryRepository` | Atomic queue operations for the recap pipeline |
 | `SimSummariesView` | Renders sim recap summaries |
 | `RecapDocument` | Assembles the postable document from intro + game rows + outro, shaped like `bin/lib/sim-recap-exemplar.txt` |
+| `SimRecapContextRepository` | Precomputes current rosters, active injuries, and in-window trades for a sim |

--- a/ibl5/classes/SimRecap/SimRecapContextRepository.php
+++ b/ibl5/classes/SimRecap/SimRecapContextRepository.php
@@ -29,7 +29,7 @@ final class SimRecapContextRepository extends \BaseMysqliRepository
      * Builds the full roster context for a sim. Fault-tolerant: an unknown or
      * window-less sim returns a well-formed empty context rather than throwing.
      *
-     * @return array{sim:int,start_date:string|null,end_date:string|null,roster:array<int,list<array{pid:int,name:string,pos:string,current_teamid:int}>>,active_injuries:list<array{pid:int,name:string,pos:string,date:string,injuryDescription:string,injuryGamesMissed:int,daysRemaining:int,returnDate:string,isNew:bool}>,sim_trades:list<array{pid:int,player_name:string|null,from_teamid:int,to_teamid:int,trade_group_id:int|null,trade_date:string}>}
+     * @return array{sim:int,start_date:string|null,end_date:string|null,roster:array<int,list<array{pid:int,name:string,pos:string,current_teamid:int}>>,active_injuries:list<array{pid:int,name:string,pos:string,date:string,injuryDescription:string,injuryGamesMissed:int,daysRemaining:int,returnDate:string,isNew:bool,current_teamid:int}>,sim_trades:list<array{pid:int,player_name:string|null,from_teamid:int,to_teamid:int,trade_group_id:int|null,trade_date:string}>}
      */
     public function buildContext(int $simId): array
     {
@@ -75,12 +75,14 @@ final class SimRecapContextRepository extends \BaseMysqliRepository
             $roster[$tid] = $lines;
         }
 
+        $rawInjuries = $this->lastSimRecap->getActiveInjuriesForPlayers($allPids, $end);
+
         return [
             'sim'             => $simId,
             'start_date'      => $start,
             'end_date'        => $end,
             'roster'          => $roster,
-            'active_injuries' => $this->lastSimRecap->getActiveInjuriesForPlayers($allPids, $end),
+            'active_injuries' => $this->enrichInjuriesWithCurrentTeam($rawInjuries, $playerMap),
             'sim_trades'      => $this->getSimTrades($start, $end),
         ];
     }
@@ -148,6 +150,28 @@ final class SimRecapContextRepository extends \BaseMysqliRepository
         );
 
         return $rows;
+    }
+
+    /**
+     * Merges current_teamid (from ibl_plr.teamid) into each injury row.
+     * The from_teamid on a TYPE_INJURY row is a frozen historical marker — it
+     * reflects which team the player was on at injury time, not now. We enrich
+     * with ibl_plr.teamid (the live value) so callers never mis-attribute a
+     * traded-and-injured player to his old team.
+     *
+     * @param list<array{pid:int,name:string,pos:string,date:string,injuryDescription:string,injuryGamesMissed:int,daysRemaining:int,returnDate:string,isNew:bool}> $injuries
+     * @param array<int,array{pid:int,name:string,pos:string,current_teamid:int}> $playerMap
+     * @return list<array{pid:int,name:string,pos:string,date:string,injuryDescription:string,injuryGamesMissed:int,daysRemaining:int,returnDate:string,isNew:bool,current_teamid:int}>
+     */
+    private function enrichInjuriesWithCurrentTeam(array $injuries, array $playerMap): array
+    {
+        $out = [];
+        foreach ($injuries as $injury) {
+            $pid = $injury['pid'];
+            $injury['current_teamid'] = isset($playerMap[$pid]) ? $playerMap[$pid]['current_teamid'] : 0;
+            $out[] = $injury;
+        }
+        return $out;
     }
 
     /**

--- a/ibl5/classes/SimRecap/SimRecapContextRepository.php
+++ b/ibl5/classes/SimRecap/SimRecapContextRepository.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimRecap;
+
+use JsbParser\TrnFileParser;
+use LastSimRecap\LastSimRecapRepository;
+use League\LeagueContext;
+
+/**
+ * Precomputes current rosters, active injuries, and in-window trades for a sim.
+ * Called prod-side via ibl5/scripts/simRecapContext.php over SSH.
+ *
+ * ADR-0093: this repository is SELECT-only and uses the read-only credential
+ * injected via db/db.php; it composes no credential of its own.
+ */
+final class SimRecapContextRepository extends \BaseMysqliRepository
+{
+    private LastSimRecapRepository $lastSimRecap;
+
+    public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null, ?LastSimRecapRepository $lastSimRecap = null)
+    {
+        parent::__construct($db, $leagueContext);
+        $this->lastSimRecap = $lastSimRecap ?? new LastSimRecapRepository($db, $leagueContext);
+    }
+
+    /**
+     * Builds the full roster context for a sim. Fault-tolerant: an unknown or
+     * window-less sim returns a well-formed empty context rather than throwing.
+     *
+     * @return array{sim:int,start_date:string|null,end_date:string|null,roster:array<int,list<array{pid:int,name:string,pos:string,current_teamid:int}>>,active_injuries:list<array{pid:int,name:string,pos:string,date:string,injuryDescription:string,injuryGamesMissed:int,daysRemaining:int,returnDate:string,isNew:bool}>,sim_trades:list<array{pid:int,player_name:string|null,from_teamid:int,to_teamid:int,trade_group_id:int|null,trade_date:string}>}
+     */
+    public function buildContext(int $simId): array
+    {
+        $window = $this->getSimWindow($simId);
+        if ($window === null) {
+            return [
+                'sim' => $simId,
+                'start_date' => null,
+                'end_date' => null,
+                'roster' => [],
+                'active_injuries' => [],
+                'sim_trades' => [],
+            ];
+        }
+
+        $start = $window['start_date'];
+        $end   = $window['end_date'];
+
+        $teamIds = $this->getTeamIdsInWindow($start, $end);
+
+        $allPids     = [];
+        $rosterByTeam = [];
+        foreach ($teamIds as $tid) {
+            $pids = $this->lastSimRecap->getTeamRosterPids($tid);
+            $allPids       = array_merge($allPids, $pids);
+            $rosterByTeam[$tid] = $pids;
+        }
+
+        $playerMap = [];
+        foreach ($this->getPlayerLines($allPids) as $player) {
+            $playerMap[$player['pid']] = $player;
+        }
+
+        /** @var array<int,list<array{pid:int,name:string,pos:string,current_teamid:int}>> $roster */
+        $roster = [];
+        foreach ($rosterByTeam as $tid => $pids) {
+            $lines = [];
+            foreach ($pids as $pid) {
+                if (isset($playerMap[$pid])) {
+                    $lines[] = $playerMap[$pid];
+                }
+            }
+            $roster[$tid] = $lines;
+        }
+
+        return [
+            'sim'             => $simId,
+            'start_date'      => $start,
+            'end_date'        => $end,
+            'roster'          => $roster,
+            'active_injuries' => $this->lastSimRecap->getActiveInjuriesForPlayers($allPids, $end),
+            'sim_trades'      => $this->getSimTrades($start, $end),
+        ];
+    }
+
+    /**
+     * @return array{start_date:string,end_date:string}|null
+     */
+    private function getSimWindow(int $simId): ?array
+    {
+        /** @var array{start_date:string|null,end_date:string|null}|null $row */
+        $row = $this->fetchOne(
+            "SELECT start_date, end_date FROM `ibl_sim_dates` WHERE sim = ?",
+            "i",
+            $simId
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        $start = $row['start_date'];
+        $end   = $row['end_date'];
+
+        // Treat '' identically to null (insertRow() cannot bind NULL, so tests seed '').
+        if ($start === null || $start === '' || $end === null || $end === '') {
+            return null;
+        }
+
+        return ['start_date' => $start, 'end_date' => $end];
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function getTeamIdsInWindow(string $start, string $end): array
+    {
+        /** @var list<array{tid:int}> $rows */
+        $rows = $this->fetchAll(
+            "SELECT DISTINCT visitor_teamid AS tid FROM `ibl_schedule`
+             WHERE game_date BETWEEN ? AND ?
+             UNION
+             SELECT DISTINCT home_teamid FROM `ibl_schedule`
+             WHERE game_date BETWEEN ? AND ?",
+            "ssss",
+            $start,
+            $end,
+            $start,
+            $end
+        );
+
+        return array_map(static fn (array $r): int => $r['tid'], $rows);
+    }
+
+    /**
+     * @param list<int> $pids
+     * @return list<array{pid:int,name:string,pos:string,current_teamid:int}>
+     */
+    private function getPlayerLines(array $pids): array
+    {
+        /** @var list<array{pid:int,name:string,pos:string,current_teamid:int}> $rows */
+        $rows = $this->fetchAllInList(
+            "SELECT pid, name, pos, teamid AS current_teamid FROM `ibl_plr` WHERE pid IN ({IN})",
+            'i',
+            $pids
+        );
+
+        return $rows;
+    }
+
+    /**
+     * @return list<array{pid:int,player_name:string|null,from_teamid:int,to_teamid:int,trade_group_id:int|null,trade_date:string}>
+     */
+    private function getSimTrades(string $start, string $end): array
+    {
+        $dateExpr = LastSimRecapRepository::TRANSACTION_DATE_SQL;
+
+        // $dateExpr is a fixed SQL fragment built from column refs and constants
+        // (no user input); concatenate rather than interpolate to satisfy the
+        // sqlStringInterpolation rule.
+        $sql = "SELECT t.pid,
+                       t.player_name,
+                       t.from_teamid,
+                       t.to_teamid,
+                       t.trade_group_id,
+                       " . $dateExpr . " AS trade_date
+                FROM `ibl_jsb_transactions` t
+                WHERE t.transaction_type = ?
+                  AND t.is_draft_pick = 0
+                  AND " . $dateExpr . " BETWEEN ? AND ?
+                ORDER BY trade_date ASC, t.trade_group_id ASC, t.id ASC";
+
+        /** @var list<array{pid:int,player_name:string|null,from_teamid:int,to_teamid:int,trade_group_id:int|null,trade_date:string}> $rows */
+        $rows = $this->fetchAll($sql, "iss", TrnFileParser::TYPE_TRADE, $start, $end);
+
+        return $rows;
+    }
+}

--- a/ibl5/docs/decisions/0093-autonomous-agent-production-read-credential.md
+++ b/ibl5/docs/decisions/0093-autonomous-agent-production-read-credential.md
@@ -1,6 +1,6 @@
 ---
 description: An unattended agent is given a production-reaching credential safely by starving it to one SELECT-only MySQL user over an SSH tunnel while every privileged write happens prod-side behind a CLI guard.
-last_verified: 2026-07-23
+last_verified: 2026-07-30
 ---
 
 # ADR-0093: An autonomous agent holding a production read-only credential
@@ -47,7 +47,10 @@ The agent is made **incapable by construction**, not trusted to behave. Four str
 - `bin/sim-recap-cron-setup` — the launchd generator that injects the one credential and ships no `.plist`.
 - `bin/test-sim-recap-tick` — the harness carrying the zero-`claude`-on-empty-tick invariant.
 - `ibl5/scripts/simRecapQueue.php`, `ibl5/scripts/storeSimRecap.php`, `ibl5/scripts/.htaccess` — the prod-side privileged entry points and their web deny.
+- `ibl5/scripts/simRecapContext.php` — the third prod-side CLI entry point; precomputes current rosters, active injuries, and in-window trades with the same SELECT-only credential; same PHP_SAPI guard and .htaccess scoped deny.
 - `ibl5/tests/WideUnit/Scripts/SimRecapQueueGuardTest.php` — source-content guard for the CLI guard, `.htaccess` scoping, and the string-cast-on-snowflakes property.
+- `ibl5/tests/WideUnit/Scripts/SimRecapContextGuardTest.php` — source-content guard for simRecapContext.php's CLI guard, .htaccess scoping, and no-credential-in-argv/env properties.
 - `ibl5/classes/SimRecap/SimSummaryRepository.php` — the frozen queue primitives the CLI exposes.
+- `ibl5/classes/SimRecap/SimRecapContextRepository.php` — the SELECT-only repository that precomputes the context emitted by simRecapContext.php.
 - `ibl5/docs/decisions/0080-mac-local-discord-bug-pipeline-cron-topology.md`, `ibl5/docs/decisions/0081-hunter-trust-split-starved-env-sandbox.md` — the prior-art topology and trust split this ADR extends to a production-reaching agent.
 - `ibl5/docs/decisions/0062-all-work-in-worktrees.md`, `ibl5/docs/decisions/0046-worktrees-outside-repo.md` — why property 4's temp working dir enforces the read-only checkout, and why the generated plist points at the main checkout.

--- a/ibl5/scripts/.htaccess
+++ b/ibl5/scripts/.htaccess
@@ -16,3 +16,11 @@
 <Files "simRecapQueue.php">
     Require all denied
 </Files>
+
+# simRecapContext.php is a third privileged CLI-only entry point (reads rosters,
+# injuries and trades with production credentials) and is invoked only as
+# `php ibl5/scripts/simRecapContext.php --sim=N`. Same file-scoped deny; the
+# PHP_SAPI guard in the script is the real control (security constraint 4).
+<Files "simRecapContext.php">
+    Require all denied
+</Files>

--- a/ibl5/scripts/simRecapContext.php
+++ b/ibl5/scripts/simRecapContext.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CLI-only roster-context precompute for the sim-recap pipeline.
+ *
+ * Usage: php ibl5/scripts/simRecapContext.php --sim=N
+ *   Emits one JSON object on stdout containing current rosters, active injuries,
+ *   and in-window trades for the given sim. A bad argv writes an error to stderr
+ *   and exits 1 before any repo is built.
+ *
+ * ADR-0093 trust boundary: this script is the prod-side half — it holds the
+ * SELECT-only credential via db/db.php (injected into MYSQL_PWD by the calling
+ * environment) and is invoked over SSH. It accepts NO credential flag, reads NO
+ * credential env var, and hardcodes nothing. The Mac-side tick calls this script
+ * via SSH and never holds the password itself.
+ *
+ * Protected by both the PHP_SAPI guard below (the first executable statement)
+ * and an ibl5/scripts/.htaccess scoped deny.
+ */
+
+// ── CLI-only guard — must stay the FIRST executable statement: a web hit must
+//    be refused before any resource (autoload, config, db) is touched.
+if (PHP_SAPI !== 'cli') {
+    http_response_code(403);
+    exit('This script is CLI-only.');
+}
+
+// ── Minimal bootstrap (mirrors scripts/simRecapQueue.php) ─────────────────────
+$_SERVER['PHP_SELF'] = 'simRecapContext';
+$_SERVER['SERVER_NAME'] = 'localhost';
+$_SERVER['SCRIPT_FILENAME'] = __FILE__;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+// Worktree fix: vendor/ symlinks to the main repo, so PSR-4 resolves classes/
+// there; register the local classes/ dir so this worktree's code is used.
+$localClassesDir = realpath(__DIR__ . '/../classes');
+if ($localClassesDir !== false) {
+    spl_autoload_register(static function (string $class) use ($localClassesDir): void {
+        $path = $localClassesDir . '/' . str_replace('\\', '/', $class) . '.php';
+        if (file_exists($path)) {
+            require_once $path;
+        }
+    });
+}
+
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../db/db.php';
+
+/** @var \mysqli $mysqli_db */
+
+function fail(string $msg): never
+{
+    fwrite(STDERR, "simRecapContext: {$msg}\n");
+    exit(1);
+}
+
+// ── Argv parse ────────────────────────────────────────────────────────────────
+$simRaw = null;
+foreach (array_slice($argv, 1) as $arg) {
+    if (!is_string($arg)) {
+        continue;
+    }
+    if (str_starts_with($arg, '--sim=')) {
+        $simRaw = substr($arg, 6);
+    } else {
+        fail("unexpected argument: {$arg}");
+    }
+}
+
+if ($simRaw === null || !ctype_digit($simRaw)) {
+    fail('--sim=N (positive integer) is required');
+}
+
+$sim = (int) $simRaw;
+if ($sim < 1) {
+    fail('--sim must be >= 1');
+}
+
+// ── Build and emit context ────────────────────────────────────────────────────
+$repo = new \SimRecap\SimRecapContextRepository($mysqli_db);
+echo json_encode($repo->buildContext($sim)), "\n";
+exit(0);

--- a/ibl5/tests/DatabaseIntegration/SimRecap/SimRecapContextCliTest.php
+++ b/ibl5/tests/DatabaseIntegration/SimRecap/SimRecapContextCliTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\SimRecap;
+
+use PHPUnit\Framework\Attributes\Group;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+
+/**
+ * Database integration test for scripts/simRecapContext.php.
+ *
+ * Launches the script as a real child process so the full path through
+ * argv-parse → buildContext → JSON stdout is exercised against a live database.
+ *
+ * Tests the unknown-sim (999999) path: no fixtures are required, the script
+ * must exit 0 and emit a well-formed six-key JSON object.  DatabaseTestCase's
+ * begin_transaction/rollback isolation is sufficient — no autocommit switch
+ * is needed because no fixtures are committed for child visibility.
+ */
+#[Group('database')]
+final class SimRecapContextCliTest extends DatabaseTestCase
+{
+    private string $scriptPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $path = realpath(__DIR__ . '/../../../scripts/simRecapContext.php');
+        self::assertNotFalse($path, 'simRecapContext.php must exist at the expected path');
+        $this->scriptPath = $path;
+    }
+
+    // ── Tests ──────────────────────────────────────────────────────────────────
+
+    /**
+     * An unknown sim exits 0 and emits a well-formed JSON object containing
+     * all six expected keys.  This exercises the fault-tolerance path of
+     * buildContext() (unknown sim → empty context, no throw).
+     */
+    public function testUnknownSimExitsZeroWithWellFormedSixKeyJson(): void
+    {
+        $result = $this->runScript(['--sim=999999']);
+
+        self::assertSame(0, $result['exit_code'],
+            'exit 0 expected for unknown sim (fault-tolerance — never throws)');
+
+        $json = json_decode($result['stdout'], true);
+        self::assertIsArray($json,
+            'stdout must be valid JSON; got: ' . $result['stdout']);
+
+        foreach (['sim', 'start_date', 'end_date', 'roster', 'active_injuries', 'sim_trades'] as $key) {
+            self::assertArrayHasKey($key, $json,
+                "JSON must contain key: {$key}");
+        }
+
+        self::assertSame(999999, $json['sim'],
+            'sim key must echo the requested sim number');
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Launch simRecapContext.php as a child process via a bootstrap tmpfile.
+     *
+     * The bootstrap prepends define('PHPUNIT_RUNNING', true) before requiring
+     * the script, mirroring the pattern established in StoreSimRecapCliTest.
+     * Using a tmpfile keeps $argv indexing predictable (no json_encode escaping
+     * that php -r introduces).
+     *
+     * @param list<string> $argv Arguments forwarded to the script (e.g. ['--sim=999999'])
+     * @return array{exit_code: int, stdout: string, stderr: string}
+     */
+    private function runScript(array $argv): array
+    {
+        $bootstrapFile = tempnam(sys_get_temp_dir(), 'sim-recap-ctx-bootstrap-');
+        if ($bootstrapFile === false) {
+            self::fail('tempnam must succeed');
+        }
+
+        $bootstrapContent = '<?php' . "\n"
+            . "define('PHPUNIT_RUNNING', true);\n"
+            . 'require ' . var_export($this->scriptPath, true) . ";\n";
+
+        try {
+            if (file_put_contents($bootstrapFile, $bootstrapContent) === false) {
+                self::fail('Failed to write bootstrap file');
+            }
+
+            $envVars = getenv();
+            $env = is_array($envVars) ? $envVars : [];
+
+            $command = array_merge([PHP_BINARY, $bootstrapFile], $argv);
+
+            $descriptors = [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ];
+
+            $process = proc_open($command, $descriptors, $pipes, null, $env);
+            if ($process === false) {
+                self::fail('proc_open failed to launch the child process');
+            }
+
+            fclose($pipes[0]);
+
+            $stdout = stream_get_contents($pipes[1]);
+            $stderr = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+
+            $exitCode = proc_close($process);
+
+            return [
+                'exit_code' => $exitCode,
+                'stdout'    => is_string($stdout) ? $stdout : '',
+                'stderr'    => is_string($stderr) ? $stderr : '',
+            ];
+        } finally {
+            @unlink($bootstrapFile);
+        }
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/SimRecap/SimRecapContextRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/SimRecap/SimRecapContextRepositoryTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\SimRecap;
+
+use JsbParser\TrnFileParser;
+use PHPUnit\Framework\Attributes\Group;
+use SimRecap\SimRecapContextRepository;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+
+#[Group('database')]
+final class SimRecapContextRepositoryTest extends DatabaseTestCase
+{
+    private SimRecapContextRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new SimRecapContextRepository($this->db);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    private function seedSim(int $sim, string $start, string $end): void
+    {
+        $this->insertRow('ibl_sim_dates', [
+            'sim'        => $sim,
+            'start_date' => $start,
+            'end_date'   => $end,
+        ]);
+    }
+
+    // ── Tests ──────────────────────────────────────────────────────────────────
+
+    public function testBuildContextRosterContainsPlayersForTeamsInWindow(): void
+    {
+        $this->seedSim(999001, '2026-01-01', '2026-01-07');
+        $this->insertScheduleRow(2026, '2026-01-05', 11, 100, 12, 90);
+        $this->insertTestPlayer(999001, 'Player One', ['teamid' => 11, 'pos' => 'PG']);
+
+        $ctx = $this->repo->buildContext(999001);
+
+        self::assertSame(999001, $ctx['sim']);
+        self::assertSame('2026-01-01', $ctx['start_date']);
+        self::assertSame('2026-01-07', $ctx['end_date']);
+        self::assertArrayHasKey(11, $ctx['roster']);
+
+        $team11 = $ctx['roster'][11];
+        $pids = array_column($team11, 'pid');
+        self::assertContains(999001, $pids);
+
+        $player = $team11[array_search(999001, $pids, true)];
+        self::assertSame('Player One', $player['name']);
+        self::assertSame('PG', $player['pos']);
+        self::assertSame(11, $player['current_teamid']);
+    }
+
+    public function testBuildContextReturnsActiveInjuryInWindow(): void
+    {
+        $this->seedSim(999002, '2026-01-01', '2026-01-07');
+        $this->insertScheduleRow(2026, '2026-01-05', 11, 100, 12, 90);
+        $this->insertTestPlayer(999002, 'Injured Player', ['teamid' => 11]);
+
+        // Injury on 2026-01-03, 20 games missed → still active on 2026-01-07
+        $this->insertRow('ibl_jsb_transactions', [
+            'season_year'          => 2026,
+            'transaction_month'    => 1,
+            'transaction_day'      => 3,
+            'transaction_type'     => TrnFileParser::TYPE_INJURY,
+            'pid'                  => 999002,
+            'injury_games_missed'  => 20,
+            'injury_description'   => 'Knee',
+        ]);
+
+        $ctx = $this->repo->buildContext(999002);
+
+        self::assertNotEmpty($ctx['active_injuries']);
+        $pids = array_column($ctx['active_injuries'], 'pid');
+        self::assertContains(999002, $pids);
+    }
+
+    public function testBuildContextReturnsTradesInWindow(): void
+    {
+        $this->seedSim(999003, '2026-01-01', '2026-01-07');
+        $this->insertScheduleRow(2026, '2026-01-05', 11, 100, 12, 90);
+        $this->insertTestPlayer(999003, 'Trade Player', ['teamid' => 11]);
+
+        // Trade on 2026-01-04 (within window)
+        $this->insertRow('ibl_jsb_transactions', [
+            'season_year'       => 2026,
+            'transaction_month' => 1,
+            'transaction_day'   => 4,
+            'transaction_type'  => TrnFileParser::TYPE_TRADE,
+            'pid'               => 999003,
+            'from_teamid'       => 5,
+            'to_teamid'         => 11,
+            'is_draft_pick'     => 0,
+        ]);
+
+        $ctx = $this->repo->buildContext(999003);
+
+        self::assertCount(1, $ctx['sim_trades']);
+        self::assertSame(999003, $ctx['sim_trades'][0]['pid']);
+        self::assertSame('2026-01-04', $ctx['sim_trades'][0]['trade_date']);
+    }
+
+    public function testBuildContextExcludesTradesOutsideWindow(): void
+    {
+        $this->seedSim(999004, '2026-01-01', '2026-01-07');
+        $this->insertScheduleRow(2026, '2026-01-05', 11, 100, 12, 90);
+
+        // Trade on 2026-01-15 (outside window)
+        $this->insertRow('ibl_jsb_transactions', [
+            'season_year'       => 2026,
+            'transaction_month' => 1,
+            'transaction_day'   => 15,
+            'transaction_type'  => TrnFileParser::TYPE_TRADE,
+            'pid'               => 999004,
+            'is_draft_pick'     => 0,
+        ]);
+
+        $ctx = $this->repo->buildContext(999004);
+
+        self::assertSame([], $ctx['sim_trades']);
+    }
+
+    public function testUnknownSimReturnsWellFormedEmptyContext(): void
+    {
+        $ctx = $this->repo->buildContext(999999);
+
+        self::assertSame(999999, $ctx['sim']);
+        self::assertNull($ctx['start_date']);
+        self::assertNull($ctx['end_date']);
+        self::assertSame([], $ctx['roster']);
+        self::assertSame([], $ctx['active_injuries']);
+        self::assertSame([], $ctx['sim_trades']);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/SimRecap/SimRecapContextRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/SimRecap/SimRecapContextRepositoryTest.php
@@ -22,6 +22,15 @@ final class SimRecapContextRepositoryTest extends DatabaseTestCase
 
     // ── Helpers ────────────────────────────────────────────────────────────────
 
+    private function seedTeam(int $teamid, string $city, string $name): void
+    {
+        $this->insertRow('ibl_team_info', [
+            'teamid'    => $teamid,
+            'team_city' => $city,
+            'team_name' => $name,
+        ]);
+    }
+
     private function seedSim(int $sim, string $start, string $end): void
     {
         $this->insertRow('ibl_sim_dates', [
@@ -33,99 +42,256 @@ final class SimRecapContextRepositoryTest extends DatabaseTestCase
 
     // ── Tests ──────────────────────────────────────────────────────────────────
 
-    public function testBuildContextRosterContainsPlayersForTeamsInWindow(): void
+    /**
+     * Headline bug: a player injured on team A then traded A→B→C must appear
+     * in active_injuries with current_teamid = C (ibl_plr.teamid), not A
+     * (the from_teamid frozen in the TYPE_INJURY row at injury time).
+     */
+    public function testInjuredThenTradedPlayerIsAttributedToHisCurrentTeam(): void
     {
+        $this->seedTeam(999001, 'Ayes City', 'Ayes');
+        $this->seedTeam(999002, 'Bees City', 'Bees');
+        $this->seedTeam(999003, 'Cees City', 'Cees');
         $this->seedSim(999001, '2026-01-01', '2026-01-07');
-        $this->insertScheduleRow(2026, '2026-01-05', 11, 100, 12, 90);
-        $this->insertTestPlayer(999001, 'Player One', ['teamid' => 11, 'pos' => 'PG']);
+        $this->insertScheduleRow(2026, '2026-01-03', 999001, 110, 999002, 105);
+        $this->insertScheduleRow(2026, '2026-01-03', 999002, 98, 999003, 102);
+        // Player's current team (ibl_plr.teamid) is team C (999003) after both trades
+        $this->insertTestPlayer(999001, 'Kobe Player', ['teamid' => 999003, 'pos' => 'SG']);
+        // TYPE_INJURY: from_teamid=999001 is the frozen historical marker (team A at injury time)
+        $this->insertRow('ibl_jsb_transactions', [
+            'season_year'         => 2026,
+            'transaction_month'   => 1,
+            'transaction_day'     => 2,
+            'transaction_type'    => TrnFileParser::TYPE_INJURY,
+            'pid'                 => 999001,
+            'from_teamid'         => 999001,
+            'injury_games_missed' => 30,
+            'injury_description'  => 'Knee',
+        ]);
+        // Trade A→B
+        $this->insertRow('ibl_jsb_transactions', [
+            'season_year'       => 2026,
+            'transaction_month' => 1,
+            'transaction_day'   => 3,
+            'transaction_type'  => TrnFileParser::TYPE_TRADE,
+            'pid'               => 999001,
+            'from_teamid'       => 999001,
+            'to_teamid'         => 999002,
+            'is_draft_pick'     => 0,
+        ]);
+        // Trade B→C
+        $this->insertRow('ibl_jsb_transactions', [
+            'season_year'       => 2026,
+            'transaction_month' => 1,
+            'transaction_day'   => 3,
+            'transaction_type'  => TrnFileParser::TYPE_TRADE,
+            'pid'               => 999001,
+            'from_teamid'       => 999002,
+            'to_teamid'         => 999003,
+            'is_draft_pick'     => 0,
+        ]);
 
         $ctx = $this->repo->buildContext(999001);
 
-        self::assertSame(999001, $ctx['sim']);
-        self::assertSame('2026-01-01', $ctx['start_date']);
-        self::assertSame('2026-01-07', $ctx['end_date']);
-        self::assertArrayHasKey(11, $ctx['roster']);
+        // Roster: player must appear under team C (999003), not A (999001)
+        $rosterPids = array_column($ctx['roster'][999003] ?? [], 'pid');
+        self::assertContains(999001, $rosterPids,
+            'Player must be in roster[999003] (current team C)');
+        foreach ($ctx['roster'][999003] ?? [] as $entry) {
+            if ($entry['pid'] === 999001) {
+                self::assertSame(999003, $entry['current_teamid'],
+                    'Roster entry current_teamid must be 999003 (ibl_plr.teamid)');
+                self::assertNotSame(999001, $entry['current_teamid'],
+                    'Roster entry current_teamid must not equal from_teamid (999001)');
+            }
+        }
 
-        $team11 = $ctx['roster'][11];
-        $pids = array_column($team11, 'pid');
-        self::assertContains(999001, $pids);
-
-        $player = $team11[array_search(999001, $pids, true)];
-        self::assertSame('Player One', $player['name']);
-        self::assertSame('PG', $player['pos']);
-        self::assertSame(11, $player['current_teamid']);
+        // active_injuries: injury must still be active, attributed to current team C
+        $injuryPids = array_column($ctx['active_injuries'], 'pid');
+        self::assertContains(999001, $injuryPids,
+            'Injury must still be present in active_injuries');
+        foreach ($ctx['active_injuries'] as $injury) {
+            if ($injury['pid'] === 999001) {
+                self::assertSame(999003, $injury['current_teamid'],
+                    'active_injuries current_teamid must be 999003 (ibl_plr.teamid)');
+                self::assertNotSame(999001, $injury['current_teamid'],
+                    'active_injuries current_teamid must not equal from_teamid (999001)');
+            }
+        }
     }
 
-    public function testBuildContextReturnsActiveInjuryInWindow(): void
+    /**
+     * A player who was never traded keeps his original team in both roster and
+     * active_injuries, and must not appear in sim_trades.
+     */
+    public function testNeverTradedInjuredPlayerKeepsHisTeamAndInjury(): void
     {
+        $this->seedTeam(999001, 'Ayes City', 'Ayes');
         $this->seedSim(999002, '2026-01-01', '2026-01-07');
-        $this->insertScheduleRow(2026, '2026-01-05', 11, 100, 12, 90);
-        $this->insertTestPlayer(999002, 'Injured Player', ['teamid' => 11]);
-
-        // Injury on 2026-01-03, 20 games missed → still active on 2026-01-07
+        $this->insertScheduleRow(2026, '2026-01-03', 999001, 100, 999001, 90);
+        $this->insertTestPlayer(999002, 'Steady Player', ['teamid' => 999001, 'pos' => 'PF']);
         $this->insertRow('ibl_jsb_transactions', [
-            'season_year'          => 2026,
-            'transaction_month'    => 1,
-            'transaction_day'      => 3,
-            'transaction_type'     => TrnFileParser::TYPE_INJURY,
-            'pid'                  => 999002,
-            'injury_games_missed'  => 20,
-            'injury_description'   => 'Knee',
+            'season_year'         => 2026,
+            'transaction_month'   => 1,
+            'transaction_day'     => 2,
+            'transaction_type'    => TrnFileParser::TYPE_INJURY,
+            'pid'                 => 999002,
+            'from_teamid'         => 999001,
+            'injury_games_missed' => 20,
+            'injury_description'  => 'Ankle',
         ]);
 
         $ctx = $this->repo->buildContext(999002);
 
-        self::assertNotEmpty($ctx['active_injuries']);
-        $pids = array_column($ctx['active_injuries'], 'pid');
-        self::assertContains(999002, $pids);
+        $rosterPids = array_column($ctx['roster'][999001] ?? [], 'pid');
+        self::assertContains(999002, $rosterPids,
+            'Never-traded player must be in roster[999001]');
+
+        $injuryPids = array_column($ctx['active_injuries'], 'pid');
+        self::assertContains(999002, $injuryPids,
+            'active_injuries must contain the player');
+        foreach ($ctx['active_injuries'] as $injury) {
+            if ($injury['pid'] === 999002) {
+                self::assertSame(999001, $injury['current_teamid'],
+                    'active_injuries current_teamid must match ibl_plr.teamid (999001)');
+            }
+        }
+
+        $tradePids = array_column($ctx['sim_trades'], 'pid');
+        self::assertNotContains(999002, $tradePids,
+            'Never-traded player must be absent from sim_trades');
     }
 
-    public function testBuildContextReturnsTradesInWindow(): void
+    /**
+     * TRANSACTION_DATE_SQL boundary: a Sep–Dec transaction_month uses season_year-1
+     * as the calendar year. A season_year=2025, month=11 injury maps to calendar
+     * date 2024-11, so it appears in a 2024-11 window but not a 2025-11 window.
+     */
+    public function testSeptemberToDecemberInjuryUsesSeasonYearMinusOne(): void
     {
-        $this->seedSim(999003, '2026-01-01', '2026-01-07');
-        $this->insertScheduleRow(2026, '2026-01-05', 11, 100, 12, 90);
-        $this->insertTestPlayer(999003, 'Trade Player', ['teamid' => 11]);
+        $this->seedTeam(999001, 'Ayes City', 'Ayes');
+        // Sim A: 2024-11 window — injury must appear
+        $this->seedSim(999003, '2024-11-01', '2024-11-30');
+        $this->insertScheduleRow(2025, '2024-11-15', 999001, 100, 999001, 95);
+        // Sim B: 2025-11 window — same injury row must NOT appear
+        $this->seedSim(999004, '2025-11-01', '2025-11-30');
+        $this->insertScheduleRow(2026, '2025-11-15', 999001, 100, 999001, 95);
 
-        // Trade on 2026-01-04 (within window)
+        $this->insertTestPlayer(999003, 'Nov Player', ['teamid' => 999001, 'pos' => 'C']);
+        // season_year=2025, month=11 → TRANSACTION_DATE_SQL → calendar 2024-11-10
+        // injury_games_missed=30 → active through 2024-12-10 > 2024-11-30 (in window A)
+        // but NOT active relative to 2025-11-30 (2024-12-10 < 2025-11-30, expired)
+        $this->insertRow('ibl_jsb_transactions', [
+            'season_year'         => 2025,
+            'transaction_month'   => 11,
+            'transaction_day'     => 10,
+            'transaction_type'    => TrnFileParser::TYPE_INJURY,
+            'pid'                 => 999003,
+            'from_teamid'         => 999001,
+            'injury_games_missed' => 30,
+            'injury_description'  => 'Back',
+        ]);
+
+        // Positive: 2024-11 window — injury must appear
+        $ctxA = $this->repo->buildContext(999003);
+        $injuryPidsA = array_column($ctxA['active_injuries'], 'pid');
+        self::assertContains(999003, $injuryPidsA,
+            'Nov injury (season_year=2025) must appear in 2024-11 window');
+        foreach ($ctxA['active_injuries'] as $injury) {
+            if ($injury['pid'] === 999003) {
+                self::assertStringStartsWith('2024-11', $injury['date'],
+                    'Injury date must be in 2024-11 (season_year - 1)');
+            }
+        }
+
+        // Negative: 2025-11 window — same injury must NOT appear
+        $ctxB = $this->repo->buildContext(999004);
+        $injuryPidsB = array_column($ctxB['active_injuries'], 'pid');
+        self::assertNotContains(999003, $injuryPidsB,
+            'Nov injury (calendar 2024-11) must be absent from 2025-11 window');
+    }
+
+    /**
+     * Only trades whose calendar date falls inside [start, end] appear in sim_trades.
+     * Per-pid membership assertions used rather than assertCount or exact-set checks
+     * to avoid flakiness from pre-existing rows in the shared DB.
+     */
+    public function testOnlyTradesInsideTheSimWindowAreEmitted(): void
+    {
+        $this->seedTeam(999001, 'Ayes City', 'Ayes');
+        $this->seedTeam(999002, 'Bees City', 'Bees');
+        $this->seedSim(999005, '2026-01-01', '2026-01-07');
+        $this->insertScheduleRow(2026, '2026-01-04', 999001, 105, 999002, 98);
+        $this->insertTestPlayer(999010, 'Inside Player', ['teamid' => 999001, 'pos' => 'PG']);
+        $this->insertTestPlayer(999011, 'Before Player', ['teamid' => 999001, 'pos' => 'SG']);
+        $this->insertTestPlayer(999012, 'After Player',  ['teamid' => 999002, 'pos' => 'SF']);
+
+        // Inside window: season_year=2026, month=1, day=4 → calendar 2026-01-04
         $this->insertRow('ibl_jsb_transactions', [
             'season_year'       => 2026,
             'transaction_month' => 1,
             'transaction_day'   => 4,
             'transaction_type'  => TrnFileParser::TYPE_TRADE,
-            'pid'               => 999003,
-            'from_teamid'       => 5,
-            'to_teamid'         => 11,
+            'pid'               => 999010,
+            'from_teamid'       => 999001,
+            'to_teamid'         => 999002,
             'is_draft_pick'     => 0,
         ]);
-
-        $ctx = $this->repo->buildContext(999003);
-
-        self::assertCount(1, $ctx['sim_trades']);
-        self::assertSame(999003, $ctx['sim_trades'][0]['pid']);
-        self::assertSame('2026-01-04', $ctx['sim_trades'][0]['trade_date']);
-    }
-
-    public function testBuildContextExcludesTradesOutsideWindow(): void
-    {
-        $this->seedSim(999004, '2026-01-01', '2026-01-07');
-        $this->insertScheduleRow(2026, '2026-01-05', 11, 100, 12, 90);
-
-        // Trade on 2026-01-15 (outside window)
+        // Before window: season_year=2026, month=12, day=28
+        // → TRANSACTION_DATE_SQL: month >= 9 → calendar year = 2026 - 1 = 2025
+        // → calendar 2025-12-28 (before 2026-01-01 window start)
+        $this->insertRow('ibl_jsb_transactions', [
+            'season_year'       => 2026,
+            'transaction_month' => 12,
+            'transaction_day'   => 28,
+            'transaction_type'  => TrnFileParser::TYPE_TRADE,
+            'pid'               => 999011,
+            'from_teamid'       => 999001,
+            'to_teamid'         => 999002,
+            'is_draft_pick'     => 0,
+        ]);
+        // After window: season_year=2026, month=1, day=15 → calendar 2026-01-15
         $this->insertRow('ibl_jsb_transactions', [
             'season_year'       => 2026,
             'transaction_month' => 1,
             'transaction_day'   => 15,
             'transaction_type'  => TrnFileParser::TYPE_TRADE,
-            'pid'               => 999004,
+            'pid'               => 999012,
+            'from_teamid'       => 999002,
+            'to_teamid'         => 999001,
             'is_draft_pick'     => 0,
         ]);
+        // Draft-pick row inside window: is_draft_pick=1 means pid is a pick id, not a player;
+        // the getSimTrades() predicate (is_draft_pick = 0) must exclude this row.
+        $this->insertRow('ibl_jsb_transactions', [
+            'season_year'       => 2026,
+            'transaction_month' => 1,
+            'transaction_day'   => 5,
+            'transaction_type'  => TrnFileParser::TYPE_TRADE,
+            'pid'               => 999013,
+            'from_teamid'       => 999001,
+            'to_teamid'         => 999002,
+            'is_draft_pick'     => 1,
+        ]);
 
-        $ctx = $this->repo->buildContext(999004);
+        $ctx = $this->repo->buildContext(999005);
+        $tradePids = array_column($ctx['sim_trades'], 'pid');
 
-        self::assertSame([], $ctx['sim_trades']);
+        self::assertContains(999010, $tradePids,
+            'Inside-window trade (2026-01-04) must appear in sim_trades');
+        self::assertNotContains(999011, $tradePids,
+            'Before-window trade (calendar 2025-12-28) must be absent from sim_trades');
+        self::assertNotContains(999012, $tradePids,
+            'After-window trade (2026-01-15) must be absent from sim_trades');
+        self::assertNotContains(999013, $tradePids,
+            'Draft-pick row (is_draft_pick=1) inside window must be absent from sim_trades');
     }
 
-    public function testUnknownSimReturnsWellFormedEmptyContext(): void
+    /**
+     * An unknown sim ID returns a well-formed six-key context with empty
+     * collections rather than throwing.
+     */
+    public function testUnknownSimReturnsWellFormedEmptyContextWithoutThrowing(): void
     {
         $ctx = $this->repo->buildContext(999999);
 

--- a/ibl5/tests/DatabaseIntegration/SimRecap/SimSummaryRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/SimRecap/SimSummaryRepositoryTest.php
@@ -405,6 +405,59 @@ final class SimSummaryRepositoryTest extends DatabaseTestCase
         self::assertSame([], $displayable, 'No box score match → no displayable game recaps');
     }
 
+    public function testFindDisplayableGameRecapsSingleGameDaySurvives(): void
+    {
+        $game = $this->gameRecap(sortOrder: 0, gameOfThatDay: 1);
+        $this->repo->markDone(999090, 'Intro.', 'Outro.', 'Recap.', [$game], null);
+
+        $this->db->query(
+            "INSERT INTO `ibl_box_scores_teams` (`game_date`, `visitor_teamid`, `home_teamid`, `game_of_that_day`, `name`)" .
+            " VALUES ('2025-01-01', 1, 2, 1, 'Metros')"
+        );
+
+        $displayable = $this->repo->findDisplayableGameRecaps(999090);
+
+        self::assertCount(1, $displayable, 'Single game with gotd=1 must be returned');
+        self::assertSame(1, $displayable[0]['game_of_that_day']);
+    }
+
+    public function testFindDisplayableGameRecapsDoubleheaderBothReturned(): void
+    {
+        $games = [
+            $this->gameRecap(sortOrder: 0, gameOfThatDay: 1),
+            $this->gameRecap(sortOrder: 1, gameOfThatDay: 2),
+        ];
+        $this->repo->markDone(999091, 'Intro.', 'Outro.', 'Recap.', $games, null);
+
+        $this->db->query(
+            "INSERT INTO `ibl_box_scores_teams` (`game_date`, `visitor_teamid`, `home_teamid`, `game_of_that_day`, `name`)" .
+            " VALUES ('2025-01-01', 1, 2, 1, 'Metros'), ('2025-01-01', 1, 2, 2, 'Stars')"
+        );
+
+        $displayable = $this->repo->findDisplayableGameRecaps(999091);
+
+        self::assertCount(2, $displayable, 'Doubleheader: both games must be returned');
+        self::assertSame(1, $displayable[0]['game_of_that_day']);
+        self::assertSame(2, $displayable[1]['game_of_that_day']);
+    }
+
+    public function testFindDisplayableGameRecapsMismatchDropped(): void
+    {
+        // A recap with game_of_that_day=0 (the old wrong value) must be dropped
+        // when the box score has game_of_that_day=1.
+        $game = $this->gameRecap(sortOrder: 0, gameOfThatDay: 0);
+        $this->repo->markDone(999092, 'Intro.', 'Outro.', 'Recap.', [$game], null);
+
+        $this->db->query(
+            "INSERT INTO `ibl_box_scores_teams` (`game_date`, `visitor_teamid`, `home_teamid`, `game_of_that_day`, `name`)" .
+            " VALUES ('2025-01-01', 1, 2, 1, 'Metros')"
+        );
+
+        $displayable = $this->repo->findDisplayableGameRecaps(999092);
+
+        self::assertSame([], $displayable, 'gotd=0 recap must not match a gotd=1 box score');
+    }
+
     // ── Private helpers ────────────────────────────────────────────────────────
 
     /**

--- a/ibl5/tests/WideUnit/Scripts/SimRecapContextGuardTest.php
+++ b/ibl5/tests/WideUnit/Scripts/SimRecapContextGuardTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\WideUnit\Scripts;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Source-content guard tests for the prod-side roster-context CLI. Mirrors
+ * SimRecapQueueGuardTest: it asserts on the script's SOURCE and never shells
+ * out to the real script, because a real run happens outside PHPUnit (so the
+ * isPhpUnit short-circuits do not engage) and could fire live side effects.
+ */
+final class SimRecapContextGuardTest extends TestCase
+{
+    private string $src;
+
+    protected function setUp(): void
+    {
+        $this->src = (string) file_get_contents(__DIR__ . '/../../../scripts/simRecapContext.php');
+    }
+
+    // ── Script guard tests ─────────────────────────────────────────────────────
+
+    public function testGuardIsPresent(): void
+    {
+        self::assertTrue(str_contains($this->src, "PHP_SAPI !== 'cli'"));
+    }
+
+    public function testGuardIsTheFirstExecutableStatement(): void
+    {
+        $guardPos = strpos($this->src, "PHP_SAPI !== 'cli'");
+        self::assertNotFalse($guardPos);
+
+        $requirePos = strpos($this->src, 'require_once');
+        self::assertNotFalse($requirePos);
+
+        $newPos = strpos($this->src, 'new ');
+        self::assertNotFalse($newPos);
+
+        self::assertLessThan($requirePos, $guardPos, 'SAPI guard must appear before any require_once');
+        self::assertLessThan($newPos, $guardPos, 'SAPI guard must appear before any object construction');
+    }
+
+    public function testGuardReturns403(): void
+    {
+        self::assertTrue(str_contains($this->src, 'http_response_code(403)'));
+    }
+
+    public function testScriptComposesNoSql(): void
+    {
+        self::assertSame(0, preg_match('/SELECT /i', $this->src), 'Script must not compose SELECT');
+        self::assertSame(0, preg_match('/INSERT /i', $this->src), 'Script must not compose INSERT');
+        self::assertSame(0, preg_match('/UPDATE /i', $this->src), 'Script must not compose UPDATE');
+        self::assertSame(0, preg_match('/DELETE /i', $this->src), 'Script must not compose DELETE');
+    }
+
+    public function testScriptCastsOnlyTheSimArgument(): void
+    {
+        self::assertSame(1, substr_count($this->src, '(int)'), 'Exactly one (int) cast expected (only --sim)');
+    }
+
+    public function testScriptTakesNoCredentialFromArgvOrEnv(): void
+    {
+        self::assertSame(
+            0,
+            preg_match('/--(password|passwd|user|db[-_]?pass)/i', $this->src),
+            'Script must not accept a credential flag'
+        );
+        self::assertFalse(
+            str_contains($this->src, 'SIM_RECAP_DB_'),
+            'Script must not read SIM_RECAP_DB_* env vars'
+        );
+        self::assertSame(
+            0,
+            preg_match('/getenv\s*\(/', $this->src),
+            'Script must not call getenv()'
+        );
+    }
+
+    public function testScriptOpensNoConnectionOfItsOwn(): void
+    {
+        self::assertSame(
+            0,
+            preg_match('/new\s+\\\\?mysqli\s*\(/', $this->src),
+            'Script must not open its own mysqli connection'
+        );
+        self::assertFalse(str_contains($this->src, 'mysqli_connect'), 'Script must not call mysqli_connect');
+        self::assertFalse(str_contains($this->src, 'real_connect'), 'Script must not call real_connect');
+        self::assertSame(
+            0,
+            preg_match('/PDO\s*\(/', $this->src),
+            'Script must not open a PDO connection'
+        );
+        // The connection must be provided via db/db.php
+        self::assertTrue(str_contains($this->src, 'db/db.php'), 'Script must load db/db.php for its connection');
+    }
+
+    // ── Htaccess tests ─────────────────────────────────────────────────────────
+
+    public function testHtaccessDeniesWebAccessToTheScript(): void
+    {
+        $htaccess = (string) file_get_contents(__DIR__ . '/../../../scripts/.htaccess');
+
+        $pos = strpos($htaccess, '<Files "simRecapContext.php">');
+        self::assertNotFalse($pos, '.htaccess must contain a <Files "simRecapContext.php"> block');
+        self::assertStringContainsString(
+            'Require all denied',
+            substr($htaccess, $pos),
+            '"Require all denied" must appear inside the simRecapContext.php Files block'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two defects in the sim recap pipeline:

1. **Roster blindness** — the sim recap agent attributes players to their injury-time team (frozen `from_teamid`) rather than their current team. This PR adds `SimRecapContextRepository` to precompute current rosters, active injuries, and in-window trades; a new CLI entry point `ibl5/scripts/simRecapContext.php` emits that as JSON; `bin/sim-recap-tick` fetches it over the existing SSH seam into `roster-context.json`; and `bin/sim-recap-prompt` injects it as Block 8 (after the exemplar, so it outranks its historical rosters) via a new optional `--roster=<path>` flag.

2. **`game_of_that_day` contract mismatch** — `bin/sim-recap-prompt` told the agent to write `game_of_that_day = 0` for a single-game date, but `ibl_box_scores_teams` is 1-based, so `SimSummaryRepository::findDisplayableGameRecaps()` silently dropped the row (and since one date section holds one game, the whole day vanished). Confirmed on sim 723 / 2008-03-25; prod row repaired 2026-07-30. This PR corrects the prompt instruction and adds 3 regression tests.

ADR-0093 invariants are preserved end-to-end: `SIM_RECAP_DB_PASSWORD` never reaches the prompt/argv/log, the agent credential stays SELECT-only, and `bin/sim-recap-prompt` still performs zero database access.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
