### PR TITLE
docs: refresh stale docs (environment, ADR-0036)

### DIFF
--- a/.claude/rules/environment.md
+++ b/.claude/rules/environment.md
@@ -3,7 +3,7 @@ description: Environment setup: CSS build, IBLbot, and environment-specific gotc
 paths:
   - "**/design/**/*.css"
   - "**/IBLbot/**/*"
-last_verified: 2026-05-31
+last_verified: 2026-07-31
 ---
 
 # Environment Commands

--- a/ibl5/docs/decisions/0036-engine-defers-hca-pending-bucket-ev-calibration.md
+++ b/ibl5/docs/decisions/0036-engine-defers-hca-pending-bucket-ev-calibration.md
@@ -1,11 +1,11 @@
 ---
 description: The Go sim engine defers home-court advantage until play-outcome bucket EVs are corpus-calibrated; ASG mode is an in-engine no-op until then.
-last_verified: 2026-05-31
+last_verified: 2026-07-31
 ---
 
 # ADR-0036: Engine defers home-court advantage pending bucket-EV calibration
 
-**Status:** Accepted
+**Status:** Accepted (deferred decision resolved — HCA re-homed by ADR-0084, 2026-07-12; see References)
 **Date:** 2026-05-31
 
 ## Context
@@ -26,7 +26,7 @@ The engine ships **playoff gating only** (net advantage ×1.25 and the fast-brea
 
 - Positive: PR7's shipped behavior (playoff ×1.25, `special_sub`) is faithful, deterministic, and golden byte-stable — no calibration dependency.
 - Positive: the deferral is recorded with the precise unblock (corpus-calibrate bucket EVs, then add the ±0.2 nudge), so a future PR has a concrete spec rather than a rediscovery.
-- Negative: ASG games simulate identically to regular-season games in-engine until HCA lands; consumers must not read "ASG mode" as behaviorally distinct yet.
+- Negative: ASG games simulate identically to regular-season games in-engine until HCA lands; consumers must not read "ASG mode" as behaviorally distinct yet. **[Resolved by ADR-0084: HCA implemented 2026-07-12; ASG now actively zeros HCA via `isASG` gate in `gametype.go`.]**
 
 ## References
 
@@ -34,3 +34,4 @@ The engine ships **playoff gating only** (net advantage ×1.25 and the fast-brea
 - `engine/internal/sim/gametype.go` — the playoff gating that did ship; documents the ASG no-op.
 - `engine/internal/sim/netadvantage.go` — `playoffNetMultiplier` (×1.25) application site.
 - The RE trace establishing the bucket-scale/EV entanglement lives in the JSB decompile notes (`COMPOSITE_DOUBLES_TRACE.md`), outside this repo.
+- `ibl5/docs/decisions/0084-faithful-foul-bucket-live-composites-hca-rehoming.md` — supersedes this ADR; implements HCA with four half-court legs and the tuned `hcaSite2BasisScale = 2.85`.


### PR DESCRIPTION
Re-verify and bump `last_verified` to 2026-07-31 for two docs that aged past the 60-day threshold.

## Changes

**`.claude/rules/environment.md`** — content verified accurate: CSS watch/build commands, IBLbot build path, gitignore claim, and `css-auto-rebuild.md` cross-reference all confirmed against current codebase.

**`ibl5/docs/decisions/0036-engine-defers-hca-pending-bucket-ev-calibration.md`** — status updated to reflect that the deferred HCA decision was resolved by ADR-0084 (2026-07-12):
- Status line updated from "Accepted" to "Accepted (deferred decision resolved — HCA re-homed by ADR-0084, 2026-07-12; see References)"
- Negative consequence annotated with [Resolved by ADR-0084] note
- ADR-0084 added to References section

## Verification

`bin/check-docs --since=master` passes. `bin/check-docs` full scan shows neither file stale. `--fix-dates` reports 0 unbumped files.

Closes #1755