### PR TITLE
chore(plan-prompt): gate --implement on blast-radius predicate

### DIFF
--- a/.claude/skills/plan-prompt/SKILL.md
+++ b/.claude/skills/plan-prompt/SKILL.md
@@ -2,7 +2,7 @@
 name: plan-prompt
 description: "Draft a /plan prompt distilled from the current conversation — ground-truth pointers, already-measured evidence, scope, constraints, verification, and the Step-3 architect tier — then, unless the Step-1.5 size triage says the work clears the ad-hoc bar, fire it as a detached headless Sonnet 4.6 run via bin/plan-now. Use after a design discussion when the planning run should be offloaded off the expensive session."
 disable-model-invocation: true
-last_verified: 2026-07-29
+last_verified: 2026-07-30
 ---
 
 # Draft a `/plan` handoff prompt and fire it headless
@@ -167,7 +167,10 @@ things with an obvious answer is the failure mode on the other side.
 
 `bin/plan-now` appends a coda telling the run to never ask, and to record + hold
 (`auto_merge: false`) any fork that survives anyway. That coda is the backstop, not
-the plan: a fork you could have resolved here costs a held PR.
+the plan: a fork you could have resolved here costs a held PR. And a fork you *did*
+resolve, but with low confidence, is not a Step 5 disposition trigger — it means you
+have not finished this step: reopen it with `AskUserQuestion` now rather than carrying
+the uncertainty into an `--implement` run.
 
 ## Step 5 — Fire, then report
 
@@ -209,8 +212,15 @@ step 3.
    `bin/plan-now`'s own, not the model's: it queues only when the run **exits clean**
    *and* the plan is **identified by its `PLAN_FILE:` line** *and* **`bin/check-plan`
    passes**. A degraded run lands on disk for a human instead. Reach for
-   `--implement` when you want to read the plan before it implements — a novel design,
-   a scope you're unsure of, or a Step 4.5 fork you resolved with low confidence.
+   `--implement` **if and only if** the work triggers `plan-architect-xhigh` — the same
+   trigger list Step 4 names above, authoritative in `.claude/rules/agent-tiering.md` §
+   Tiers. That is a blast-radius test, not a size-or-novelty one: those triggers mark
+   the changes whose bad outcome you cannot take back, and only those are worth a human
+   reading the plan before it implements. Everything else queues safely because
+   `/post-plan` always opens the PR, Phase 6.5's arming conditions only ever *hold*, and
+   a `feat:` title stays held by the commit-type floor and the `human-signoff` required
+   check regardless — so a wrong queue call costs a PR you read at review time instead
+   of at plan time.
 
    Because the plan will be *executed*, not skimmed: Step 4.5's fork pre-resolution and
    the Step-3 tier directive are what stand between this block and a wrong PR.

--- a/ibl5/docs/backlog/loop-engineering-backlog.md
+++ b/ibl5/docs/backlog/loop-engineering-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Loop-engineering backlog — automouse queue robustness (dependency ordering, circuit breakers, canaries, self-healing), autonomous intake loops, plan decomposition/tier-routing machinery, and the human comprehension counter-loop, with per-entry status.
-last_verified: 2026-07-29
+last_verified: 2026-07-30
 ---
 
 # Loop-Engineering Backlog
@@ -27,7 +27,7 @@ last_verified: 2026-07-29
 
 | Status | Count |
 |--------|------:|
-| ⬜ Open | 8 |
+| ⬜ Open | 9 |
 | 📋 Planned | 2 |
 | ◑ Partial | 2 |
 | ✅ Implemented | 9 |
@@ -60,6 +60,7 @@ last_verified: 2026-07-29
 | L19 | Weekly product-analytics review | ⬜ Open | 🟦 | M |
 | L20 | post-plan body-rewrite clobbers `Depends-on:`, bypassing arm condition (6) | ⬜ Open | 🟥 | M |
 | L21 | Phase 5.0 parsers fail-open on an unclosed code fence (conformance check covers nothing) | ⬜ Open | 🟥 | S |
+| L22 | Sweep queue-vs-review disposition gates across other skills/scripts | ⬜ Open | 🟦 | S |
 
 ### L1 Plan dependency DAG
 **Location:** `bin/automouse-queue` — queue order is symlink mtime (`ls -1tr`); `bin/automouse-queue-reorder-ui` re-touches mtimes by hand. No `depends_on` anywhere (verified).
@@ -173,6 +174,13 @@ last_verified: 2026-07-29
 **Suggested direction:** Have the harness report an unbalanced fence as `INDETERMINATE` rather than an empty list, so Phase 5.0 holds loudly instead of passing quietly — mirroring how condition (3) already treats unresolved items. An alternative is to run `cf_fence_unbalanced` from the post-plan path as a pre-parse guard. This changes a Phase 5.0 contract and wants a `/plan`; do not fix ad-hoc (`.claude/skills` ship-pipeline invariant per `.claude/rules/work-triage.md` § Ad-hoc safety mirror).
 **Risk if untouched:** A malformed plan that slips past `bin/check-plan` [F] silently voids the conformance gate at ship time, with no indication that it did so.
 **Status (2026-07-29):** ⬜ Open — 🟥 (ship-pipeline invariant; loop-machinery changes should default to `auto_merge: false`). (discovered 2026-07-29 during matrix-fence-strip; documented in `parse_matrix` docstring on that branch)
+
+### L22 Sweep queue-vs-review disposition gates across other skills/scripts
+**Location:** `.claude/skills/` — every other skill or script carrying `--queue` vs `--implement` (or equivalent queue-vs-human-review) disposition guidance. `.claude/skills/plan-prompt/SKILL.md` Step 5 item 2 is already converted (this entry's originating PR). Candidates to enumerate: `.claude/skills/plan/SKILL.md` (Step 4 gate 14 and its `auto_merge` guidance), `.claude/skills/post-plan/SKILL.md` (the Phase 6.5 arm conditions), and `bin/plan-now`'s disposition coda. **Peer conflict:** `.claude/skills/plan/SKILL.md` was owned by branch `plan-frontmatter-scaffold-strip` during the originating PR's implementation window, so the sweep is deferred until that branch merges.
+**Problem:** The blast-radius predicate now governing `/plan-prompt`'s gate — reach for `--implement` if and only if the work triggers `plan-architect-xhigh` — applies equally to every other queue-vs-review gate in the pipeline. Those gates still key on subjective self-assessment (novelty, felt scope, drafting-session confidence), which is unfalsifiable and fires hardest exactly when the deciding session has the least information. Left alone, each gate re-accretes its own carve-outs on its next edit and the pipeline ends up holding several mutually inconsistent answers to one question.
+**Suggested direction:** Once `plan-frontmatter-scaffold-strip` has merged, enumerate every disposition gate under `.claude/skills/` and `bin/`, apply the same three-trigger predicate (security surface or trust boundary; destructive or schema-tightening migration; `.claude/skills` ship-pipeline invariant — authoritative in `.claude/rules/agent-tiering.md` § Tiers), and ship it as one `chore:` PR. **Explicit non-target:** `.claude/rules/work-triage.md` § Ad-hoc safety mirror is deliberately out of scope — it answers a different question (should this work be planned at all, where a UI/UX or subjective-judgment surface is a legitimate trigger), not whether a human reads the plan before it implements. Do not fold it in.
+**Risk if untouched:** The predicate lives in one skill while its peers keep subjective carve-outs, so the queue-vs-review decision stays inconsistent across the pipeline and each gate drifts independently.
+**Status (2026-07-30):** ⬜ Open — 🟦 (the design is already resolved by the originating PR, so the sweep itself is mechanical; human-merge per this doc's burn-down default for loop-machinery changes). (discovered 2026-07-30 during plan-prompt-blast-radius-disposition)
 
 ---
 


### PR DESCRIPTION
## Summary
- Replaced subjective disposition triggers (novel design, scope uncertainty, low confidence) with objective blast-radius test in plan-prompt Step 5
- `--implement` now gates on `plan-architect-xhigh` triggers only: security surfaces/trust boundaries, destructive migrations, ship-pipeline invariants
- Cross-references Step 4 and authoritative `.claude/rules/agent-tiering.md` § Tiers to avoid duplication
- Added L22 backlog entry for sweeping queue-vs-review gates across other skills (deferred pending `plan-frontmatter-scaffold-strip` merge)
- Bumped `last_verified` dates

## Manual Testing

No manual testing needed — verified by automated tests.
