### PR TITLE
chore(backlog): document sim-recap testing gaps from #1753 audit

### DIFF
--- a/ibl5/docs/backlog/ci-backlog.md
+++ b/ibl5/docs/backlog/ci-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: CI/GitHub-Actions workflow simplification backlog — duplicated setup/notify boilerplate, job consolidation, and verified-not-redundant workflows, with per-entry status + automouse-readiness.
-last_verified: 2026-07-14
+last_verified: 2026-07-31
 ---
 
 # CI Workflow Simplification Backlog
@@ -29,12 +29,14 @@ last_verified: 2026-07-14
 
 | Status | Count |
 |--------|------:|
-| ⬜ Open | 2 |
-| 📋 Planned | 0 |
-| ✅ Implemented | 8 |
+| ⬜ Open | 1 |
+| 📋 Planned | 2 |
+| ◑ Partial | 1 |
+| ✅ Implemented | 9 |
 | 🚫 Declined | 0 |
 
 > The 4 "verified-not-redundant" entries in Axis 4 are **decisions to keep**, not open work — they exist so a future audit does not re-flag them. Not counted above.
+> ✅ corrected from 8 → 9 on 2026-07-31: a recount from table rows (Axes 1–3, 5) found 9 implemented entries (3.5 had already folded into 1.1 but was still counted separately; 5.1 was the sole ⬜, not 2). ⬜ was 1 before the Axis 6 additions. [CORRECTED 2026-07-31]
 
 ---
 
@@ -127,6 +129,46 @@ These look like duplicate workflows but each occupies a distinct, justified role
 **Suggested direction:** Compile IBLbot on the CI runner (where it already builds during tests), upload `dist/` as an artifact, and have the deploy step `rsync`/scp the prebuilt `dist/` to the droplet + `npm ci --omit=dev` (runtime deps only) + pm2 restart — no compiler on the server. This also unblocks the `typescript@7` Dependabot pin (the Go compiler is fine on a CI runner). Mirrors how compiled CSS is already built in CI and deployed as an artifact (`main.yml` "Build CSS" → "Deploy compiled CSS to server").
 **Risk if untouched:** Every future bump to a heavier build tool (TS, esbuild, a bundler) risks re-breaking the deploy on server memory limits; each is caught only at deploy time, blocking the whole production pipeline until hand-patched.
 **Status (2026-07-14):** ⬜ Open — surfaced by the PR #1453 deploy-failure investigation; needs a `/plan` (touches the deploy/notify path → expect `auto_merge: false`, 🟦).
+
+---
+
+## Axis 6: Sim-recap testing-gap spin-offs (PR #1753 audit)
+
+Entries 6.1 and 6.2 are CI/coverage gaps surfaced by the 2026-07-31 audit of PR #1753. Entry 6.3 is a sim-recap application fix tracked here by origin (PR #1753 audit), not by theme — no backlog file covers payload-validation gaps today. Source record for all three: `$HOME/claude-plans/sim-recap-testing-gaps-breakdown.md`.
+
+| # | Title | Status | Automouse | Effort |
+|---|-------|--------|-----------|-------:|
+| 6.1 | CI path-filter coupling splits sim-recap producer from consumer | 📋 Planned | 🟦 | M |
+| 6.2 | `ibl5/scripts/` excluded from phpstan; script fatals degrade silently | ◑ Partial | 🟦 | S |
+| 6.3 | `SimRecapPayload` accepts `game_of_that_day < 1`; `SimSummaryRepository` silently drops those rows | 📋 Planned | 🟥 | M |
+
+### 6.1 CI path-filter coupling splits sim-recap producer from consumer
+*(discovered 2026-07-31 during #1753)*
+**Location:** `.github/workflows/tests.yml` `changes:` job — the `src` filter gates `db-integration` on `**.php`; the `shell` filter gates `harness-tests` on `bin/**`. The sim-recap producer (`ibl5/scripts/simRecap*`, `ibl5/classes/SimRecap/**`) and consumer (`bin/sim-recap-*`) are on opposite sides of this boundary.
+**Problem:** A PHP-only change to the sim-recap producer runs zero prompt/tick tests. A `bin/`-only change to the consumer runs zero DB integration tests. The filter split is what let the traded-player regression survive PR review — CI stayed green because the producer and consumer were never tested together.
+**Suggested direction:** Extend the `changes:` coupling declaration so that a change to `bin/sim-recap-*` triggers `db-integration`, and a change to `ibl5/scripts/simRecap*` or `ibl5/classes/SimRecap/**` triggers `harness-tests`. Prefer the general cross-coupling pattern over a sim-recap special case.
+**Risk if untouched:** Every future sim-recap PR that touches one surface only (PHP or shell) silently omits half the test coverage. The named regression (traded player attributed to wrong team) would not have been caught by CI.
+**Closes gap:** #4 from `$HOME/claude-plans/sim-recap-testing-gaps-breakdown.md`
+**Status (2026-07-31):** 📋 Planned — `~/claude-plans/ci-path-filter-sim-recap-coupling.md` (written 2026-07-31, routed `plan-architect-xhigh` as a ship-pipeline invariant). Not yet implemented. 🟦.
+
+### 6.2 `ibl5/scripts/` excluded from phpstan; script fatals degrade silently
+*(discovered 2026-07-31 during #1753)*
+**Location:** `ibl5/phpstan.neon` `paths:` (currently lists `classes`, `phpstan-rules`, and extension-less `bin/` scripts — zero mention of `scripts`); no `php -l` sweep exists anywhere in `.github/` or `bin/`.
+**Problem:** A broken class reference in any `ibl5/scripts/*.php` file exits 255 while a guard unit test (e.g. `SimRecapContextGuardTest`) reports OK — the guard test is regex-only over source text and cannot catch a class-resolution failure. In prod, that fatal degrades silently: `simRecapContext.php` (example) would return exit 255 and the caller wraps the failure as `{}`, shipping a roster-blind recap. Proven by mutation during the #1753 audit. Also pending: a stale ADR-0092 citation in `ibl5/scripts/simRecapQueue.php`'s docblock (correct ADR is 0093) — fold into this PR if it does not trip `bin/check-docs` freshness, otherwise its own trivial fix.
+**Suggested direction:** Add `scripts` to `ibl5/phpstan.neon` `paths:` and generate a baseline (`ibl5/phpstan-baseline.neon`) to absorb pre-existing findings. Optionally add a `php -l` sweep. Ad-hoc — an existing pattern (add path + generate baseline) covers this; no `/plan` needed.
+**Risk if untouched:** Any syntax or class-reference error in `ibl5/scripts/*.php` is invisible to CI. It surfaces only as a prod degradation (the exact bug class PR #1753 fixed).
+**Closes gap:** #1 (static-analysis half) from `$HOME/claude-plans/sim-recap-testing-gaps-breakdown.md`
+**Status (2026-07-31):** ◑ Partial — implemented 2026-07-31 in worktree `phpstan-scripts-dir-coverage` (phpstan `paths:` + baseline + the ADR-0092→0093 docblock fix); not yet merged. 🟦.
+
+### 6.3 `SimRecapPayload` accepts `game_of_that_day < 1`; `SimSummaryRepository` silently drops those rows
+*(discovered 2026-07-31 during #1753)*
+**Location:** `ibl5/classes/SimRecap/SimRecapPayload.php` (`requireInt` with no lower bound on `game_of_that_day`); `ibl5/classes/SimRecap/SimSummaryRepository.php` (`COALESCE(bst.game_of_that_day, 0) = gr.game_of_that_day` silently drops rows where `game_of_that_day = 0`).
+**Problem:** The new `…MismatchDropped` test (PR #1753) pins the silent drop as *expected behavior*. The correct fix is an ingest-time lower-bound check so that `game_of_that_day < 1` is rejected at `SimRecapPayload::fromJson()`. An open design fork must be resolved first: **fail-closed vs. warn**, and what to do when box scores land *after* the recap.
+**Suggested direction:** Resolve the fail-closed-vs-warn fork (lean fail-closed with a structured error); add a `requireInt` lower bound; revisit `testFindDisplayableGameRecapsMismatchDropped` to test the rejection, not the silent drop. This item is the plan's own deferred "ingest-time reconciliation of `game_of_that_day`" Out-of-Scope item.
+**Risk if untouched:** `game_of_that_day = 0` silently drops recap rows; the test suite treats this as expected, so future regressions in this path pass CI green.
+**Closes gap:** #8 from `$HOME/claude-plans/sim-recap-testing-gaps-breakdown.md`
+**Tracked here** by PR #1753 audit origin, not by theme (no existing backlog covers payload-validation gaps).
+**Status (2026-07-31):** 📋 Planned — `~/claude-plans/game-of-that-day-validation-floor.md` (written 2026-07-31). Not yet implemented. 🟥.
 
 ---
 

--- a/ibl5/docs/backlog/loop-engineering-backlog.md
+++ b/ibl5/docs/backlog/loop-engineering-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Loop-engineering backlog — automouse queue robustness (dependency ordering, circuit breakers, canaries, self-healing), autonomous intake loops, plan decomposition/tier-routing machinery, and the human comprehension counter-loop, with per-entry status.
-last_verified: 2026-07-30
+last_verified: 2026-07-31
 ---
 
 # Loop-Engineering Backlog
@@ -27,8 +27,8 @@ last_verified: 2026-07-30
 
 | Status | Count |
 |--------|------:|
-| ⬜ Open | 9 |
-| 📋 Planned | 2 |
+| ⬜ Open | 10 |
+| 📋 Planned | 6 |
 | ◑ Partial | 2 |
 | ✅ Implemented | 9 |
 | 🚫 Declined | 0 |
@@ -61,6 +61,11 @@ last_verified: 2026-07-30
 | L20 | post-plan body-rewrite clobbers `Depends-on:`, bypassing arm condition (6) | ⬜ Open | 🟥 | M |
 | L21 | Phase 5.0 parsers fail-open on an unclosed code fence (conformance check covers nothing) | ⬜ Open | 🟥 | S |
 | L22 | Sweep queue-vs-review disposition gates across other skills/scripts | ⬜ Open | 🟦 | S |
+| L23 | sim-recap degraded path emits no Discord signal; qctx() failure ships roster-blind with CI green | 📋 Planned | 🟦 | S |
+| L24 | Phase 5.0 conformance is path-level only; planned method names absent from diff pass undetected | 📋 Planned | 🟥 | S |
+| L25 | CI-wiring gap: matrix CLI-executable rows may live in jobs the PR's own path filters never trigger | 📋 Planned | 🟥 | S |
+| L26 | Gate 15 never examines silent-fallback paths when the hold is security-justified | 📋 Planned | 🟥 | S |
+| L27 | /post-plan should sweep Out-of-Scope deferral phrases and open a backlog entry per hit | ⬜ Open | 🟥 | S |
 
 ### L1 Plan dependency DAG
 **Location:** `bin/automouse-queue` — queue order is symlink mtime (`ls -1tr`); `bin/automouse-queue-reorder-ui` re-touches mtimes by hand. No `depends_on` anywhere (verified).
@@ -181,6 +186,54 @@ last_verified: 2026-07-30
 **Suggested direction:** Once `plan-frontmatter-scaffold-strip` has merged, enumerate every disposition gate under `.claude/skills/` and `bin/`, apply the same three-trigger predicate (security surface or trust boundary; destructive or schema-tightening migration; `.claude/skills` ship-pipeline invariant — authoritative in `.claude/rules/agent-tiering.md` § Tiers), and ship it as one `chore:` PR. **Explicit non-target:** `.claude/rules/work-triage.md` § Ad-hoc safety mirror is deliberately out of scope — it answers a different question (should this work be planned at all, where a UI/UX or subjective-judgment surface is a legitimate trigger), not whether a human reads the plan before it implements. Do not fold it in.
 **Risk if untouched:** The predicate lives in one skill while its peers keep subjective carve-outs, so the queue-vs-review decision stays inconsistent across the pipeline and each gate drifts independently.
 **Status (2026-07-30):** ⬜ Open — 🟦 (the design is already resolved by the originating PR, so the sweep itself is mechanical; human-merge per this doc's burn-down default for loop-machinery changes). (discovered 2026-07-30 during plan-prompt-blast-radius-disposition)
+
+### L23 sim-recap degraded path emits no Discord signal; qctx() failure ships roster-blind with CI green
+*(discovered 2026-07-31 during #1753)*
+**Location:** `bin/sim-recap-tick` (calls `qctx()`; on failure logs `WARNING` to launchd only and continues with `{}`); `ibl5/classes/Discord/Discord.php` (Discord class surface); `bin/bug-pipeline-tick` + `bin/lib/bug-pipeline-gh.sh` (existing pattern to copy).
+**Problem:** When `qctx()` fails, the recap ships roster-blind. CI stays green — the fix can no-op in prod indefinitely with no visible signal. Only a human reading launchd logs would notice. Also: Block 8's "authoritative" header always emits followed by bare `{}`, so the documented roster-blind mode (Block 8 omitted) is unreachable in prod.
+**Suggested direction:** Emit a Discord signal on `qctx()` failure, copying the `bin/bug-pipeline-tick` + `bin/lib/bug-pipeline-gh.sh` pattern. Also decide Block 8's empty-`{}` behavior at plan time.
+**Risk if untouched:** A qctx() failure in prod is undetectable until a GM notices the recap is wrong — the exact failure mode PR #1753 was written to fix.
+**Closes gap:** #9 from `$HOME/claude-plans/sim-recap-testing-gaps-breakdown.md`
+**Status (2026-07-31):** 📋 Planned — `~/claude-plans/sim-recap-degraded-discord-alert.md` (written 2026-07-31). Not yet implemented. 🟦.
+
+### L24 Phase 5.0 conformance is path-level only; planned method names absent from diff pass undetected
+*(discovered 2026-07-31 during #1753)*
+**Location:** `.claude/skills/post-plan/_phase-5-final-verification.md` — greps for the test *file path* from the Verification Matrix (`grep -qF "$T" /tmp/post-plan-changed-$PPID`), not individual method names. `.claude/review-shared/_plan-verification.md`.
+**Problem:** When an implementer substitutes weaker test methods for plan-specified ones, Phase 5.0 passes — the file path appeared in the diff. This is how 4 of the 5 plan-specified test cases in PR #1753 were replaced without triggering a `MISSING:` signal. Sibling entry L21 covers the fail-open from unclosed fences; this entry covers the fail-open from path-only conformance.
+**Suggested direction:** Extend Phase 5.0 to extract planned test method names from the matrix and phase bodies and emit `MISSING:` for any method absent from the diff. *Confirmed uncovered by #1665/#1667/#1668/#1714 (dedup 2026-07-31).* Route: one `/plan` with L25/L26 (C2/C3), `plan-architect-xhigh` (ship-pipeline invariant), `auto_merge: false`.
+**Risk if untouched:** Any future implementer can substitute weaker tests than the plan specified; CI stays green and post-plan conformance passes silently.
+**Closes gap:** root cause of gaps #6 and #7 (and the general weakened-test class) from `$HOME/claude-plans/sim-recap-testing-gaps-breakdown.md`
+**Dedup:** reconciled 2026-07-31 — uncovered by #1668 / #1665 / #1667 / #1714.
+**Status (2026-07-31):** 📋 Planned — `~/claude-plans/plan-c-verification-conformance.md` (written 2026-07-31; covers L24+L25+L26 as one PR). 🟥.
+
+### L25 CI-wiring gap: matrix CLI-executable rows may live in jobs the PR's own path filters never trigger
+*(discovered 2026-07-31 during #1753)*
+**Location:** `.claude/skills/post-plan/_phase-5-final-verification.md`; `.github/workflows/tests.yml` path-filter coupling (see ci-backlog 6.1 for the structural fix).
+**Problem:** A `CLI-executable / post-impl` matrix row can be "wired into CI" on paper but in a job whose path filter the PR never triggers. Neither gate 15 nor gate 16 asks whether the CI job actually fires on the PR's changed paths. Matrix rows 11 and 20 in PR #1753 were one-shot commands that provided zero permanent regression protection.
+**Suggested direction:** Add a residual check: for each `CLI-executable` matrix row, either (a) the row's CI job is triggered by the PR's path filter, or (b) the row is explicitly marked `one-shot`. *Dedup completed 2026-07-31: uncovered by #1668/#1665/#1667/#1714 — #1668 executes CLI matrix cells locally once more but covers neither half of the CI-wiring question.* Route: one `/plan` with L24/L26 (C1/C3), `plan-architect-xhigh`, `auto_merge: false`.
+**Risk if untouched:** A test that appears in a CI job but whose job is never triggered by the PR's path filters provides zero coverage — indistinguishable from a wired test until examined.
+**Closes gap:** #4 (meta-tooling half, complementary to ci-backlog 6.1) from `$HOME/claude-plans/sim-recap-testing-gaps-breakdown.md`
+**Dedup:** reconciled 2026-07-31 — uncovered by #1668 / #1665 / #1667 / #1714.
+**Status (2026-07-31):** 📋 Planned — `~/claude-plans/plan-c-verification-conformance.md` (written 2026-07-31; covers L24+L25+L26 as one PR). 🟥.
+
+### L26 Gate 15 never examines silent-fallback paths when the hold is security-justified
+*(discovered 2026-07-31 during #1753)*
+**Location:** `.claude/skills/plan/SKILL.md` Step 4 gate 15 (loud-failure signal lever list); the gate currently fires only when the hold is justified by a *verification gap*.
+**Problem:** Gate 15 includes "a loud-failure signal replacing a silent fallback" in its lever list. It did not engage for PR #1753 because the hold was justified on gate-14b security-surface grounds — not a verification gap. The `qctx()` failure → `WARNING` → `{}` → roster-blind-recap path was never examined. The detectability concern is orthogonal to what justifies the hold.
+**Suggested direction:** Extend gate 15 (do not add a new gate — meta-tooling-bar.md extend-before-add). Add a named trigger: a new silent-fallback / degraded path in a synchronous sim path or a `bin/*-tick` script requires a loud signal (Discord), independent of what justifies the hold. *Confirmed uncovered by #1665/#1667/#1668/#1714 (dedup 2026-07-31).* Route: one `/plan` with L24/L25 (C1/C2), `plan-architect-xhigh`, `auto_merge: false`.
+**Risk if untouched:** Future silent-fallback paths in ship-adjacent code will not be examined at plan time when the plan hold is security-motivated rather than verification-gap-motivated.
+**Closes gap:** #9 (meta-tooling — prevents future versions of this class) from `$HOME/claude-plans/sim-recap-testing-gaps-breakdown.md`
+**Dedup:** reconciled 2026-07-31 — uncovered by #1668 / #1665 / #1667 / #1714.
+**Status (2026-07-31):** 📋 Planned — `~/claude-plans/plan-c-verification-conformance.md` (written 2026-07-31; covers L24+L25+L26 as one PR). 🟥.
+
+### L27 /post-plan should sweep Out-of-Scope deferral phrases and open a backlog entry per hit
+*(discovered 2026-07-31 during #1753)*
+**Location:** `.claude/skills/post-plan/SKILL.md`; `.claude/skills/post-plan/_phase-5-final-verification.md` (candidate phase to extend).
+**Problem:** 40 of 275 plans in `~/claude-plans/` contain deferral phrases ("file it separately", "its own plan", "separate PR"). Nothing captures any of them. PR #1753's own `## Out of Scope` deferred two items (B2 and a stale ADR citation) that would have evaporated without the manual audit that produced `$HOME/claude-plans/sim-recap-testing-gaps-breakdown.md`.
+**Suggested direction:** Post-plan sweeps the merged plan's `## Out of Scope` section for deferral phrases and opens a backlog entry (or stamped TODO in the appropriate backlog file) per hit — turning a deferral into a tracked row automatically rather than relying on a human to remember. `plan-architect-xhigh` (ship-pipeline invariant), `auto_merge: false`. Dedup resolved 2026-07-31; the C plan (`plan-c-verification-conformance`) does NOT cover this, so it stays standalone.
+**Risk if untouched:** Every plan that uses `## Out of Scope` continues to evaporate its deferrals; 40 existing plans already have untracked items.
+**Closes gap:** meta-tracking — prevents the D-class failure (deferral evaporation) across all future plans
+**Status (2026-07-31):** ⬜ Open — not covered by the C plan; needs its own `/plan`. 🟥.
 
 ---
 


### PR DESCRIPTION
## Summary
- Updated ci-backlog.md and loop-engineering-backlog.md with findings from PR #1753 sim-recap audit (last_verified: 2026-07-31)
- Added Axis 6 to ci-backlog: 3 entries tracking CI path-filter coupling (6.1), phpstan scripts directory coverage (6.2), and game_of_that_day validation (6.3)
- Added L23–L27 to loop-engineering-backlog: degraded-path Discord signaling, Phase 5.0 conformance depth, CI matrix wiring, gate 15 silent-fallback detection, and /post-plan deferral sweep
- Corrected ci-backlog status count (8 → 9 implemented) and updated all summary tables
- All entries include root-cause, suggested direction, risk if untouched, and status with pointers to plan files

## Manual Testing

No manual testing needed — verified by automated tests.
