### PR TITLE
chore(docker): bind services to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       - --providers.docker.network=ibl5-proxy
       - --entrypoints.web.address=:80
     ports:
-      - "80:80"
-      - "8081:8080"
+      - "127.0.0.1:80:80"
+      - "127.0.0.1:8081:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
@@ -25,7 +25,7 @@ services:
     container_name: ibl5-mariadb
     restart: unless-stopped
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3306:3306"
     environment:
       MARIADB_ROOT_PASSWORD: root
       MARIADB_DATABASE: iblhoops_ibl5
@@ -75,8 +75,8 @@ services:
     container_name: ibl5-mailpit
     restart: unless-stopped
     ports:
-      - "8025:8025"
-      - "1025:1025"
+      - "127.0.0.1:8025:8025"
+      - "127.0.0.1:1025:1025"
     labels:
       - traefik.enable=true
       - traefik.http.routers.mailpit.rule=Host(`mailpit.localhost`)
@@ -108,7 +108,7 @@ services:
     container_name: ibl5-browsersync
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     volumes:
       - ./ibl5:/watch:ro
     depends_on:


### PR DESCRIPTION
## Summary
- Bind all exposed Docker services to 127.0.0.1
- Services now only accessible from localhost, not the network
- Improves security isolation for local development environment

## Manual Testing

No manual testing needed — verified by automated tests.
