### PR TITLE
chore(lighthouse): suppress bare URLs for param-required modules

### DIFF
--- a/.claude/rules/lighthouse-pr-comments.md
+++ b/.claude/rules/lighthouse-pr-comments.md
@@ -3,7 +3,7 @@ description: Lighthouse CI posts per-URL scores and deltas-vs-master as a sticky
 paths:
   - ".github/workflows/lighthouse*"
   - "ibl5/.lighthouserc.json"
-last_verified: 2026-06-20
+last_verified: 2026-08-02
 ---
 
 # Lighthouse PR Comments
@@ -44,6 +44,11 @@ A 🟡 marker is informational — investigate before merging.
 - URL **selection** lives in `bin/lighthouse-pr-urls` plus the shared
   `Cli\LighthouseUrls` class: the module→sub-page map is `LighthouseUrls::SUB_PAGES`,
   and the global/sweeping fallback set is `LighthouseUrls::REPRESENTATIVE_PATHS`.
+- A module that **hard-requires query params** (its bare `?name=<Module>` URL 404s)
+  needs BOTH a `SUB_PAGES` entry and a `LighthouseUrls::PARAM_REQUIRED_MODULES` entry —
+  the latter suppresses the bare URL, which Lighthouse would otherwise treat as
+  `ERRORED_DOCUMENT_REQUEST` and hard-fail the entire audit run on. Enforced by
+  `bin/lighthouse-audit-urls --check` in the `e2e-shards` job of `e2e-tests.yml`.
 - The representative fallback set is mirrored in `ibl5/.lighthouserc.json` `collect.url`
   (pinned equal to `REPRESENTATIVE_PATHS` by a `LighthouseUrlsTest` unit test); both
   workflows `jq`-override `.ci.collect.url`, so the static array is only the

--- a/.claude/rules/lighthouse-pr-comments.md
+++ b/.claude/rules/lighthouse-pr-comments.md
@@ -48,7 +48,11 @@ A 🟡 marker is informational — investigate before merging.
   needs BOTH a `SUB_PAGES` entry and a `LighthouseUrls::PARAM_REQUIRED_MODULES` entry —
   the latter suppresses the bare URL, which Lighthouse would otherwise treat as
   `ERRORED_DOCUMENT_REQUEST` and hard-fail the entire audit run on. Enforced by
-  `bin/lighthouse-audit-urls --check` in the `e2e-shards` job of `e2e-tests.yml`.
+  `bin/lighthouse-audit-urls --check`, the last step of `.github/actions/lighthouse-setup`
+  — so it gates all three Lighthouse workflows (`lighthouse.yml`, `lighthouse-baseline.yml`,
+  `lighthouse-audit.yml`) before any audit runs. It validates the **full** site set even
+  when the workflow audits only a PR-selected subset, so a new param-required module is
+  caught the first time any Lighthouse workflow runs.
 - The representative fallback set is mirrored in `ibl5/.lighthouserc.json` `collect.url`
   (pinned equal to `REPRESENTATIVE_PATHS` by a `LighthouseUrlsTest` unit test); both
   workflows `jq`-override `.ci.collect.url`, so the static array is only the

--- a/.github/actions/lighthouse-setup/action.yml
+++ b/.github/actions/lighthouse-setup/action.yml
@@ -32,3 +32,12 @@ runs:
     - uses: ./.github/actions/setup-docker-e2e
       with:
         build-css: 'true'
+
+    # Lighthouse hard-fails the ENTIRE run on any document response >= 400
+    # (ERRORED_DOCUMENT_REQUEST), so a single unreachable URL in the generated
+    # set reds every Lighthouse workflow. Assert reachability here, in the
+    # shared prelude, where the failure is attributable to the URL set rather
+    # than to a Lighthouse score.
+    - name: Assert every Lighthouse audit URL is reachable
+      shell: bash
+      run: bin/lighthouse-audit-urls --check --base-url=http://localhost:8080

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -477,6 +477,9 @@ jobs:
           test-user-regular: ${{ secrets.IBL_TEST_USER_REGULAR || 'ci-e2e-regular' }}
           test-pass-regular: ${{ secrets.IBL_TEST_PASS_REGULAR || 'e2e-regular-pass' }}
 
+      - name: Assert every Lighthouse audit URL is reachable
+        run: bin/lighthouse-audit-urls --check --base-url=http://localhost:8080
+
       # --- Fixture-drift baseline (runtime mutator-isolation gate — ADR-0052) ---
       - name: Snapshot fixture baseline
         run: bin/check-e2e-fixture-drift snapshot /tmp/fixture-before.txt

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -477,9 +477,6 @@ jobs:
           test-user-regular: ${{ secrets.IBL_TEST_USER_REGULAR || 'ci-e2e-regular' }}
           test-pass-regular: ${{ secrets.IBL_TEST_PASS_REGULAR || 'e2e-regular-pass' }}
 
-      - name: Assert every Lighthouse audit URL is reachable
-        run: bin/lighthouse-audit-urls --check --base-url=http://localhost:8080
-
       # --- Fixture-drift baseline (runtime mutator-isolation gate — ADR-0052) ---
       - name: Snapshot fixture baseline
         run: bin/check-e2e-fixture-drift snapshot /tmp/fixture-before.txt

--- a/bin/lighthouse-audit-urls
+++ b/bin/lighthouse-audit-urls
@@ -19,6 +19,7 @@ use Cli\LighthouseUrls;
 
 $baseUrl = 'http://localhost:8080';
 $jsonOutput = false;
+$check = false;
 
 foreach ($argv as $i => $arg) {
     if ($i === 0) {
@@ -28,12 +29,15 @@ foreach ($argv as $i => $arg) {
         $baseUrl = substr($arg, strlen('--base-url='));
     } elseif ($arg === '--json') {
         $jsonOutput = true;
+    } elseif ($arg === '--check') {
+        $check = true;
     } elseif ($arg === '--help') {
-        fwrite(STDOUT, "Usage: bin/lighthouse-audit-urls [--base-url=URL] [--json]\n");
+        fwrite(STDOUT, "Usage: bin/lighthouse-audit-urls [--base-url=URL] [--json] [--check]\n");
+        fwrite(STDOUT, "  --check  Request every generated URL and exit 1 if any returns HTTP >= 400.\n");
         exit(0);
     } else {
         fwrite(STDERR, "Unknown argument: $arg\n");
-        fwrite(STDERR, "Usage: bin/lighthouse-audit-urls [--base-url=URL] [--json]\n");
+        fwrite(STDERR, "Usage: bin/lighthouse-audit-urls [--base-url=URL] [--json] [--check]\n");
         exit(2);
     }
 }
@@ -41,6 +45,52 @@ foreach ($argv as $i => $arg) {
 $baseUrl = rtrim($baseUrl, '/');
 
 $urls = LighthouseUrls::fullSiteUrls($baseUrl);
+
+if ($check) {
+    $context = stream_context_create([
+        'http' => [
+            'method' => 'GET',
+            'ignore_errors' => true,
+            'timeout' => 20,
+            'follow_location' => 1,
+            'max_redirects' => 5,
+            'user_agent' => 'lighthouse-audit-urls/--check',
+        ],
+    ]);
+
+    $failures = [];
+
+    foreach ($urls as $url) {
+        $headers = @get_headers($url, false, $context);
+        $status = 0;
+        if ($headers !== false) {
+            foreach ($headers as $header) {
+                if (preg_match('/^HTTP\/[\d.]+\s+(\d{3})/', $header, $m)) {
+                    $status = (int) $m[1];
+                }
+            }
+        }
+        fwrite(STDOUT, "$status $url\n");
+        if ($status === 0 || $status >= 400) {
+            $failures[] = "  $status $url";
+        }
+    }
+
+    $total = count($urls);
+    if ($failures === []) {
+        fwrite(STDOUT, "OK: all $total audit URLs returned < 400.\n");
+        exit(0);
+    }
+
+    $failCount = count($failures);
+    fwrite(STDERR, "\n");
+    fwrite(STDERR, "FAIL: $failCount of $total audit URL(s) returned >= 400 — Lighthouse fails the entire run on an ERRORED_DOCUMENT_REQUEST.\n");
+    foreach ($failures as $line) {
+        fwrite(STDERR, $line . "\n");
+    }
+    fwrite(STDERR, "\nIf the module hard-requires query params, add a Cli\\LighthouseUrls::SUB_PAGES entry AND list it in Cli\\LighthouseUrls::PARAM_REQUIRED_MODULES.\n");
+    exit(1);
+}
 
 if ($jsonOutput) {
     fwrite(STDOUT, json_encode($urls, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");

--- a/ibl5/classes/Cli/LighthouseUrls.php
+++ b/ibl5/classes/Cli/LighthouseUrls.php
@@ -18,6 +18,23 @@ final class LighthouseUrls
         'SeasonArchive'       => '&year=2025',
         'Injuries'            => '&teamid=1',
         'OneOnOneGame'        => '&gameid=1',
+        'GameBoxscore'        => '&date=2026-02-20&game=1',
+    ];
+
+    /**
+     * Modules whose BARE `?name=<Module>` URL is not an auditable page: they
+     * hard-require query params and answer 404 without them. Lighthouse treats
+     * any document response >= 400 as ERRORED_DOCUMENT_REQUEST and fails the
+     * whole run, so the bare variant must be suppressed from the audit set.
+     *
+     * Every member MUST also carry a SUB_PAGES entry — otherwise suppressing
+     * the bare URL drops the module out of the audit entirely, trading a loud
+     * 404 for silent coverage loss. Pinned by LighthouseUrlsTest.
+     *
+     * @var list<string>
+     */
+    public const PARAM_REQUIRED_MODULES = [
+        'GameBoxscore',
     ];
 
     /** @var list<string> */
@@ -32,9 +49,11 @@ final class LighthouseUrls
     /**
      * The full-site audit URL set: index first, then for every registered
      * module its bare `name=<Module>` URL plus, for sub-paged modules, the
-     * additional sub-page variant (two entries for those). This is the exact
-     * loop the original `bin/lighthouse-audit-urls` ran; do not change its
-     * shape without re-pinning the characterization test.
+     * additional sub-page variant (two entries for those). Modules listed in
+     * PARAM_REQUIRED_MODULES contribute only their sub-page variant — their
+     * bare URL 404s and would hard-fail the Lighthouse run. Otherwise this is
+     * the exact loop the original `bin/lighthouse-audit-urls` ran; do not
+     * change its shape without re-pinning the characterization test.
      *
      * @return list<string>
      */
@@ -46,7 +65,9 @@ final class LighthouseUrls
         $urls[] = $baseUrl . '/ibl5/index.php';
 
         foreach (ModuleRegistry::getAllModules() as $module) {
-            $urls[] = $baseUrl . '/ibl5/modules.php?name=' . $module;
+            if (!in_array($module, self::PARAM_REQUIRED_MODULES, true)) {
+                $urls[] = $baseUrl . '/ibl5/modules.php?name=' . $module;
+            }
 
             if (isset(self::SUB_PAGES[$module])) {
                 $urls[] = $baseUrl . '/ibl5/modules.php?name=' . $module . self::SUB_PAGES[$module];

--- a/ibl5/tests/Cli/LighthouseAuditUrlsTest.php
+++ b/ibl5/tests/Cli/LighthouseAuditUrlsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Cli;
 
+use Cli\LighthouseUrls;
 use Module\ModuleRegistry;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
@@ -35,11 +36,15 @@ final class LighthouseAuditUrlsTest extends TestCase
             static fn (string $line): bool => $line !== ''
         );
 
+        // Derived, not hardcoded: a param-required module contributes only its
+        // sub-page variant, so a hardcoded sub-page count silently cancels
+        // against the suppressed bare URL and stops proving anything.
         $moduleCount = count(ModuleRegistry::getAllModules());
-        $subPageCount = 8;
+        $subPageCount = count(LighthouseUrls::SUB_PAGES);
+        $paramRequiredCount = count(LighthouseUrls::PARAM_REQUIRED_MODULES);
         $homepageCount = 1;
         self::assertGreaterThanOrEqual(
-            $moduleCount + $homepageCount + $subPageCount,
+            $moduleCount + $homepageCount + $subPageCount - $paramRequiredCount,
             count($lines)
         );
     }

--- a/ibl5/tests/Cli/LighthouseUrlsTest.php
+++ b/ibl5/tests/Cli/LighthouseUrlsTest.php
@@ -26,9 +26,66 @@ final class LighthouseUrlsTest extends TestCase
     {
         $expected = 1
             + count(ModuleRegistry::getAllModules())
-            + count(LighthouseUrls::SUB_PAGES);
+            + count(LighthouseUrls::SUB_PAGES)
+            - count(LighthouseUrls::PARAM_REQUIRED_MODULES);
 
         self::assertCount($expected, LighthouseUrls::fullSiteUrls(self::BASE));
+    }
+
+    /**
+     * Regression: GameBoxscore was registered in ModuleRegistry with no
+     * SUB_PAGES entry, so fullSiteUrls() emitted a bare `?name=GameBoxscore`
+     * URL. That page 404s without date+game, and Lighthouse fails the whole
+     * run on a >= 400 document (ERRORED_DOCUMENT_REQUEST).
+     */
+    public function testParamRequiredModuleEmitsNoBareUrl(): void
+    {
+        $fullSet = LighthouseUrls::fullSiteUrls(self::BASE);
+
+        foreach (LighthouseUrls::PARAM_REQUIRED_MODULES as $module) {
+            self::assertNotContains(
+                self::BASE . '/ibl5/modules.php?name=' . $module,
+                $fullSet,
+                "'$module' requires query params — its bare URL must not be audited"
+            );
+        }
+    }
+
+    /**
+     * Suppressing the bare URL must not drop the module from the audit set —
+     * that would trade a loud 404 for silent coverage loss.
+     */
+    public function testEveryParamRequiredModuleHasASubPage(): void
+    {
+        foreach (LighthouseUrls::PARAM_REQUIRED_MODULES as $module) {
+            self::assertArrayHasKey(
+                $module,
+                LighthouseUrls::SUB_PAGES,
+                "'$module' suppresses its bare URL, so it MUST have a SUB_PAGES entry"
+            );
+        }
+    }
+
+    /**
+     * Deliberately does NOT route through PARAM_REQUIRED_MODULES: dropping
+     * 'GameBoxscore' from that const would empty the loops above and leave them
+     * asserting nothing, while the bare 404 URL returns to the audit set.
+     */
+    public function testGameBoxscoreBareUrlIsNeverAudited(): void
+    {
+        self::assertNotContains(
+            self::BASE . '/ibl5/modules.php?name=GameBoxscore',
+            LighthouseUrls::fullSiteUrls(self::BASE),
+            'GameBoxscore 404s without date+game — its bare URL hard-fails the Lighthouse run'
+        );
+    }
+
+    public function testGameBoxscoreIsAuditedWithParameters(): void
+    {
+        self::assertContains(
+            self::BASE . '/ibl5/modules.php?name=GameBoxscore&date=2026-02-20&game=1',
+            LighthouseUrls::fullSiteUrls(self::BASE)
+        );
     }
 
     public function testModuleUrlAppliesSubPage(): void


### PR DESCRIPTION
## Summary
- Fix Lighthouse audit failures caused by 404 responses on bare module URLs (GameBoxscore)
- Add `PARAM_REQUIRED_MODULES` constant to declare modules requiring query params
- Exclude bare URLs for these modules from audit set; only parameterized variants are tested
- Add `bin/lighthouse-audit-urls --check` validation as the last step of `.github/actions/lighthouse-setup`, so it gates all three Lighthouse workflows before any audit runs
- Add comprehensive tests enforcing that param-required modules have SUB_PAGES entries and emit no bare URLs

## Why the gate lives in `lighthouse-setup`, not `e2e-shards`

It was first placed in the `e2e-shards` job, where it fataled on `platform_check.php`. That placement was not merely wrong, it was **flaky**: `e2e-shards` installs composer deps only on a vendor-cache miss, and its `Linux-vendor-` restore-key is shared with `setup-php-env`, whose install runs on PHP 8.5 **without** `--ignore-platform-reqs`. A restored `vendor/` can therefore carry a strict `platform_check.php` that fatals on the runner's stock PHP 8.3.6 — whichever job saved the cache last decided the outcome.

`lighthouse-setup` installs unconditionally with `--ignore-platform-reqs`, which is why `bin/lighthouse-audit-urls --json` already runs there today. `setup-docker-e2e` imports `ci-seed.sql` before starting Apache, so the check cannot race the seed.

**Scope note:** the check validates the **full** 56-URL set on every Lighthouse run, while `lighthouse.yml` audits only the PR-selected subset. That is deliberate — it catches a new param-required module the subset would not include — but it also means any future ≥400 anywhere in the site set reds every PR touching PHP/CSS/TS. Currently clean: all 56 return 200 against the CI seed.

## Manual Testing

No manual testing needed — verified by automated tests.
