### PR TITLE
chore: promote /plan-offload-by-default rule to always-loaded agent-tiering.md

### DIFF
--- a/.claude/rules/agent-tiering-detail.md
+++ b/.claude/rules/agent-tiering-detail.md
@@ -1,6 +1,6 @@
 ---
-description: Read-on-demand detail for agent-tiering — the skip-vs-spawn heuristic, Fable approval-gate procedure (incl. the asm-level static-RE exception where Fable is the recommended tier), flat-fan-out (nested sub-agent) rationale, the bounded-checklist diff-triage exception that scopes the Opus row's open-ended diff-triage, orchestrator context economics (delegate-don't-dismiss, split-don't-self-clear), and per-tier prompt style. Loads only when editing workflow orchestration defs.
-last_verified: 2026-07-27
+description: Read-on-demand detail for agent-tiering — the skip-vs-spawn heuristic, Fable approval-gate procedure (incl. the asm-level static-RE exception where Fable is the recommended tier), flat-fan-out (nested sub-agent) rationale, the bounded-checklist diff-triage exception that scopes the Opus row's open-ended diff-triage, orchestrator context economics (delegate-don't-dismiss, split-don't-self-clear), the measured evidence behind the offload-`/plan`-by-default rule, and per-tier prompt style. Loads only when editing workflow orchestration defs.
+last_verified: 2026-08-02
 paths:
   - ".claude/skills/**/*.md"
 ---
@@ -128,7 +128,12 @@ Tier the orchestrator by the judgment **it** retains:
 - **Single backlog item** → **Sonnet** (Steps 2.5/3/4 orchestrator calls are light; same recipe-backed class the "Opus (delegated)" row routes to `plan-architect-sonnet`).
 - **Multiple items in one pass** → **Opus** (cross-item PR decomposition, **dependency ordering**, tier-boundary splits). Cheaper: run each as its own **Sonnet** `/plan` and make only the ordering call yourself.
 
-**Getting to a Sonnet orchestrator from an Opus session:** when an expensive session has already done the design thinking, don't run `/plan` inline — run `/plan-prompt` (`.claude/skills/plan-prompt/SKILL.md`), which drafts a `/plan` prompt carrying the ground-truth pointers, the already-measured evidence, and an explicit Step-3 tier directive, then fires it via `bin/plan-now` as a **detached headless Sonnet 4.6 session** (the clipboard copy remains, for running it by hand). Sonnet orchestrates; the tier directive is what keeps the *design* on Opus. Because that run has no human in it, `/plan-prompt` Step 4.5 makes the drafting session resolve the user-facing forks that `/plan` Step 3.5 would otherwise put to a human, and `bin/plan-now` holds auto-merge on any fork that survives. Sonnet-orchestrating is only cheaper than Opus-orchestrating if the context actually crosses the session boundary — that handoff prompt is the thing that carries it.
+**Getting to a Sonnet orchestrator from an Opus session** — the operative rule now lives in `agent-tiering.md` § `/plan` orchestrator model (promoted there 2026-08-02, because a session that never Read this file was the one making the inline call). This file keeps the mechanics and the evidence:
+
+- `/plan-prompt` (`.claude/skills/plan-prompt/SKILL.md`) drafts the handoff and fires it via `bin/plan-now`; the clipboard copy remains, for running it by hand.
+- Because the fired run has no human in it, `/plan-prompt` Step 4.5 makes the *drafting* session resolve the user-facing forks that `/plan` Step 3.5 would otherwise put to a human, and `bin/plan-now` holds auto-merge on any fork that survives.
+- **Measured 2026-08-02** over ~30 days of this project's transcripts (capacity-proxy $ as a throughput measure, not billing): 195 architect spawns, of which **114 (58%) ran inline inside interactive sessions** rather than in a dedicated `/plan` run. Orchestrator cost per spawn: **Opus $7.36** (53 spawns, $390) vs **Sonnet $2.66** (142 spawns, $377). The architect tier is unchanged either way, so the delta is pure orchestrator overhead.
+- Sonnet-orchestrating is only cheaper if the context actually crosses the session boundary — the handoff prompt is the thing that carries it.
 
 ## Explore Agent Tiering
 

--- a/.claude/rules/agent-tiering.md
+++ b/.claude/rules/agent-tiering.md
@@ -1,6 +1,6 @@
 ---
 description: Which tier to pick for each sub-agent, including the Sonnet 4.6 def-pins. Skip-vs-spawn heuristic and deeper rationale live in agent-tiering-detail.md.
-last_verified: 2026-07-25
+last_verified: 2026-08-02
 ---
 
 # Agent Tiering
@@ -11,21 +11,23 @@ Tier every sub-agent (and every agent a plan spawns) by the reasoning the task a
 
 | Tier | Model param | Use for |
 |------|-------------|---------|
-| **Haiku** | `model: "haiku"` | Command output, pattern-matching named checklists, grep-and-format, mechanical lookups — answerable by running commands and reporting, without judging relevance. |
+| **Haiku** | `model: "haiku"` | Command output, grep-and-format, mechanical lookups — answerable by running commands and reporting, without judging relevance. |
 | **Sonnet** | `subagent_type: "sonnet-4-6"`, omit `model` — see § Sonnet 4.6 pins | Synthesis: "is this finding relevant?", cross-file traces, semantic compliance checks, rename sweeps needing call-site judgment, review agents, backlog housekeeping, manual-test classification. Never pass `model: "sonnet"` — the alias now resolves to Sonnet 5. |
 | **Opus** | self (no delegation) | Novel reasoning, FK ordering, rule authoring, ADR writing, ambiguous test failures, final code review, open-ended diff-triage (see detail file). Never delegate understanding. |
-| **Opus (delegated)** | `subagent_type: "plan-architect"` | Implementation **planning** only, via `/plan` Step 3 — three defs selected by ONE ordered precedence (mirrors Step 3): **`plan-architect-xhigh`** (`effort: xhigh`) FIRST for security surfaces, trust boundaries, destructive migrations, or ship-pipeline invariant changes; else **`plan-architect-sonnet`** (`model: claude-sonnet-4-6`) when the task is recipe-backed — an explicit recipe plus a named existing pattern to copy (mechanical composition of a pre-resolved recipe, so no understanding is delegated); else the default **`plan-architect`** (`model: opus` + `effort: high`). Do **not** pass an inline `model` override — each def owns it. |
-| **Fable** | `model: "fable"` — **prompt first, last resort** | Rung above Opus (~2× cost). Use **only** when a task is absolutely critical **and** Fable is 100% necessary to solve it — and **never without prompting the user first** for explicit approval. Default to Opus. Full gate: `agent-tiering-detail.md`. |
+| **Opus (delegated)** | `subagent_type: "plan-architect"` | Implementation **planning** only, via `/plan` Step 3 — three defs by ONE ordered precedence (mirrors Step 3): **`plan-architect-xhigh`** (`effort: xhigh`) FIRST for security surfaces, trust boundaries, destructive migrations, or ship-pipeline invariant changes; else **`plan-architect-sonnet`** (`model: claude-sonnet-4-6`) for recipe-backed tasks; else the default **`plan-architect`** (`model: opus` + `effort: high`). Do **not** pass an inline `model` override — each def owns it. |
+| **Fable** | `model: "fable"` — **prompt first, last resort** | Rung above Opus (~2× cost). Use **only** when a task is absolutely critical **and** Fable is 100% necessary to solve it — **never without prompting the user first**. Default to Opus. Full gate: `agent-tiering-detail.md`. |
 
-> **The boundary keys on task *type* (judgment vs. mechanical), not raw model capability** — a stronger Sonnet moves nothing across the line. Re-validated 2026-06-30 vs Sonnet 5 (then the `sonnet` alias, native 1M context): unchanged. Why: `agent-tiering-detail.md`.
+> **The boundary keys on task *type* (judgment vs. mechanical), not raw model capability** — a stronger Sonnet moves nothing across the line. Why: `agent-tiering-detail.md`.
 
 ## `/plan` orchestrator model
 
 The `/plan` session model is a separate call from the sub-agent rows above. Tier the orchestrator by the judgment it retains — single backlog item → **Sonnet**, multiple items in one pass → **Opus** (cross-item decomposition + dependency ordering). The `plan-architect` is Step-3-tiered (xhigh → sonnet → opus) regardless of orchestrator. Full rationale: `agent-tiering-detail.md` § `/plan` orchestrator model.
 
+**Default: don't run `/plan` inline from an Opus session — offload it.** Once the design thinking is done, run **`/plan-prompt`** (`.claude/skills/plan-prompt/SKILL.md`), which fires it via `bin/plan-now` as a **detached headless Sonnet 4.6 `/plan` session**. Sonnet orchestrates; the tier directive keeps the *design* on Opus. Stay inline only when the fork genuinely needs the human in the loop mid-run (`/plan` Step 3.5) and you can't pre-resolve it. Mechanics and evidence: `agent-tiering-detail.md` § `/plan` orchestrator model.
+
 ## Sonnet 4.6 pins
 
-Sonnet surfaces are pinned to 4.6 via an agent def or skill frontmatter (the `model` enum can't express a specific version) — **the def-based pin wins only when `model` is omitted**.
+Sonnet surfaces are pinned to 4.6 via an agent def or skill frontmatter — **the def-based pin wins only when `model` is omitted**.
 
 **Never pass `model: "sonnet"` to Agent()** — that alias now resolves to Sonnet 5.
 
@@ -39,6 +41,6 @@ Sonnet surfaces are pinned to 4.6 via an agent def or skill frontmatter (the `mo
 
 ## Explore Agents
 
-Tier Explore per prompt — don't default all to one tier (Explore itself is pinned to Sonnet 4.6, § Sonnet 4.6 pins). Haiku for enumeration / single-file lookups / grep-and-list; omit `model` (Sonnet 4.6) for multi-hop traces, cross-module synthesis, open-ended investigation. Table + examples: `agent-tiering-detail.md` § Explore Agent Tiering.
+Tier Explore per prompt — Haiku for enumeration / single-file lookups / grep-and-list; omit `model` (Sonnet 4.6) for multi-hop traces, cross-module synthesis, open-ended investigation. Table + examples: `agent-tiering-detail.md` § Explore Agent Tiering.
 
-Plan-authoring tiering (labeling each phase, mechanical-recipe agents, bulk-sweep patterns) lives in `.claude/skills/plan/_architect-contract.md`, the plan-architect's output contract that `/plan` Step 3 directs the architect to Read.
+Plan-authoring tiering lives in `.claude/skills/plan/_architect-contract.md`, the plan-architect's output contract that `/plan` Step 3 directs the architect to Read.


### PR DESCRIPTION
## Summary

Promotes the 'default: don't run `/plan` inline from an Opus session — offload it' rule to `agent-tiering.md` (always-loaded) so it fires in every session, not only in sessions that open the detail file.

### Changes

**`.claude/rules/agent-tiering.md`** (always-loaded, 5000-byte budget):
- Adds the offload-by-default rule paragraph to the `/plan` orchestrator model section
- Trims several verbose sections to stay within the per-file byte budget: Opus-delegated row, Fable row, boundary note, Explore section, Sonnet 4.6 pins intro
- All trimmed detail already lives in `agent-tiering-detail.md`

**`.claude/rules/agent-tiering-detail.md`** (path-scoped, loaded on `.claude/skills/**`):
- Restructures 'Getting to a Sonnet orchestrator' as bullet-point mechanics with provenance pointer back to the main rule
- Adds measured evidence: 195 architect spawns over ~30 days, 58% ran inline, Opus $7.36/spawn vs Sonnet $2.66/spawn orchestrator overhead

## Why

A session that never reads `agent-tiering-detail.md` was making inline `/plan` calls from Opus. The rule needed to be in the always-loaded file.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.