### PR TITLE
fix(bug-pipeline): fail-closed guards prevent token bleed

### DIFF
--- a/bin/bug-pipeline-tick
+++ b/bin/bug-pipeline-tick
@@ -68,7 +68,21 @@ log() { printf '[%s] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$*"; }
 # ── One seam for every PHP-CLI wrapper call ───────────────────────────────────
 cli() {
     local cmd="$1"; shift
-    "$PHP_BIN" "$SCRIPTS_DIR/${cmd}.php" "$@"
+    local out rc
+    out="$("$PHP_BIN" "$SCRIPTS_DIR/${cmd}.php" "$@")"; rc=$?
+    if [ "$rc" -ne 0 ]; then
+        # FAIL CLOSED. A PHP fatal prints to stdout as well as stderr, and every caller
+        # command-substitutes us — so emitting it hands parse-garbage to jq and, worse, lets
+        # a non-empty "row" sail past an `[ -z "$claimed" ]` guard. That is exactly how a
+        # MariaDB outage dispatched 84 hunters against report id "" on 2026-08-04. No wrapper
+        # uses a non-zero exit as a normal signal (an empty tick is exit 0 + no output), so
+        # suppressing output here cannot mask a working path.
+        # The diagnostic MUST go to stderr: log() writes to stdout, which IS our captured value.
+        printf '[%s] ERROR: %s.php exited %s — treating as no output (fail closed)\n' \
+            "$(date '+%Y-%m-%dT%H:%M:%S')" "$cmd" "$rc" >&2
+        return "$rc"
+    fi
+    printf '%s' "$out"
 }
 
 # ── Usage/rate-limit detector (regex copied from automouse-run:308-311) ───────
@@ -532,6 +546,14 @@ run_hunt_ladder() { # claimed hunt_id wt_appdir
         result="$(cat "$wt_appdir/.bug-pipeline/hunt-result.json" 2>/dev/null || echo '{}')"
         verdict="$(printf '%s' "$result" | jq -r '.verdict // "escalate"' 2>/dev/null)"
         if [ "$verdict" = "fixed" ]; then rm -f "$rendered"; LADDER_STATE="fixed"; return 0; fi
+        # terminal:true is the hunter's own "a retry by a stronger tier would be pointless"
+        # (bin/bug-pipeline-hunter-prompt § hunt-result schema). Climbing to sonnet then opus
+        # anyway spends 2 of 3 tiers — the dearest two — to re-derive the same answer.
+        # Stop here; drive_hunt_row re-reads the same flag and routes to needs_human.
+        if [ "$(printf '%s' "$result" | jq -r '.terminal // false' 2>/dev/null)" = "true" ]; then
+            log "hunt $hunt_id: $model returned terminal — skipping remaining tiers"
+            rm -f "$rendered"; LADDER_STATE="escalate"; return 0
+        fi
         # escalate → next (dearer) tier
     done
     rm -f "$rendered"; LADDER_STATE="escalate"; return 0
@@ -625,8 +647,26 @@ bug_slug() { # id original_text
 # then ship (fixed) / park (blocked) / give up (escalate+cap or terminal). Foreground —
 # the tick blocks until the hunt returns, so overlapping ticks can't double-hunt (invariant 1).
 drive_hunt_row() { # claimed_row_json
-    local claimed="$1" hunt_id slug wt_root wt_appdir attempts terminal
-    hunt_id="$(printf '%s' "$claimed" | jq -r '.id')"
+    local claimed="$1" hunt_id slug wt_root wt_appdir attempts terminal body
+    # ★ Authoritative id guard — the ONE choke point every hunter dispatch passes through
+    # (maybe_hunt and resume_blocked_hunt both land here). A row without a usable .id is not a
+    # bug report; dispatching one renders "You are working on report # (class: )" and burns the
+    # whole ladder, Opus included, on nothing.
+    hunt_id="$(printf '%s' "$claimed" | jq -r '.id // empty' 2>/dev/null)"
+    if [ -z "$hunt_id" ] || [ "$hunt_id" = "null" ]; then
+        log "ERROR: claimed row has no usable .id — refusing to dispatch a hunter (no claude spawned)"
+        return 0
+    fi
+    # An empty report body has nothing to localize: every tier can only escalate. Hand it to a
+    # human without spawning anything. Deliberately no Discord post/mention here — a repeating
+    # upstream fault would trade a token bleed for a notification bleed.
+    body="$(printf '%s' "$claimed" | jq -r '.original_text // empty' 2>/dev/null | tr -d '[:space:]')"
+    if [ -z "$body" ]; then
+        log "bug $hunt_id has an empty report body — no hunter dispatched; -> needs_human"
+        cli transition "$hunt_id" needs_human --release-lease >/dev/null || true
+        return 0
+    fi
+    log "claimed bug $hunt_id into hunting; dispatching hunter"
     attempts="$(printf '%s' "$claimed" | jq -r '.hunt_attempts // 0')"
     slug="$(bug_slug "$hunt_id" "$(printf '%s' "$claimed" | jq -r '.original_text // empty')")"
     # Legacy cutover: a pre-rename hunt left a bug-<id> worktree — reuse it, don't fork a second one.
@@ -663,14 +703,16 @@ drive_hunt_row() { # claimed_row_json
 # drive it. Independent of the enumerator — a lone classified bug yields [] from the enumerator
 # yet must still be hunted. Returns 0 iff a hunt was driven (caller ends the tick — one/tick).
 maybe_hunt() {
-    local claimed hunt_id
-    claimed="$(cli claim-next 2>/dev/null)"
+    local claimed
+    # No 2>/dev/null: cli's fail-closed diagnostic must reach launchd-stderr.log.
+    if ! claimed="$(cli claim-next)"; then
+        log "claim-next failed — no row claimed this tick (no claude spawned)"
+        return 1
+    fi
     if [ -z "$claimed" ]; then
         return 1   # nothing huntable / lost the claim race / already 'hunting'
     fi
-    hunt_id="$(printf '%s' "$claimed" | jq -r '.id')"
-    log "claimed bug $hunt_id into hunting; dispatching hunter"
-    drive_hunt_row "$claimed"
+    drive_hunt_row "$claimed"   # owns the .id guard and the "claimed bug N" log line
     return 0
 }
 
@@ -678,7 +720,9 @@ maybe_hunt() {
 resume_blocked_hunt() { # row_json (surfaced by the enumerator, blocked_until already elapsed)
     local row="$1" id slug wt_root resumed
     id="$(printf '%s' "$row" | jq -r '.id')"
-    resumed="$(cli claim-next --resume="$id" 2>/dev/null)"   # atomic WHERE status='blocked' guard
+    if ! resumed="$(cli claim-next --resume="$id")"; then     # atomic WHERE status='blocked' guard
+        log "resume: claim-next failed for $id — skipping (no claude spawned)"; return 0
+    fi
     if [ -z "$resumed" ]; then
         log "resume: $id already resumed by another tick — skip"; return 0
     fi
@@ -701,7 +745,7 @@ resume_blocked_hunt() { # row_json (surfaced by the enumerator, blocked_until al
 # and MAY read/write gh here — categorically distinct from the starved hunter (no gh at all).
 reconcile_pr_open_rows() {
     local rows row id pr issue branch n state thread_id
-    rows="$(cli list-pr-open 2>/dev/null)"
+    rows="$(cli list-pr-open)" || rows=''   # cli's own stderr diagnostic reaches launchd-stderr.log
     printf '%s' "$rows" | jq -e 'type == "array"' >/dev/null 2>&1 || return 0
     while IFS= read -r row; do
         [ -n "$row" ] || continue
@@ -766,7 +810,7 @@ main() {
     fi
 
     local actionable normalized
-    actionable="$(cli list-active-conversations 2>/dev/null)"
+    actionable="$(cli list-active-conversations)" || actionable=''   # empty ⇒ trips the fail-closed array check below
     normalized="$(printf '%s' "$actionable" | tr -d '[:space:]')"
 
     # ★ EMPTY-TICK COST GUARD — exit cheap, spawn zero `claude`.

--- a/bin/lib/bug-pipeline-test-stubs.sh
+++ b/bin/lib/bug-pipeline-test-stubs.sh
@@ -130,6 +130,8 @@ SH
 #!/usr/bin/env bash
 echo "DB_NAME=$DB_NAME" >> "$STUB/env.log"
 cat "$STUB/actionable.json" 2>/dev/null || echo '[]'
+# LIST_ACTIVE_RC seam: same shape as CLAIM_NEXT_RC — a PHP fatal writes to stdout AND exits non-zero.
+if [ -n "${LIST_ACTIVE_RC:-}" ] && [ "$LIST_ACTIVE_RC" != "0" ]; then exit "$LIST_ACTIVE_RC"; fi
 SH
 
     # transition.php stub: log args, echo ok (no DB).
@@ -149,6 +151,8 @@ case "$*" in
   *--resume*) cat "$STUB/claim-next-resume.out" 2>/dev/null || true ;;
   *)          cat "$STUB/claim-next.out"        2>/dev/null || true ;;
 esac
+# CLAIM_NEXT_RC seam: reproduce a PHP fatal, which prints to BOTH streams and exits non-zero.
+if [ -n "${CLAIM_NEXT_RC:-}" ] && [ "$CLAIM_NEXT_RC" != "0" ]; then exit "$CLAIM_NEXT_RC"; fi
 SH
 
     # list-pr-open.php stub: log; emit the case's pr_open rows (default: empty array).
@@ -215,7 +219,8 @@ bpt_reset() {
           "$STUB"/gh-pr-list.out "$STUB"/gh-pr-list-*.out "$STUB"/gh-pr-view.out 2>/dev/null
     rm -rf "$STUB"/wt/* 2>/dev/null
     printf '[]' > "$STUB/actionable.json"
-    unset GH_FAIL STUB_THREAD_ID STUB_MESSAGE_ID STUB_ISSUE_NUMBER WT_NEW_FAIL STUB_CREATE_THREAD_FAIL
+    unset GH_FAIL STUB_THREAD_ID STUB_MESSAGE_ID STUB_ISSUE_NUMBER WT_NEW_FAIL STUB_CREATE_THREAD_FAIL \
+          CLAIM_NEXT_RC LIST_ACTIVE_RC
 }
 
 bpt_set_actionable()  { printf '%s' "$1" > "$STUB/actionable.json"; }

--- a/bin/test-bug-pipeline-hunt
+++ b/bin/test-bug-pipeline-hunt
@@ -198,13 +198,28 @@ bpt_count   "r21: exactly one mention"          1 <(grep MENTION "$STUB/calls.lo
 bpt_log_has "$STUB" curl.log '"thread_id":"880000000000000001"' "r21: thread_id sent as a JSON string"
 bpt_log_has "$STUB" curl.log '"discord_id":"770000000000000007"' "r21: approver id sent as a JSON string"
 
-# ── Row 22 — terminal:true short-circuits the cap → needs_human after ONE ladder run ──
+# ── Row 22 — terminal:true short-circuits BOTH the ladder and the cap → needs_human after ONE tier ──
+# The count is the load-bearing assertion: terminal means "a dearer tier would be pointless"
+# (bin/bug-pipeline-hunter-prompt § hunt-result schema), so sonnet and opus must never run.
 bpt_reset
 bpt_set_claim "$CLAIM"; bpt_set_result '{"verdict":"escalate","terminal":true}'
 bpt_run
-bpt_count     "r22: exactly one ladder ran (no 2nd attempt)" 3 "$STUB/hunt-models.log"
+bpt_count     "r22: exactly ONE tier ran (no sonnet, no opus, no 2nd attempt)" 1 "$STUB/hunt-models.log"
+bpt_log_has   "$STUB" hunt-models.log "claude-haiku-4-5" "r22: the one tier that ran is the cheapest"
 bpt_log_has   "$STUB" transition.log "needs_human" "r22: terminal failure → needs_human"
+# Terminal still records the one attempt it consumed — unchanged by the ladder short-circuit, and
+# inert in practice: the row leaves the hunting loop for needs_human, so the count is never re-read.
+bpt_log_has   "$STUB" transition.log "--attempts=1" "r22: the consumed attempt is persisted"
 bpt_log_lacks "$STUB" transition.log "--attempts=2" "r22: never reaches attempt 2"
+
+# ── Row 22b — terminal:true at the MIDDLE tier: haiku escalates, sonnet terminal → opus never runs ──
+bpt_reset
+bpt_set_claim "$CLAIM"
+bpt_set_result_for claude-haiku-4-5  '{"verdict":"escalate","terminal":false}'
+bpt_set_result_for claude-sonnet-4-6 '{"verdict":"escalate","terminal":true}'
+bpt_run
+bpt_count     "r22b: ladder stopped at tier 2" 2 "$STUB/hunt-models.log"
+bpt_log_lacks "$STUB" hunt-models.log "opus" "r22b: opus never spawned once a tier says terminal"
 
 # ── Row 25 — usage-limit mid-hunt → blocked + future blocked_until; NOT needs_human; attempts unchanged ──
 bpt_reset
@@ -253,6 +268,53 @@ bpt_run
 bpt_count "r-legacy: no wt-new call (legacy dir reused)" 0 "$STUB/wt-new.log"
 bpt_log_has "$STUB" transition.log "transition 7 pr_open" "r-legacy: hunt still ships using the reused legacy worktree"
 
+# ── Rows 37-40 — ★ TOKEN-BLEED GUARDS: a broken upstream must spawn ZERO hunters ─────────────
+# Regression pin for 2026-08-04: MariaDB was down, every claim-next died with an uncaught
+# mysqli_sql_exception printed to BOTH stdout and stderr, `[ -z "$claimed" ]` therefore passed,
+# and `jq -r '.id'` yielded "" — so 28 ticks each dispatched the full haiku→sonnet→opus ladder
+# against report id "". 84 sessions, zero useful work.
+PHP_FATAL='PHP Fatal error:  Uncaught mysqli_sql_exception: Connection refused in /app/ibl5/db/db.php:101
+Stack trace:
+#0 /app/ibl5/scripts/bug-pipeline/_bootstrap.php(45)'
+
+# ── Row 37 — claim-next exits non-zero (PHP fatal on stdout) → cli fails closed, no hunter ──
+bpt_reset
+bpt_set_claim "$PHP_FATAL"
+export CLAIM_NEXT_RC=255
+bpt_run
+unset CLAIM_NEXT_RC
+bpt_expect_eq   "r37: exit 0" 0 "$BPT_RC"
+bpt_file_absent "$STUB/claude.sentinel" "r37: a failing claim-next spawns ZERO hunters"
+bpt_count       "r37: no worktree created" 0 "$STUB/wt-new.log"
+bpt_log_has     "$STUB" tick.out "claim-next.php exited 255" "r37: the failure is logged, not swallowed"
+
+# ── Row 38 — claim-next exits 0 but prints non-JSON garbage → id guard, no hunter ──
+bpt_reset
+bpt_set_claim "$PHP_FATAL"
+bpt_run
+bpt_expect_eq   "r38: exit 0" 0 "$BPT_RC"
+bpt_file_absent "$STUB/claude.sentinel" "r38: unparseable claim output spawns ZERO hunters"
+bpt_log_has     "$STUB" tick.out "no usable .id" "r38: refusal is logged"
+bpt_log_lacks   "$STUB" tick.out "claimed bug  into hunting" "r38: no phantom claim in the timeline"
+
+# ── Row 39 — well-formed JSON with no .id field → id guard, no hunter ──
+bpt_reset
+bpt_set_claim '{"status":"hunting","class":"bug","original_text":"the trade button is broken"}'
+bpt_run
+bpt_file_absent "$STUB/claude.sentinel" "r39: an id-less row spawns ZERO hunters"
+bpt_count       "r39: no worktree created" 0 "$STUB/wt-new.log"
+
+# ── Row 40 — valid row, empty report body → needs_human WITHOUT spawning a hunter ──
+# Every tier could only escalate on an empty body; hand it straight to a human. No Discord
+# post/mention here on purpose — a repeating fault must not trade a token bleed for a ping bleed.
+bpt_reset
+bpt_set_claim '{"id":"7","status":"hunting","class":"bug","thread_id":"880000000000000001","issue_number":"4242","original_text":"   ","hunt_attempts":0}'
+bpt_run
+bpt_file_absent "$STUB/claude.sentinel" "r40: an empty report body spawns ZERO hunters"
+bpt_count       "r40: no worktree created" 0 "$STUB/wt-new.log"
+bpt_log_has     "$STUB" transition.log "transition 7 needs_human --release-lease" "r40: handed to a human, lease released"
+bpt_count       "r40: no Discord post for an empty body" 0 <(grep POST_TO_THREAD "$STUB/calls.log" 2>/dev/null)
+
 # ── Row 32 — RCA labels on ship: area/root_cause slugs → ensure+add label against the issue ──
 bpt_reset
 bpt_set_claim "$CLAIM"
@@ -295,9 +357,10 @@ bpt_set_claim "$CLAIM"; bpt_set_result '{"verdict":"fixed"}'; bpt_hunt_dirty; ex
 bpt_run
 unset GH_FAIL
 bpt_log_has "$STUB" transition.log "transition 7 pr_open" "r36: ship reaches pr_open despite failing gh"
-# NULL issue_number → issue ops no-op (no crash, still ships)
+# NULL issue_number → issue ops no-op (no crash, still ships). original_text must be present:
+# this row exercises the missing-ISSUE path, and drive_hunt_row refuses an empty BODY (row 40).
 bpt_reset
-bpt_set_claim '{"id":"9","status":"hunting","class":"bug","thread_id":"880000000000000009","hunt_attempts":0}'
+bpt_set_claim '{"id":"9","status":"hunting","class":"bug","thread_id":"880000000000000009","original_text":"the trade button is broken","hunt_attempts":0}'
 bpt_set_result '{"verdict":"fixed"}'; bpt_hunt_dirty
 bpt_run
 bpt_log_has "$STUB" transition.log "transition 9 pr_open" "r36: NULL issue_number row still ships (issue ops no-op)"

--- a/bin/test-bug-pipeline-tick
+++ b/bin/test-bug-pipeline-tick
@@ -35,6 +35,20 @@ bpt_run
 bpt_expect_eq "garbage enumerator → exit 1" 1 "$BPT_RC"
 bpt_file_absent "$STUB/claude.sentinel" "garbage enumerator spawns zero claude"
 
+# ── ★ NEG — enumerator EXITS NON-ZERO with a PHP fatal on stdout → fail-closed ─
+# The 2026-08-04 shape: a MariaDB outage makes every wrapper die with an uncaught
+# mysqli_sql_exception printed to BOTH streams. cli() must swallow that stdout rather than
+# hand it on as data, so the array check below it trips and the tick aborts before dispatch.
+bpt_reset
+bpt_set_actionable 'PHP Fatal error:  Uncaught mysqli_sql_exception: Connection refused'
+export LIST_ACTIVE_RC=255
+bpt_run
+unset LIST_ACTIVE_RC
+bpt_expect_eq   "failing enumerator → exit 1" 1 "$BPT_RC"
+bpt_file_absent "$STUB/claude.sentinel" "failing enumerator spawns zero claude"
+bpt_log_has     "$STUB" tick.out "list-active-conversations.php exited 255" \
+                "the enumerator failure is logged, not swallowed"
+
 # ── Env resolution: unset DB_NAME → driver exports iblhoops_ibl5 to children ──
 bpt_reset
 ( unset DB_NAME; bpt_set_actionable '[]'; bpt_run )


### PR DESCRIPTION
## Summary
- Fail-closed `cli()` wrapper: captures exit codes, logs errors to stderr instead of passing garbage output as data to callers
- ID validation guard in `drive_hunt_row()`: rejects rows with missing/null/empty `.id` before dispatch
- Body validation guard: rejects rows with empty report body (no hunter spawned; handed directly to human)
- Terminal short-circuit: `run_hunt_ladder()` stops at `terminal:true` instead of escalating to costlier tiers
- Diagnostic access: removed `2>/dev/null` suppressions to expose PHP fatal errors in logs
- Regression tests: 4 new cases pinned to 2026-08-04 MariaDB outage (non-zero exits, garbage output, missing IDs, empty bodies)

## Manual Testing

No manual testing needed — verified by automated tests.
