### PR TITLE
fix(deps): bump brace-expansion to 5.0.9, ip-address and socket.io-parser to patched versions

### DIFF
--- a/ibl5/package-lock.json
+++ b/ibl5/package-lock.json
@@ -2380,19 +2380,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.3",
       "dev": true,
@@ -4465,9 +4452,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5386,17 +5373,32 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/mri": {
@@ -6017,9 +6019,9 @@
       }
     },
     "node_modules/resp-modifier/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6455,7 +6457,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ibl5/package.json
+++ b/ibl5/package.json
@@ -38,9 +38,9 @@
     "uuid": "14.0.0",
     "ws": "8.21.0",
     "immutable": "4.3.9",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "eslint": {
-      "brace-expansion": "5.0.8"
+      "brace-expansion": "5.0.9"
     }
   },
   "//pin": "@playwright/test is exact-pinned (no caret) so bin/playwright-image-tag derives the Playwright Docker image tag from THIS version at runtime — the image and the installed client cannot drift (ADR-0070). Dependabot bumps this; every CI surface follows automatically. The transitive playwright-core carried via @axe-core/playwright is left untouched — overriding it risks an incompatible axe-core/playwright-core pair, and it is separate from the runtime Playwright that executes tests.",


### PR DESCRIPTION
## Summary

Fixes 4 high-severity npm audit findings that were blocking CI (`JS Dependency Audit` job).

| Package | Before | After | Advisory |
|---------|--------|-------|----------|
| `brace-expansion` | 5.0.8 | 5.0.9 | GHSA-rgw5-rvv9-x895 (DoS) |
| `ip-address` | 10.2.0 | 10.4.0 | GHSA-mwp4-54f8-5fhr / GHSA-4xrf-jv44-h6hh / GHSA-22jq-vg5j-6vgg (SSRF) |
| `socket.io-parser` | 4.2.6 | 4.2.7 | GHSA-2m8v-j782-fhvr (Memory Exhaustion) |

Root cause: the `overrides` block in `package.json` was pinning `brace-expansion` to `5.0.8`, the vulnerable version. Updated to `5.0.9` and ran `npm install` to regenerate the lockfile.

`npm audit --audit-level=high` now returns `found 0 vulnerabilities`.
