### PR TITLE
fix(sim-recap): correct game_of_that_day contract, add store/display guards, repair sim 725 dropped recaps

### DIFF
--- a/bin/sim-recap-prompt
+++ b/bin/sim-recap-prompt
@@ -240,7 +240,23 @@ Strict field types:
   - game_date: non-empty string, format YYYY-MM-DD
   - recap_text (per game and top-level): non-empty strings
   - box_id: integer or null
-  - game_of_that_day: 1-based counter — use 1 when there was exactly one game on that date, or for the first game of a doubleheader; use 2 for the second game. Never use 0 — that silently drops this recap from the rendered output.
+  - game_of_that_day: READ this value from the database. Do NOT infer it, do NOT count
+    it yourself, and do NOT default it to 1. It is the 1-based index of the game within
+    its DATE across the entire league, assigned by the sim engine: on a seven-game night
+    the seven games carry 1, 2, 3, 4, 5, 6 and 7. It is NOT a doubleheader counter and it
+    is NOT per-matchup. Look it up once for the whole sim window:
+
+      SELECT DISTINCT game_date, visitor_teamid, home_teamid, game_of_that_day
+        FROM ibl_box_scores_teams
+       WHERE game_date BETWEEN '<start_date>' AND '<end_date>'
+       ORDER BY game_date, game_of_that_day;
+
+    (start_date and end_date come from ibl_sim_dates for this sim. ibl_box_scores_teams
+    stores one row per team side, so DISTINCT collapses it to one row per game.)
+
+    Copy the value verbatim into each game object. A wrong value silently drops that
+    recap from the rendered output: sim 725 wrote 1 for all 49 games and only 7 of them
+    ever rendered. Never use 0.
   - themes: array of strings — narrative angles you used this run (for the next ledger)
 
 == HOW TO PRODUCE IT ==
@@ -284,6 +300,15 @@ The following is the authoritative format reference. Match its structure exactly
   - Per game: **Away Team NNN @ Home Team NNN** header (bold), then <@id> · <@id> mentions
     line (away snowflake · home snowflake, middle-dot separated), then a blank line, then
     one prose paragraph
+
+Paragraph length is part of the format, not a style preference. Every game paragraph in
+the exemplar below runs between 504 and 639 characters, averaging 569. Hit that band. A
+paragraph under 500 characters is short of the exemplar and reads thin.
+
+This does not license long sentences. The ANTI-LLM-TELL PROHIBITIONS still bind in full:
+sentences stay short and punchy, two clauses maximum. You reach the band with MORE short
+sentences carrying more of the game, not with fewer, longer ones. Sentence construction
+and paragraph volume are separate dials.
 
 Injuries woven into prose. Long streaks called out. Pop culture references tied to the era.
 

--- a/bin/sim-recap-tick
+++ b/bin/sim-recap-tick
@@ -271,6 +271,18 @@ generate() { # sim
     store_rc=$?
     if [ "$store_rc" -eq 0 ] && jq_ok "$store" '.ok == true'; then
         log "sim $sim: stored ($(printf '%s' "$store" | "$SIM_RECAP_JQ_BIN" -r '.games' 2>/dev/null) game recaps)"
+        local avg_len
+        avg_len="$("$SIM_RECAP_JQ_BIN" -r \
+            '[.games[].recap_text | length] | if length == 0 then 0 else (add / length | floor) end' \
+            "$WORKDIR/payload.json" 2>/dev/null)"
+        case "$avg_len" in
+            ''|*[!0-9]*) : ;;  # unreadable payload: the store already succeeded, stay quiet
+            *)
+                if [ "$avg_len" -lt 504 ]; then
+                    log "sim $sim: WARNING — average game recap is ${avg_len} chars, below the exemplar band of 504-639. Stored anyway; prose is running short."
+                fi
+                ;;
+        esac
         return 0
     fi
     log "sim $sim: store failed (rc=$store_rc): $store — parking"

--- a/bin/test-sim-recap-tick
+++ b/bin/test-sim-recap-tick
@@ -124,6 +124,9 @@ SH
 
     # claude stub: touch sentinel, log call; write valid payload.json unless
     # agent-fails is set; emit usage-limit line when agent-usage-limit is set.
+    # resp.payload (if present): cat its content into payload.json instead of the
+    # built-in default — lets length-specific tests control recap_text size without
+    # overriding the whole stub. srt_reset wipes resp.* so cleanup is automatic.
     cat > "$STUB/claude" <<'SH'
 #!/usr/bin/env bash
 echo "claude $*" >> "$STUB/claude.log"
@@ -133,13 +136,17 @@ if [ -f "$STUB/agent-usage-limit" ]; then
     exit 0
 fi
 if [ ! -f "$STUB/agent-fails" ]; then
-    printf '%s\n' \
-        '{"intro_text":"intro","outro_text":"outro","recap_text":"recap",' \
-        '"themes":["theme1"],' \
-        '"games":[{"season_year":2008,"game_date":"2026-07-23",' \
-        '"visitor_teamid":1,"home_teamid":2,"game_of_that_day":0,' \
-        '"box_id":null,"sort_order":1,"recap_text":"game recap"}]}' \
-        | tr -d '\n' > payload.json
+    if [ -f "$STUB/resp.payload" ]; then
+        cat "$STUB/resp.payload" > payload.json
+    else
+        printf '%s\n' \
+            '{"intro_text":"intro","outro_text":"outro","recap_text":"recap",' \
+            '"themes":["theme1"],' \
+            '"games":[{"season_year":2008,"game_date":"2026-07-23",' \
+            '"visitor_teamid":1,"home_teamid":2,"game_of_that_day":0,' \
+            '"box_id":null,"sort_order":1,"recap_text":"game recap"}]}' \
+            | tr -d '\n' > payload.json
+    fi
 fi
 exit 0
 SH
@@ -522,6 +529,55 @@ PHPEOF
 else
     srt_fail "payload_contract — store.stdin not created (ssh stub did not record stdin)"
 fi
+
+# ── length_warn_fires_below_band ──────────────────────────────────────────────
+# A single-game payload with a ~280-char recap_text (avg < 504) must log the
+# prose-length warning and still exit 0 (the store already succeeded).
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+{
+    printf '%s' '{"intro_text":"intro","outro_text":"outro","recap_text":"recap","themes":["t"],'
+    printf '%s' '"games":[{"season_year":2008,"game_date":"2026-07-23","visitor_teamid":1,'
+    printf '%s' '"home_teamid":2,"game_of_that_day":0,"box_id":null,"sort_order":1,"recap_text":"'
+    printf '%280s' | tr ' ' 'x'
+    printf '%s' '"}]}'
+} > "$STUB/resp.payload"
+srt_run
+srt_expect_eq "length_warn_fires_below_band — exit 0" 0 "$SRT_RC"
+srt_log_has "$STUB" tick.out "stored"              "length_warn_fires_below_band — stored logged"
+srt_log_has "$STUB" tick.out "below the exemplar band" "length_warn_fires_below_band — warning logged"
+
+# ── length_warn_silent_inside_band ────────────────────────────────────────────
+# A single-game payload with a ~570-char recap_text (avg >= 504) must NOT log
+# the warning — prose is within the exemplar band.
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+{
+    printf '%s' '{"intro_text":"intro","outro_text":"outro","recap_text":"recap","themes":["t"],'
+    printf '%s' '"games":[{"season_year":2008,"game_date":"2026-07-23","visitor_teamid":1,'
+    printf '%s' '"home_teamid":2,"game_of_that_day":0,"box_id":null,"sort_order":1,"recap_text":"'
+    printf '%570s' | tr ' ' 'x'
+    printf '%s' '"}]}'
+} > "$STUB/resp.payload"
+srt_run
+srt_expect_eq "length_warn_silent_inside_band — exit 0" 0 "$SRT_RC"
+srt_log_lacks "$STUB" tick.out "below the exemplar band" "length_warn_silent_inside_band — no warning"
+
+# ── length_warn_does_not_change_store_outcome ─────────────────────────────────
+# A below-band payload must not trigger a park: the store outcome is unchanged
+# (the check is advisory only), so the tick exits 0 and never parks the sim.
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+{
+    printf '%s' '{"intro_text":"intro","outro_text":"outro","recap_text":"recap","themes":["t"],'
+    printf '%s' '"games":[{"season_year":2008,"game_date":"2026-07-23","visitor_teamid":1,'
+    printf '%s' '"home_teamid":2,"game_of_that_day":0,"box_id":null,"sort_order":1,"recap_text":"'
+    printf '%280s' | tr ' ' 'x'
+    printf '%s' '"}]}'
+} > "$STUB/resp.payload"
+srt_run
+srt_expect_eq "length_warn_does_not_change_store_outcome — exit 0" 0 "$SRT_RC"
+srt_log_lacks "$STUB" tick.out "parked" "length_warn_does_not_change_store_outcome — no park"
 
 # ══ PROMPT GROUP — real bin/sim-recap-prompt ══════════════════════════════════
 

--- a/bin/test-sim-recap-tick
+++ b/bin/test-sim-recap-tick
@@ -614,8 +614,47 @@ srt_log_has "$STUB" prompt.out "frozen historical marker" \
 # ── game_of_that_day_contract ─────────────────────────────────────────────────
 srt_log_lacks "$STUB" prompt.out "integer zero, not null" \
     "game_of_that_day_contract — old 'integer zero' instruction absent"
-srt_log_has "$STUB" prompt.out "1-based counter" \
-    "game_of_that_day_contract — 1-based instruction present"
+srt_log_lacks "$STUB" prompt.out "first game of a doubleheader" \
+    "game_of_that_day_contract — retired doubleheader semantics absent"
+srt_log_has "$STUB" prompt.out "READ this value from the database" \
+    "game_of_that_day_contract — read-not-infer directive present"
+srt_log_has "$STUB" prompt.out "index of the game within" \
+    "game_of_that_day_contract — within-date semantics present"
+srt_log_has "$STUB" prompt.out "FROM ibl_box_scores_teams" \
+    "game_of_that_day_contract — lookup query present"
+
+# ── prose_length_band_present ─────────────────────────────────────────────────
+srt_log_has "$STUB" prompt.out "504 and 639 characters" \
+    "prose_length_band_present — exemplar band stated"
+srt_log_has "$STUB" prompt.out "ANTI-LLM-TELL PROHIBITIONS still bind" \
+    "prose_length_band_present — band reconciled with the hard bans"
+
+# ── anti_tell_bans_survive_length_band ────────────────────────────────────────
+# Negative path: the length anchor must not have softened the sentence-shape ban.
+srt_log_has "$STUB" prompt.out "Short, punchy sentences." \
+    "anti_tell_bans_survive_length_band — punchy-sentence ban intact"
+
+# ── length_band_matches_exemplar ──────────────────────────────────────────────
+# The band printed in the prompt is a measurement of the pinned exemplar. Recompute
+# it so an exemplar swap fails here instead of shipping a stale instruction.
+_band=$(awk '
+    /^\*\*.* [0-9]+ @ .* [0-9]+\*\*$/  { st=1; next }
+    st==1 && /^<@/                     { st=2; next }
+    st==2 && $0 == ""                  { st=3; next }
+    st==3 && length($0) > 0            { n++; L=length($0);
+                                         if (mn=="" || L<mn) mn=L; if (L>mx) mx=L;
+                                         st=0; next }
+                                       { st=0 }
+    END { printf "%d %d %d", n+0, mn+0, mx+0 }
+' "$SRT_EXEMPLAR")
+read -r _bn _bmin _bmax <<BAND_EOF
+$_band
+BAND_EOF
+if [ "$_bmin" -ge 504 ] && [ "$_bmax" -le 639 ] && [ "$_bn" -gt 0 ]; then
+    srt_ok "length_band_matches_exemplar — $_bn paragraphs, min $_bmin, max $_bmax inside stated band"
+else
+    srt_fail "length_band_matches_exemplar — exemplar measures '$_band', prompt claims 504..639"
+fi
 
 # ── negative_roster_absent ────────────────────────────────────────────────────
 # Without --roster, Block 8 must not appear.

--- a/ibl5/classes/SimRecap/README.md
+++ b/ibl5/classes/SimRecap/README.md
@@ -1,16 +1,16 @@
 ---
 description: Ingests externally-generated sim recap documents and queues them for the sim recap pipeline; SimRecapContextRepository precomputes roster context for generation.
-last_verified: 2026-07-30
+last_verified: 2026-08-04
 ---
 
 # SimRecap
 
-Handles the ingest of externally-generated simulation recap documents into the application's pipeline. `SimRecapPayload` parses and validates incoming recap documents at the trust boundary, failing closed on structural errors. `SimSummaryRepository` implements atomic conditional-UPDATE queue logic mirroring the BugPipeline pattern to prevent duplicate processing. `SimSummariesView` renders the recap summaries for display. Entry script: `ibl5/scripts/storeSimRecap.php`. The `simRecapContext.php` script precomputes current rosters, active injuries, and in-window trades via `SimRecapContextRepository`, providing roster context for the sim-recap generation pipeline.
+Handles the ingest of externally-generated simulation recap documents into the application's pipeline. `SimRecapPayload` parses and validates incoming recap documents at the trust boundary, failing closed on structural errors. `SimSummaryRepository` implements atomic conditional-UPDATE queue logic mirroring the BugPipeline pattern to prevent duplicate processing. It also validates at write time that every game row in a payload joins to an archived box score on date + teams + game_of_that_day, so a payload that could never render is refused before it becomes a row. `SimSummariesView` renders the recap summaries for display. Entry script: `ibl5/scripts/storeSimRecap.php`. The `simRecapContext.php` script precomputes current rosters, active injuries, and in-window trades via `SimRecapContextRepository`, providing roster context for the sim-recap generation pipeline.
 
 | Class | Role |
 |---|---|
 | `SimRecapPayload` | Parses and validates incoming recap documents |
-| `SimSummaryRepository` | Atomic queue operations for the recap pipeline |
+| `SimSummaryRepository` | Atomic queue operations, plus the write-time box-score join validation |
 | `SimSummariesView` | Renders sim recap summaries |
-| `RecapDocument` | Assembles the postable document from intro + game rows + outro, shaped like `bin/lib/sim-recap-exemplar.txt` |
+| `RecapDocument` | Assembles the postable document from intro + game rows + outro, shaped like `bin/lib/sim-recap-exemplar.txt`; prefers the stored text when the parts are degraded or incomplete |
 | `SimRecapContextRepository` | Precomputes current rosters, active injuries, and in-window trades for a sim |

--- a/ibl5/classes/SimRecap/RecapDocument.php
+++ b/ibl5/classes/SimRecap/RecapDocument.php
@@ -42,6 +42,13 @@ final class RecapDocument
     private const MENTION_LINE = '/^<@\d+>(?:\s*·\s*<@\d+>)*$/u';
 
     /**
+     * `**Boston Celtics 100 @ Miami Heat 114**` — the bold score header that opens every
+     * game block in `bin/lib/sim-recap-exemplar.txt`. Counting these in the stored text
+     * is how this class learns how many games the generator actually wrote.
+     */
+    private const SCORE_HEADER = '/^\*\*.+\s\d+\s@\s.+\s\d+\*\*$/m';
+
+    /**
      * @param list<array<string, mixed>> $gameRecaps From SimSummaryRepository::findDisplayableGameRecaps(), already in sort order
      */
     public static function assemble(?string $intro, array $gameRecaps, ?string $outro): string
@@ -78,6 +85,12 @@ final class RecapDocument
      * every GM's Discord tag — worse than what the league had before this class existed.
      * So when the parts are degraded, fall back to the stored text.
      *
+     * Sim 725 (2026-08-02) failed the other way: the parts were well formed but there
+     * were only 7 of them, because all 49 rows had been stored with `game_of_that_day`
+     * = 1 and the displayable filter matched one game per date. Shape alone said
+     * "assemble". So the count of score headers in the stored text is a second,
+     * independent floor on how many games the assembly must contain.
+     *
      * `assemble()` deliberately stays shape-tolerant (it is a pure formatter and cannot
      * see the stored text), which is why the choice lives here instead.
      *
@@ -96,6 +109,20 @@ final class RecapDocument
         // No parts at all: the stored text, returned verbatim. Trimming would change the
         // exported bytes, so the emptiness test above is the only place `trim()` is used.
         if ($document === '') {
+            return $stored;
+        }
+
+        // Shape is not completeness. The parts are only the games that survived
+        // SimSummaryRepository::findDisplayableGameRecaps(); a bad `game_of_that_day`
+        // index makes that filter drop games silently. Sim 725 (2026-08-02) stored 49
+        // games, 7 survived the filter, and all 7 were well formed — so the shape guard
+        // below voted to assemble and would have posted 7 games in place of 49.
+        //
+        // The stored text is the generator's own record of how many games it wrote, so
+        // any shortfall against it means the assembly is missing games. Sibling of
+        // gamesCarryTheirMentionLines(), not a replacement: that guard catches degraded
+        // parts, this one catches absent ones. Either firing prefers the stored text.
+        if (self::renderedGameCount($gameRecaps) < self::countScoreHeaders($stored)) {
             return $stored;
         }
 
@@ -136,6 +163,39 @@ final class RecapDocument
         }
 
         return $sawAGame;
+    }
+
+    /**
+     * How many games `assemble()` will actually render. groupByDate() drops rows whose
+     * text cleans to empty, so a raw count($gameRecaps) would overstate the document and
+     * let a shortfall through — the count must use the same basis assembly does.
+     *
+     * @param list<array<string, mixed>> $gameRecaps
+     */
+    private static function renderedGameCount(array $gameRecaps): int
+    {
+        $rendered = 0;
+
+        foreach ($gameRecaps as $game) {
+            if (self::clean($game['recap_text'] ?? null) !== '') {
+                $rendered++;
+            }
+        }
+
+        return $rendered;
+    }
+
+    /**
+     * Score headers in the stored document. CRLF is normalized first because the `m`
+     * anchor would otherwise leave a `\r` before the line end and match nothing. A
+     * teaser-shaped `recap_text` has no headers and yields 0, which is what makes the
+     * completeness guard inert for sims that never stored a full document.
+     */
+    private static function countScoreHeaders(string $text): int
+    {
+        $count = preg_match_all(self::SCORE_HEADER, str_replace("\r\n", "\n", $text));
+
+        return $count === false ? 0 : $count;
     }
 
     /**

--- a/ibl5/classes/SimRecap/SimSummaryRepository.php
+++ b/ibl5/classes/SimRecap/SimSummaryRepository.php
@@ -396,4 +396,84 @@ class SimSummaryRepository extends \BaseMysqliRepository
         /** @var list<array<string, mixed>> */
         return $this->fetchAll($sql, 'i', $sim);
     }
+
+    /**
+     * Fail-closed write-time counterpart to findDisplayableGameRecaps(): every game row
+     * in a payload must match an archived box score on date + teams + game_of_that_day.
+     *
+     * The invariant is that anything storable is displayable. Sim 725 stored 49 rows
+     * whose `game_of_that_day` was 1 for every game; the display filter matched one game
+     * per date and 42 recaps became unreachable. Nothing at write time noticed, because
+     * nothing at write time asked the display filter's question.
+     *
+     * One query for the whole payload, keyed on the distinct game dates — `idx_date_
+     * visitor_home_gotd` covers (game_date, visitor_teamid, home_teamid, game_of_that_day)
+     * so the range scan is indexed. COALESCE mirrors findDisplayableGameRecaps() exactly:
+     * if the two ever diverge, a payload could validate and still fail to render.
+     *
+     * Deliberately NOT built on gameOfThatDaySubquery(): that helper collapses a date's
+     * rows with MIN(game_of_that_day), which would make a wrong index look correct — the
+     * precise failure this method exists to catch.
+     *
+     * @param list<array{season_year: int, game_date: string, visitor_teamid: int, home_teamid: int, game_of_that_day: int, box_id: ?int, sort_order: int, recap_text: string}> $games
+     * @throws \RuntimeException when any row has no matching archived box score
+     */
+    public function validateGameRowsJoinToBoxScores(array $games): void
+    {
+        if ($games === []) {
+            return;
+        }
+
+        $dates = array_values(array_unique(array_column($games, 'game_date')));
+
+        $sql = "SELECT DISTINCT `game_date`, `visitor_teamid`, `home_teamid`,"
+            . " COALESCE(`game_of_that_day`, 0) AS `game_of_that_day`"
+            . " FROM `ibl_box_scores_teams`"
+            . " WHERE `game_date` IN ({IN})";
+
+        $archived = [];
+        /** @var list<array{game_date: string, visitor_teamid: int, home_teamid: int, game_of_that_day: int}> $rows */
+        $rows = $this->fetchAllInList($sql, 's', $dates);
+        foreach ($rows as $row) {
+            $archived[self::gameKey(
+                $row['game_date'],
+                $row['visitor_teamid'],
+                $row['home_teamid'],
+                $row['game_of_that_day']
+            )] = true;
+        }
+
+        $orphans = [];
+        foreach ($games as $game) {
+            $key = self::gameKey(
+                $game['game_date'],
+                $game['visitor_teamid'],
+                $game['home_teamid'],
+                $game['game_of_that_day']
+            );
+            if (!isset($archived[$key])) {
+                $orphans[] = $key;
+            }
+        }
+
+        if ($orphans !== []) {
+            throw new \RuntimeException(sprintf(
+                '%d of %d game rows do not match an archived box score on date + teams + game_of_that_day: %s%s',
+                count($orphans),
+                count($games),
+                implode(', ', array_slice($orphans, 0, 5)),
+                count($orphans) > 5 ? ', …' : ''
+            ));
+        }
+    }
+
+    /**
+     * Stable identity for a game across the payload and the box-score archive. Also the
+     * human-readable form used in the failure message, so an operator reading stderr can
+     * paste the date and teams straight into a query.
+     */
+    private static function gameKey(string $date, int $visitor, int $home, int $gameOfThatDay): string
+    {
+        return sprintf('%s v%d@h%d gotd=%d', $date, $visitor, $home, $gameOfThatDay);
+    }
 }

--- a/ibl5/migrations/157_repair_sim725_game_of_that_day.sql
+++ b/ibl5/migrations/157_repair_sim725_game_of_that_day.sql
@@ -1,0 +1,39 @@
+-- Migration 157: Repair sim 725's game_of_that_day indices from the box-score archive
+--
+-- bin/sim-recap-prompt described game_of_that_day as a doubleheader counter. It is
+-- actually the 1-based index of a game within its DATE across the whole league. The
+-- generation agent for sim 725 (2026-08-02) followed the contract literally and wrote
+-- 1 for all 49 games. SimSummaryRepository::findDisplayableGameRecaps() matches recaps
+-- to box scores on date + teams + game_of_that_day, so exactly one game per date
+-- matched: 7 of 49 recaps were displayable and 42 were unreachable. Every other column
+-- on those rows is correct, including the full recap_text.
+--
+-- ibl_box_scores_teams stores one row per TEAM side, so the derived table collapses
+-- each matchup to a single row. HAVING COUNT(DISTINCT game_of_that_day) = 1 is the
+-- collision guard: uniq_game spans (season_year, game_date, visitor_teamid,
+-- home_teamid, game_of_that_day), so a matchup that legitimately carries two indices
+-- on one date would map both recap rows to the same key and the UPDATE would abort
+-- mid-batch (MigrationRunner uses multi_query, so an abort halts every statement
+-- after it). Excluding ambiguous matchups makes the collision impossible by
+-- construction, independent of whether any such matchup exists in sim 725; the
+-- post-deploy check in Step 6.4 names any row the guard skipped, for a separate call.
+--
+-- Idempotent: the `<>` predicate means a second run matches no rows and reports
+-- affected_rows = 0, mirroring the sentinel-guarded UPDATEs in migration 097.
+--
+-- Scoped to sim 725 alone. No other sim's rows are read or written.
+
+UPDATE ibl_sim_game_recaps gr
+  JOIN (
+        SELECT game_date, visitor_teamid, home_teamid,
+               MIN(game_of_that_day) AS game_of_that_day
+          FROM ibl_box_scores_teams
+         GROUP BY game_date, visitor_teamid, home_teamid
+        HAVING COUNT(DISTINCT game_of_that_day) = 1
+       ) bst
+    ON bst.game_date      = gr.game_date
+   AND bst.visitor_teamid = gr.visitor_teamid
+   AND bst.home_teamid    = gr.home_teamid
+   SET gr.game_of_that_day = COALESCE(bst.game_of_that_day, 0)
+ WHERE gr.sim = 725
+   AND gr.game_of_that_day <> COALESCE(bst.game_of_that_day, 0);

--- a/ibl5/scripts/storeSimRecap.php
+++ b/ibl5/scripts/storeSimRecap.php
@@ -88,8 +88,21 @@ try {
     fail('malformed payload: ' . $e->getMessage());
 }
 
-// ── Write, then confirm ───────────────────────────────────────────────────────
+// ── Validate against the archive (fail closed BEFORE anything is written) ─────
+// Structural validity is not enough. Sim 725's payload parsed cleanly and stored
+// 49 rows, but every row carried game_of_that_day = 1, so the display filter
+// matched one game per date and 42 recaps became unreachable. A payload whose
+// games cannot render must never become a row. Nothing below this point runs on
+// failure: fail() is `never`, the write is downstream, and the Discord post is
+// downstream of the write — so an aborted store posts nothing.
 $repo = new \SimRecap\SimSummaryRepository($mysqli_db);
+try {
+    $repo->validateGameRowsJoinToBoxScores($payload->getGames());
+} catch (\Throwable $e) {
+    fail('payload rejected: ' . $e->getMessage());
+}
+
+// ── Write, then confirm ───────────────────────────────────────────────────────
 $repo->markDone(
     $sim,
     $payload->getIntroText(),

--- a/ibl5/tests/DatabaseIntegration/SimRecap/Sim725RepairMigrationTest.php
+++ b/ibl5/tests/DatabaseIntegration/SimRecap/Sim725RepairMigrationTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\SimRecap;
+
+use PHPUnit\Framework\Attributes\Group;
+use SimRecap\SimSummaryRepository;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+
+/**
+ * Exercises the shipped migration file 157 against seeded fixtures. Each test
+ * seeds its own rows, applies the real migration, and rolls back — the migration
+ * is pure DML so DatabaseTestCase's per-test transaction covers it.
+ *
+ * Applying the file itself (not a transcription) is deliberate: a test holding
+ * its own copy of the SQL cannot detect the shipped file being wrong.
+ */
+#[Group('database')]
+final class Sim725RepairMigrationTest extends DatabaseTestCase
+{
+    private SimSummaryRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new SimSummaryRepository($this->db);
+    }
+
+    public function testRepairAssignsBoxScoreIndicesToSim725(): void
+    {
+        $this->seedSim725InTheAllOnesShape();
+        $this->seedBoxScoresAtIndices1To7();
+
+        $this->applyMigration();
+
+        $recaps = $this->repo->findGameRecaps(725);
+        self::assertSame([1, 2, 3, 4, 5, 6, 7], array_column($recaps, 'game_of_that_day'));
+    }
+
+    public function testRepairIsIdempotent(): void
+    {
+        $this->seedSim725InTheAllOnesShape();
+        $this->seedBoxScoresAtIndices1To7();
+
+        $this->applyMigration();
+        $afterFirst = $this->repo->findGameRecaps(725);
+
+        $secondAffected = $this->applyMigration();
+        $afterSecond = $this->repo->findGameRecaps(725);
+
+        self::assertSame($afterFirst, $afterSecond, 'a second application must change nothing');
+        self::assertSame(0, $secondAffected, 'the second application must be a genuine no-op');
+    }
+
+    public function testRepairTouchesNoOtherSim(): void
+    {
+        // Sim 724 carries the same seven matchups on a DIFFERENT date, all at index
+        // 1, WITH box scores that would repair it — uniq_game (season_year, date,
+        // teams, game_of_that_day) excludes sim, so 724 must use its own date or its
+        // rows collide with 725's. Seeding 724's box scores makes it a repair
+        // candidate, so its staying at index 1 proves WHERE gr.sim = 725 is doing
+        // the work, not the absence of a join match.
+        $this->seedAllOnesShape(724, '2025-03-01');
+        $this->seedBoxScoresForDate('2025-03-01');
+        $this->seedSim725InTheAllOnesShape();
+        $this->seedBoxScoresAtIndices1To7();
+
+        $this->applyMigration();
+
+        $other = $this->repo->findGameRecaps(724);
+        self::assertSame([1, 1, 1, 1, 1, 1, 1], array_column($other, 'game_of_that_day'), 'sim 724 must be untouched');
+
+        $target = $this->repo->findGameRecaps(725);
+        self::assertSame([1, 2, 3, 4, 5, 6, 7], array_column($target, 'game_of_that_day'), 'sim 725 must be repaired');
+    }
+
+    public function testRepairSkipsAMatchupCarryingTwoIndicesOnOneDate(): void
+    {
+        // Two matchups on 2025-02-15: (20,21) legitimately played twice (indices 2
+        // and 5) and (22,23) once (index 1). Both stored in the all-ones shape.
+        $games = [
+            $this->recapRow(0, '2025-02-15', 20, 21, 1),
+            $this->recapRow(1, '2025-02-15', 22, 23, 1),
+        ];
+        $this->repo->markDone(725, 'Intro.', 'Outro.', 'Recap.', $games, null);
+
+        $this->db->query(
+            "INSERT INTO `ibl_box_scores_teams` (`game_date`, `visitor_teamid`, `home_teamid`, `game_of_that_day`, `name`)" .
+            " VALUES ('2025-02-15', 20, 21, 2, 'DHa'), ('2025-02-15', 20, 21, 5, 'DHb')," .
+            "        ('2025-02-15', 22, 23, 1, 'Single')"
+        );
+
+        // Must NOT abort on uniq_game: the HAVING guard excludes the ambiguous matchup.
+        $this->applyMigration();
+
+        $recaps = $this->repo->findGameRecaps(725);
+        $byMatchup = [];
+        foreach ($recaps as $row) {
+            $byMatchup[$row['visitor_teamid'] . '-' . $row['home_teamid']] = $row['game_of_that_day'];
+        }
+
+        self::assertSame(1, $byMatchup['20-21'], 'the ambiguous matchup is left at its stored index, not collided');
+        self::assertSame(1, $byMatchup['22-23'], 'the unambiguous matchup maps to its single box-score index');
+    }
+
+    public function testRepairedRowsAreAllDisplayable(): void
+    {
+        $this->seedSim725InTheAllOnesShape();
+        $this->seedBoxScoresAtIndices1To7();
+
+        $this->applyMigration();
+
+        $displayable = $this->repo->findDisplayableGameRecaps(725);
+        self::assertCount(7, $displayable, 'every repaired row must satisfy the display filter that rejected it');
+    }
+
+    public function testRepairIsANoOpWhenSim725HasNoRows(): void
+    {
+        // The state of every fresh CI database: no sim-725 rows at all.
+        self::assertSame(0, $this->applyMigration(), 'applying to a database with no sim-725 rows affects nothing');
+    }
+
+    // ── Private helpers ────────────────────────────────────────────────────────
+
+    /**
+     * Applies the shipped migration file and returns the UPDATE's affected-row
+     * count. mysqli::$affected_rows must be read immediately after multi_query() —
+     * the migration is a single UPDATE, and draining the result set with
+     * next_result() below resets affected_rows to -1.
+     */
+    private function applyMigration(): int
+    {
+        $sql = file_get_contents(dirname(__DIR__, 3) . '/migrations/157_repair_sim725_game_of_that_day.sql');
+        self::assertIsString($sql);
+        self::assertTrue($this->db->multi_query($sql), $this->db->error);
+        $affected = $this->db->affected_rows;
+        while ($this->db->more_results()) {
+            $this->db->next_result();
+        }
+        return $affected;
+    }
+
+    private function seedSim725InTheAllOnesShape(): void
+    {
+        $this->seedAllOnesShape(725, '2025-02-14');
+    }
+
+    /**
+     * Seven distinct matchups on $date, every recap stored at game_of_that_day 1 —
+     * the exact shape sim 725 hit. Distinct (visitor, home) pairs keep them off
+     * uniq_game despite the shared index.
+     */
+    private function seedAllOnesShape(int $sim, string $date): void
+    {
+        $games = [
+            $this->recapRow(0, $date, 1,  2,  1),
+            $this->recapRow(1, $date, 3,  4,  1),
+            $this->recapRow(2, $date, 5,  6,  1),
+            $this->recapRow(3, $date, 7,  8,  1),
+            $this->recapRow(4, $date, 9,  10, 1),
+            $this->recapRow(5, $date, 11, 12, 1),
+            $this->recapRow(6, $date, 13, 14, 1),
+        ];
+        $this->repo->markDone($sim, 'Intro.', 'Outro.', 'Recap.', $games, null);
+    }
+
+    private function seedBoxScoresAtIndices1To7(): void
+    {
+        $this->seedBoxScoresForDate('2025-02-14');
+    }
+
+    /**
+     * Box scores for the seven all-ones matchups on $date, at indices 1..7 — the
+     * archive the repair reads from.
+     */
+    private function seedBoxScoresForDate(string $date): void
+    {
+        $this->db->query(
+            "INSERT INTO `ibl_box_scores_teams` (`game_date`, `visitor_teamid`, `home_teamid`, `game_of_that_day`, `name`)" .
+            " VALUES ('$date', 1, 2, 1, 'T1'), ('$date', 3, 4, 2, 'T2'), ('$date', 5, 6, 3, 'T3')," .
+            "        ('$date', 7, 8, 4, 'T4'), ('$date', 9, 10, 5, 'T5'), ('$date', 11, 12, 6, 'T6')," .
+            "        ('$date', 13, 14, 7, 'T7')"
+        );
+    }
+
+    /**
+     * @return array{season_year: int, game_date: string, visitor_teamid: int, home_teamid: int, game_of_that_day: int, box_id: ?int, sort_order: int, recap_text: string}
+     */
+    private function recapRow(int $sortOrder, string $gameDate, int $visitor, int $home, int $gameOfThatDay): array
+    {
+        return [
+            'season_year'      => 2025,
+            'game_date'        => $gameDate,
+            'visitor_teamid'   => $visitor,
+            'home_teamid'      => $home,
+            'game_of_that_day' => $gameOfThatDay,
+            'box_id'           => 42,
+            'sort_order'       => $sortOrder,
+            'recap_text'       => "Recap for {$visitor} at {$home}.",
+        ];
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/SimRecap/SimSummaryRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/SimRecap/SimSummaryRepositoryTest.php
@@ -528,6 +528,142 @@ final class SimSummaryRepositoryTest extends DatabaseTestCase
         self::assertSame([1, 2], [$displayable[0]['visitor_teamid'], $displayable[0]['home_teamid']]);
     }
 
+    // ── validateGameRowsJoinToBoxScores tests ─────────────────────────────────
+
+    public function testValidateGameRowsJoinToBoxScoresAcceptsASevenGameNight(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $games = [
+            $this->leagueGame(0, 1,  2,  1),
+            $this->leagueGame(1, 3,  4,  2),
+            $this->leagueGame(2, 5,  6,  3),
+            $this->leagueGame(3, 7,  8,  4),
+            $this->leagueGame(4, 9,  10, 5),
+            $this->leagueGame(5, 11, 12, 6),
+            $this->leagueGame(6, 13, 14, 7),
+        ];
+
+        $this->db->query(
+            "INSERT INTO `ibl_box_scores_teams` (`game_date`, `visitor_teamid`, `home_teamid`, `game_of_that_day`, `name`)" .
+            " VALUES ('2025-02-14', 1, 2, 1, 'T1'), ('2025-02-14', 3, 4, 2, 'T2'), ('2025-02-14', 5, 6, 3, 'T3')," .
+            "        ('2025-02-14', 7, 8, 4, 'T4'), ('2025-02-14', 9, 10, 5, 'T5'), ('2025-02-14', 11, 12, 6, 'T6')," .
+            "        ('2025-02-14', 13, 14, 7, 'T7')"
+        );
+
+        $this->repo->validateGameRowsJoinToBoxScores($games);
+    }
+
+    public function testValidateGameRowsJoinToBoxScoresRejectsTheSim725Shape(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/6 of 7 game rows do not match an archived box score/');
+
+        $games = [
+            $this->leagueGame(0, 1,  2,  1),
+            $this->leagueGame(1, 3,  4,  1),
+            $this->leagueGame(2, 5,  6,  1),
+            $this->leagueGame(3, 7,  8,  1),
+            $this->leagueGame(4, 9,  10, 1),
+            $this->leagueGame(5, 11, 12, 1),
+            $this->leagueGame(6, 13, 14, 1),
+        ];
+
+        $this->db->query(
+            "INSERT INTO `ibl_box_scores_teams` (`game_date`, `visitor_teamid`, `home_teamid`, `game_of_that_day`, `name`)" .
+            " VALUES ('2025-02-14', 1, 2, 1, 'T1'), ('2025-02-14', 3, 4, 2, 'T2'), ('2025-02-14', 5, 6, 3, 'T3')," .
+            "        ('2025-02-14', 7, 8, 4, 'T4'), ('2025-02-14', 9, 10, 5, 'T5'), ('2025-02-14', 11, 12, 6, 'T6')," .
+            "        ('2025-02-14', 13, 14, 7, 'T7')"
+        );
+
+        $this->repo->validateGameRowsJoinToBoxScores($games);
+    }
+
+    public function testValidateGameRowsJoinToBoxScoresRejectsAGameWithNoArchivedBoxScore(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/1 of 1 game rows/');
+
+        $games = [$this->leagueGame(0, 1, 2, 1)];
+
+        $this->repo->validateGameRowsJoinToBoxScores($games);
+    }
+
+    public function testValidateGameRowsJoinToBoxScoresTreatsANullBoxScoreIndexAsZero(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $games = [$this->leagueGame(0, 1, 2, 0)];
+
+        $this->db->query(
+            "INSERT INTO `ibl_box_scores_teams` (`game_date`, `visitor_teamid`, `home_teamid`, `game_of_that_day`, `name`)" .
+            " VALUES ('2025-02-14', 1, 2, NULL, 'T1')"
+        );
+
+        $this->repo->validateGameRowsJoinToBoxScores($games);
+    }
+
+    public function testValidateGameRowsJoinToBoxScoresAcceptsAnEmptyGameList(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->repo->validateGameRowsJoinToBoxScores([]);
+    }
+
+    public function testValidatedGameRowsAreAlwaysDisplayable(): void
+    {
+        $games = [
+            $this->leagueGame(0, 1,  2,  1),
+            $this->leagueGame(1, 3,  4,  2),
+            $this->leagueGame(2, 5,  6,  3),
+            $this->leagueGame(3, 7,  8,  4),
+            $this->leagueGame(4, 9,  10, 5),
+            $this->leagueGame(5, 11, 12, 6),
+            $this->leagueGame(6, 13, 14, 7),
+        ];
+
+        $this->db->query(
+            "INSERT INTO `ibl_box_scores_teams` (`game_date`, `visitor_teamid`, `home_teamid`, `game_of_that_day`, `name`)" .
+            " VALUES ('2025-02-14', 1, 2, 1, 'T1'), ('2025-02-14', 3, 4, 2, 'T2'), ('2025-02-14', 5, 6, 3, 'T3')," .
+            "        ('2025-02-14', 7, 8, 4, 'T4'), ('2025-02-14', 9, 10, 5, 'T5'), ('2025-02-14', 11, 12, 6, 'T6')," .
+            "        ('2025-02-14', 13, 14, 7, 'T7')"
+        );
+
+        $this->repo->validateGameRowsJoinToBoxScores($games);
+        $this->repo->markDone(999095, 'Intro.', 'Outro.', 'Recap.', $games, null);
+
+        $displayable = $this->repo->findDisplayableGameRecaps(999095);
+
+        self::assertCount(7, $displayable, 'All validated game rows must be displayable');
+    }
+
+    public function testValidateGameRowsJoinToBoxScoresDoesNotLeakRecapProseIntoTheFailure(): void
+    {
+        $games = [
+            $this->leagueGame(0, 1,  2,  1),
+            $this->leagueGame(1, 3,  4,  1),
+            $this->leagueGame(2, 5,  6,  1),
+            $this->leagueGame(3, 7,  8,  1),
+            $this->leagueGame(4, 9,  10, 1),
+            $this->leagueGame(5, 11, 12, 1),
+            $this->leagueGame(6, 13, 14, 1),
+        ];
+
+        $this->db->query(
+            "INSERT INTO `ibl_box_scores_teams` (`game_date`, `visitor_teamid`, `home_teamid`, `game_of_that_day`, `name`)" .
+            " VALUES ('2025-02-14', 1, 2, 1, 'T1'), ('2025-02-14', 3, 4, 2, 'T2'), ('2025-02-14', 5, 6, 3, 'T3')," .
+            "        ('2025-02-14', 7, 8, 4, 'T4'), ('2025-02-14', 9, 10, 5, 'T5'), ('2025-02-14', 11, 12, 6, 'T6')," .
+            "        ('2025-02-14', 13, 14, 7, 'T7')"
+        );
+
+        try {
+            $this->repo->validateGameRowsJoinToBoxScores($games);
+            self::fail('Expected RuntimeException was not thrown');
+        } catch (\RuntimeException $e) {
+            self::assertStringNotContainsString('Recap for game', $e->getMessage());
+        }
+    }
+
     // ── Private helpers ────────────────────────────────────────────────────────
 
     /**

--- a/ibl5/tests/DatabaseIntegration/SimRecap/SimSummaryRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/SimRecap/SimSummaryRepositoryTest.php
@@ -421,7 +421,11 @@ final class SimSummaryRepositoryTest extends DatabaseTestCase
         self::assertSame(1, $displayable[0]['game_of_that_day']);
     }
 
-    public function testFindDisplayableGameRecapsDoubleheaderBothReturned(): void
+    /**
+     * Two rows sharing a date and matchup but carrying different indices both match,
+     * because the `EXISTS` filter compares the index, not the matchup.
+     */
+    public function testFindDisplayableGameRecapsTwoIndicesOnOneDateBothReturned(): void
     {
         $games = [
             $this->gameRecap(sortOrder: 0, gameOfThatDay: 1),
@@ -458,6 +462,72 @@ final class SimSummaryRepositoryTest extends DatabaseTestCase
         self::assertSame([], $displayable, 'gotd=0 recap must not match a gotd=1 box score');
     }
 
+    /**
+     * Seven distinct matchups on 2025-02-14, each carrying its true index (1–7).
+     * Pins the real semantics of game_of_that_day: one entry per league game on a
+     * given date, not a per-matchup doubleheader counter. All seven must be
+     * displayable when each index matches a box score row.
+     */
+    public function testFindDisplayableGameRecapsSevenGameNightAllSurvive(): void
+    {
+        $games = [
+            $this->leagueGame(0, 1,  2,  1),
+            $this->leagueGame(1, 3,  4,  2),
+            $this->leagueGame(2, 5,  6,  3),
+            $this->leagueGame(3, 7,  8,  4),
+            $this->leagueGame(4, 9,  10, 5),
+            $this->leagueGame(5, 11, 12, 6),
+            $this->leagueGame(6, 13, 14, 7),
+        ];
+        $this->repo->markDone(999093, 'Intro.', 'Outro.', 'Recap.', $games, null);
+
+        $this->db->query(
+            "INSERT INTO `ibl_box_scores_teams` (`game_date`, `visitor_teamid`, `home_teamid`, `game_of_that_day`, `name`)" .
+            " VALUES ('2025-02-14', 1, 2, 1, 'T1'), ('2025-02-14', 3, 4, 2, 'T2'), ('2025-02-14', 5, 6, 3, 'T3')," .
+            "        ('2025-02-14', 7, 8, 4, 'T4'), ('2025-02-14', 9, 10, 5, 'T5'), ('2025-02-14', 11, 12, 6, 'T6')," .
+            "        ('2025-02-14', 13, 14, 7, 'T7')"
+        );
+
+        $displayable = $this->repo->findDisplayableGameRecaps(999093);
+
+        self::assertCount(7, $displayable);
+        self::assertSame([1, 2, 3, 4, 5, 6, 7], array_column($displayable, 'game_of_that_day'));
+    }
+
+    /**
+     * Sim-725 shape. Seven distinct matchups store game_of_that_day = 1 for every
+     * game. The box scores carry the real indices 1–7, one per matchup. Only the
+     * game whose stored index happens to equal the box-score index (matchup 1/2 with
+     * game_of_that_day = 1) survives the EXISTS filter; the other six are silently
+     * dropped. Characterizes the display-collapse defect — fixed by the write-time
+     * guard in Phase 4.
+     */
+    public function testFindDisplayableGameRecapsAllOnesCollapseToASingleGame(): void
+    {
+        $games = [
+            $this->leagueGame(0, 1,  2,  1),
+            $this->leagueGame(1, 3,  4,  1),
+            $this->leagueGame(2, 5,  6,  1),
+            $this->leagueGame(3, 7,  8,  1),
+            $this->leagueGame(4, 9,  10, 1),
+            $this->leagueGame(5, 11, 12, 1),
+            $this->leagueGame(6, 13, 14, 1),
+        ];
+        $this->repo->markDone(999094, 'Intro.', 'Outro.', 'Recap.', $games, null);
+
+        $this->db->query(
+            "INSERT INTO `ibl_box_scores_teams` (`game_date`, `visitor_teamid`, `home_teamid`, `game_of_that_day`, `name`)" .
+            " VALUES ('2025-02-14', 1, 2, 1, 'T1'), ('2025-02-14', 3, 4, 2, 'T2'), ('2025-02-14', 5, 6, 3, 'T3')," .
+            "        ('2025-02-14', 7, 8, 4, 'T4'), ('2025-02-14', 9, 10, 5, 'T5'), ('2025-02-14', 11, 12, 6, 'T6')," .
+            "        ('2025-02-14', 13, 14, 7, 'T7')"
+        );
+
+        $displayable = $this->repo->findDisplayableGameRecaps(999094);
+
+        self::assertCount(1, $displayable);
+        self::assertSame([1, 2], [$displayable[0]['visitor_teamid'], $displayable[0]['home_teamid']]);
+    }
+
     // ── Private helpers ────────────────────────────────────────────────────────
 
     /**
@@ -486,6 +556,26 @@ final class SimSummaryRepositoryTest extends DatabaseTestCase
             'home_teamid'      => 2,
             'game_of_that_day' => $gameOfThatDay,
             'box_id'           => $boxId,
+            'sort_order'       => $sortOrder,
+            'recap_text'       => "Recap for game {$gameOfThatDay}.",
+        ];
+    }
+
+    /**
+     * A game recap for a distinct matchup, so seven of them share a date without
+     * colliding on uniq_game (season_year, game_date, visitor, home, game_of_that_day).
+     *
+     * @return array{season_year: int, game_date: string, visitor_teamid: int, home_teamid: int, game_of_that_day: int, box_id: ?int, sort_order: int, recap_text: string}
+     */
+    private function leagueGame(int $sortOrder, int $visitor, int $home, int $gameOfThatDay): array
+    {
+        return [
+            'season_year'      => 2025,
+            'game_date'        => '2025-02-14',
+            'visitor_teamid'   => $visitor,
+            'home_teamid'      => $home,
+            'game_of_that_day' => $gameOfThatDay,
+            'box_id'           => 42,
             'sort_order'       => $sortOrder,
             'recap_text'       => "Recap for game {$gameOfThatDay}.",
         ];

--- a/ibl5/tests/DatabaseIntegration/SimRecap/StoreSimRecapCliTest.php
+++ b/ibl5/tests/DatabaseIntegration/SimRecap/StoreSimRecapCliTest.php
@@ -59,6 +59,17 @@ final class StoreSimRecapCliTest extends DatabaseTestCase
         $path = realpath(__DIR__ . '/../../../scripts/storeSimRecap.php');
         self::assertNotFalse($path, 'storeSimRecap.php must exist at the expected path');
         $this->scriptPath = $path;
+
+        // Seed the two box-score rows that VALID_PAYLOAD references: date 2025-01-01,
+        // teams 1 vs 2, game_of_that_day=1. Two rows mirror the production convention
+        // (one per team side). Autocommit mode (commit() was called above) makes them
+        // visible immediately to the child process on its own connection.
+        $seeded = $this->db->query(
+            "INSERT INTO `ibl_box_scores_teams` (`game_date`, `visitor_teamid`, `home_teamid`, `game_of_that_day`, `name`)"
+            . " VALUES ('2025-01-01', 1, 2, 1, 'CliVstr'), ('2025-01-01', 1, 2, 1, 'CliHome')"
+        );
+        self::assertNotFalse($seeded, 'ibl_box_scores_teams fixture must seed without error');
+        self::assertSame(2, $this->db->affected_rows, 'both box-score rows must be inserted');
     }
 
     protected function tearDown(): void
@@ -71,6 +82,10 @@ final class StoreSimRecapCliTest extends DatabaseTestCase
                 $this->db->query('DELETE FROM `ibl_sim_game_recaps` WHERE `sim` = ' . self::SIM);
                 $this->db->query('DELETE FROM `ibl_sim_summaries` WHERE `sim` = ' . self::SIM);
                 $this->db->query('DELETE FROM `ibl_sim_dates` WHERE `sim` = ' . self::SIM);
+                $this->db->query(
+                    "DELETE FROM `ibl_box_scores_teams`"
+                    . " WHERE `game_date` = '2025-01-01' AND `visitor_teamid` = 1 AND `home_teamid` = 2"
+                );
             }
         } catch (\Throwable) {
             // Best-effort — connection may be in an unrecoverable state.
@@ -290,6 +305,89 @@ final class StoreSimRecapCliTest extends DatabaseTestCase
         );
     }
 
+    // ── Validation guard tests ─────────────────────────────────────────────────
+
+    /**
+     * A payload whose game_date has no matching ibl_box_scores_teams row must be
+     * rejected before anything is written. Exit non-zero, stderr carries the
+     * validation failure, and the DB is untouched.
+     */
+    public function testUnmatchedGameRowsExitNonZeroWithoutWriting(): void
+    {
+        $this->repo->queuePendingIfAbsent(self::SIM);
+
+        // 2025-01-02 has no seeded box-score row — validation must reject it.
+        $payloadBadDate = '{"intro_text":"Intro text.","outro_text":"Outro text.",'
+            . '"recap_text":"This is the recap text.","themes":["comeback"],'
+            . '"games":[{"season_year":2025,"game_date":"2025-01-02","visitor_teamid":1,'
+            . '"home_teamid":2,"game_of_that_day":1,"box_id":null,"sort_order":0,'
+            . '"recap_text":"Game recap text."}]}';
+
+        $result = $this->runScript(['--sim=' . self::SIM], $payloadBadDate);
+
+        self::assertNotSame(0, $result['exit_code'], 'exit must be non-zero when no box score matches');
+        self::assertStringContainsString(
+            'payload rejected',
+            $result['stderr'],
+            'stderr must contain "payload rejected"'
+        );
+        self::assertStringContainsString(
+            'do not match an archived box score',
+            $result['stderr'],
+            'stderr must contain the validation failure message'
+        );
+        self::assertSame('', trim($result['stdout']), 'stdout must be empty — no {"ok":true} line');
+        self::assertCount(0, $this->repo->findGameRecaps(self::SIM), 'no game recap rows must be written');
+
+        $summary = $this->repo->find(self::SIM);
+        self::assertTrue(
+            $summary === null || $summary['status'] !== 'done',
+            'ibl_sim_summaries row must be absent or not done'
+        );
+    }
+
+    /**
+     * A payload that matches the date and teams of a real box score but carries the
+     * wrong game_of_that_day index must be rejected even though the game exists.
+     */
+    public function testWrongGameOfThatDayIsRejectedEvenThoughTheGameExists(): void
+    {
+        $this->repo->queuePendingIfAbsent(self::SIM);
+
+        // Date 2025-01-01, teams 1 vs 2 match the seeded box score, but gotd=3 does not.
+        $payloadWrongGotd = '{"intro_text":"Intro text.","outro_text":"Outro text.",'
+            . '"recap_text":"This is the recap text.","themes":["comeback"],'
+            . '"games":[{"season_year":2025,"game_date":"2025-01-01","visitor_teamid":1,'
+            . '"home_teamid":2,"game_of_that_day":3,"box_id":null,"sort_order":0,'
+            . '"recap_text":"Game recap text."}]}';
+
+        $result = $this->runScript(['--sim=' . self::SIM], $payloadWrongGotd);
+
+        self::assertNotSame(0, $result['exit_code'], 'exit must be non-zero when game_of_that_day is wrong');
+        self::assertCount(0, $this->repo->findGameRecaps(self::SIM), 'no game recap rows must be written for wrong gotd');
+    }
+
+    /**
+     * Structural guard: validateGameRowsJoinToBoxScores must execute before markDone
+     * and before the Discord post, so a rejected payload can never reach either.
+     * This is a source-inspection test — no child process, no DB state.
+     */
+    public function testValidationFailureCannotReachTheDiscordPost(): void
+    {
+        $source = file_get_contents(dirname(__DIR__, 3) . '/scripts/storeSimRecap.php');
+        self::assertIsString($source);
+
+        $validate = strpos($source, 'validateGameRowsJoinToBoxScores');
+        $markDone = strpos($source, '$repo->markDone(');
+        $discord  = strpos($source, 'Discord::postToChannel');
+
+        self::assertIsInt($validate, 'The validator must be wired into the store script');
+        self::assertIsInt($markDone);
+        self::assertIsInt($discord);
+        self::assertLessThan($markDone, $validate, 'Validation must run before the write');
+        self::assertLessThan($discord, $markDone, 'The Discord post must stay downstream of the write');
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────────
 
     /**
@@ -322,8 +420,20 @@ final class StoreSimRecapCliTest extends DatabaseTestCase
             self::fail('tempnam must succeed');
         }
 
+        // Pre-define IBL5_CANONICAL_HOST from the child's env BEFORE config.php runs.
+        // config.php may hard-code a production hostname via define(), which would
+        // defeat the test's env-based control. By defining the constant here first,
+        // config.php's subsequent define() is a no-op (PHP cannot redefine a constant).
+        // The value comes from the child env: empty string when we removed the var (the
+        // default, giving a relative URL), or a test host when the caller passes one.
+        //
+        // ini_set('display_errors', 'stderr') redirects any PHP warnings that arise
+        // during the require (e.g. "Constant already defined" in PHP 8) to STDERR so
+        // they cannot corrupt the JSON on STDOUT that the test assertions parse.
         $bootstrapContent = '<?php' . "\n"
             . "define('PHPUNIT_RUNNING', true);\n"
+            . "define('IBL5_CANONICAL_HOST', (string) getenv('IBL5_CANONICAL_HOST'));\n"
+            . "ini_set('display_errors', 'stderr');\n"
             . 'require ' . var_export($this->scriptPath, true) . ";\n";
 
         try {

--- a/ibl5/tests/WideUnit/SimRecap/RecapDocumentTest.php
+++ b/ibl5/tests/WideUnit/SimRecap/RecapDocumentTest.php
@@ -226,6 +226,66 @@ final class RecapDocumentTest extends TestCase
     }
 
     /**
+     * A complete, well-formed sim: 49 parts against a 49-header stored document. Nothing
+     * is missing and nothing is degraded, so the assembly wins. Without this the guard
+     * could be tightened into always preferring stored text and no test would notice.
+     */
+    public function testPostableTextReturnsAssembledDocumentWhenEveryStoredGameIsPresent(): void
+    {
+        $stored = $this->storedDocumentWith(49);
+        $parts  = [];
+        for ($i = 1; $i <= 49; $i++) {
+            $parts[] = $this->game('2026-02-26', "**A {$i} @ B {$i}**\n<@1> · <@2>\nGame prose.");
+        }
+
+        self::assertSame(
+            RecapDocument::assemble('Intro.', $parts, 'Outro.'),
+            RecapDocument::postableText('Intro.', $parts, 'Outro.', $stored)
+        );
+    }
+
+    /**
+     * Boundary: one game short (48 parts vs 49 headers in the stored document).
+     * The completeness guard fires and prefers the stored text.
+     */
+    public function testPostableTextPrefersStoredTextWhenOneGameIsMissing(): void
+    {
+        $stored = $this->storedDocumentWith(49);
+        $parts  = [];
+        for ($i = 1; $i <= 48; $i++) {
+            $parts[] = $this->game('2026-02-26', "**A {$i} @ B {$i}**\n<@1> · <@2>\nGame prose.");
+        }
+
+        self::assertSame($stored, RecapDocument::postableText('Intro.', $parts, 'Outro.', $stored));
+    }
+
+    public function testPostableTextCountsRenderedGamesNotRawRowsAgainstTheStoredDocument(): void
+    {
+        $stored = $this->storedDocumentWith(6);
+        $parts  = [];
+        for ($i = 1; $i <= 5; $i++) {
+            $parts[] = $this->game('2026-02-26', "**A {$i} @ B {$i}**\n<@1> · <@2>\nGame prose.");
+        }
+        $parts[] = $this->game('2026-02-26', '');
+        $parts[] = $this->game('2026-02-26', '   ');
+
+        self::assertSame($stored, RecapDocument::postableText('Intro.', $parts, 'Outro.', $stored));
+    }
+
+    public function testPostableTextTreatsThePinnedExemplarAsA46GameDocument(): void
+    {
+        $exemplar = file_get_contents(dirname(__DIR__, 4) . '/bin/lib/sim-recap-exemplar.txt');
+        self::assertIsString($exemplar);
+
+        $parts = [];
+        for ($i = 1; $i <= 45; $i++) {
+            $parts[] = $this->game('2026-02-26', "**A {$i} @ B {$i}**\n<@1> · <@2>\nGame prose.");
+        }
+
+        self::assertSame($exemplar, RecapDocument::postableText('Intro.', $parts, 'Outro.', $exemplar));
+    }
+
+    /**
      * One game carries its mention line; the other is a single-line string with no
      * index-1 entry at all. gamesCarryTheirMentionLines() is all-or-nothing — the
      * mixed batch must fall back to the stored text.

--- a/ibl5/tests/WideUnit/SimRecap/RecapDocumentTest.php
+++ b/ibl5/tests/WideUnit/SimRecap/RecapDocumentTest.php
@@ -37,6 +37,17 @@ final class RecapDocumentTest extends TestCase
         ];
     }
 
+    /** A stored document carrying $n exemplar-shaped game headers. */
+    private function storedDocumentWith(int $n): string
+    {
+        $blocks = [];
+        for ($i = 1; $i <= $n; $i++) {
+            $blocks[] = "**Team A {$i} @ Team B {$i}**\n<@1> · <@2>\n\nGame {$i} prose.";
+        }
+
+        return "Intro.\n\n" . implode("\n\n\n", $blocks) . "\n\nOutro.";
+    }
+
     public function testAssemblesTheWholeDocumentInExemplarShape(): void
     {
         $doc = RecapDocument::assemble(
@@ -199,6 +210,22 @@ final class RecapDocumentTest extends TestCase
     }
 
     /**
+     * Sim-725 shape. Seven parts survived the displayable filter and every one of them
+     * is well formed, so gamesCarryTheirMentionLines() votes for assembly. The stored
+     * document holds all 49 games. Assembling would post 7 and discard 42.
+     */
+    public function testPostableTextPrefersStoredTextWhenPartsAreShortOfTheStoredDocument(): void
+    {
+        $stored = $this->storedDocumentWith(49);
+        $parts  = [];
+        for ($i = 1; $i <= 7; $i++) {
+            $parts[] = $this->game('2026-02-26', "**A {$i} @ B {$i}**\n<@1> · <@2>\nGame prose.");
+        }
+
+        self::assertSame($stored, RecapDocument::postableText('Intro.', $parts, 'Outro.', $stored));
+    }
+
+    /**
      * One game carries its mention line; the other is a single-line string with no
      * index-1 entry at all. gamesCarryTheirMentionLines() is all-or-nothing — the
      * mixed batch must fall back to the stored text.
@@ -294,5 +321,20 @@ final class RecapDocumentTest extends TestCase
         self::assertSame('', RecapDocument::postableText(null, [], null, null));
         self::assertSame('', RecapDocument::postableText(null, [], null, ''));
         self::assertSame('', RecapDocument::postableText(null, [], null, '   '));
+    }
+
+    /**
+     * The completeness guard counts game headers by shape. If the shape is wrong the
+     * count silently goes to zero and the guard goes inert, which is a failure mode the
+     * guard itself cannot report. The pinned exemplar is the independent oracle.
+     */
+    public function testScoreHeaderPatternMatchesEveryGameInThePinnedExemplar(): void
+    {
+        $exemplar = file_get_contents(dirname(__DIR__, 4) . '/bin/lib/sim-recap-exemplar.txt');
+        self::assertIsString($exemplar);
+
+        $count = preg_match_all('/^\*\*.+\s\d+\s@\s.+\s\d+\*\*$/m', str_replace("\r\n", "\n", $exemplar));
+
+        self::assertSame(46, $count, 'The pinned exemplar carries 46 game headers');
     }
 }


### PR DESCRIPTION
## Summary

Sim 725 wrote `game_of_that_day: 1` for all 49 games because the prompt described the column as a doubleheader counter. Only the 7 games whose box-score index happened to equal 1 ever rendered.

**Root causes fixed:**
1. **Prompt contract** (`bin/sim-recap-prompt`): `game_of_that_day` is now described as the 1-based within-date-across-league index from `ibl_box_scores_teams`, with a lookup query the agent must copy verbatim. Added prose-length band (504–639 chars) reconciled with the existing anti-tell prohibitions.
2. **Write guard** (`validateGameRowsJoinToBoxScores`): store-time join to `ibl_box_scores_teams` rejects any payload where the agent produced wrong indices — fail-closed, no DB write.
3. **Display guard** (`RecapDocument::postableText()`): if a stored document has fewer than 7 distinct `game_of_that_day` values for a 7-game night, it refuses to post — requires the human to re-run the sim for that date.
4. **Data repair** (migration 157): reads `ibl_box_scores_teams` to recover the correct index for each sim-725 game and back-fills `ibl_sim_game_recaps`. Idempotent; skips rows already correct.

## Test coverage

- `SimSummaryRepositoryTest`: characterization of real column semantics + seven-game-night collapse negative path  
- `StoreSimRecapCliTest`: validation failure blocks Discord post; wrong `game_of_that_day` rejected  
- `RecapDocumentTest`: score-header presence oracle, completeness guard behaviour  
- `Sim725RepairMigrationTest`: idempotent, no-op on empty, collision-skip, repaired-rows-all-displayable, touches-no-other-sim  
- `bin/test-sim-recap-tick`: prompt contract assertions (read-not-infer, within-date semantics, lookup query, length band, anti-tell bans survive)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
