### PR TITLE
chore(automation): add discord-dm and watch-automouse-plan scripts

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -10,7 +10,8 @@ container.
 | Group | Scripts |
 |-------|---------|
 | Worktrees | `wt-new`, `wt-up`, `wt-down`, `wt-list`, `wt-rebase`, `wt-remove`, `wt-db-test`, `e2e-wt.sh` |
-| Automouse automation | `automouse-run`, `automouse-queue`, `automouse-prompt-impl`, `automouse-prompt-postplan` |
+| Automouse automation | `automouse-run`, `automouse-queue`, `automouse-prompt-impl`, `automouse-prompt-postplan`, `watch-automouse-plan` (wait for a queued plan's phase to finish, then DM) |
+| Notifications | `discord-dm` (host-side IBLbot DM with retries + spool; the sibling of `.github/actions/notify-discord`) |
 | CI / quality gates | `adr-check`, `check-docs`, `check-hot-files`, `check-master-ci-green`, `check-plan`, `check-plan-staleness`, `check-vr-coverage`, `check-e2e-hygiene`, `check-e2e-fa-offers-owner`, `check-e2e-mutator-isolation`, `check-e2e-fixture-drift`, `check-destructive-migrations`, `refactor-flag` |
 | Prod ops | `db-sync-prod`, `log-fetch-prod`, `merge-master-to-prod`, `smoke-prod` (SSH from host); `iblbot-healthcheck` (pm2 cron watchdog, runs on the prod box) |
 | Dev / Docker env | `dev-up`, `db-test-up`, `db-migrate` |

--- a/bin/discord-dm
+++ b/bin/discord-dm
@@ -1,0 +1,146 @@
+#!/bin/bash
+# discord-dm — send a Discord DM through IBLbot from the host, with retries.
+#
+# The host-side sibling of .github/actions/notify-discord: the bot binds
+# 127.0.0.1:50000 on prod, so every sender has to tunnel in over ssh and POST to
+# localhost. That recipe was previously copy-pasted per caller, one-shot, with
+# `curl -sf` swallowing the HTTP status — a single transient 5xx during a pm2
+# restart window (bin/iblbot-healthcheck restarts on a cron, so those windows are
+# minutes long, not seconds) silently dropped the message. This script is the one
+# place that recipe lives, and it never fails silently:
+#
+#   * retries across a window longer than a pm2 restart (default ~5min total)
+#   * logs HTTP status + curl rc + ssh rc on every attempt
+#   * 4xx is permanent (missing field) — fails fast, no retry. Note the bot
+#     answers a *bad snowflake* with 500, indistinguishable from a transient
+#     failure, so a wrong recipient costs the full retry window. That's the right
+#     trade: 500 is exactly the code the lost message came back with.
+#   * on total failure: macOS notification + a spool line, then exit 1
+#
+# Usage:
+#   bin/discord-dm "message"                 # message as an argument
+#   printf '%s' "$msg" | bin/discord-dm -    # message on stdin (multi-line safe)
+#
+#   --to <snowflake>   recipient (default: $DISCORD_DM_TO, else ~/.iblbot-dm-id)
+#   --attempts <n>     send attempts before giving up (default 6)
+#   --host <ssh-host>  ssh target (default: $DISCORD_DM_SSH_HOST, else iblhoops.net)
+#   --quiet            no per-attempt chatter on stderr (failures still print)
+#   --no-fallback      skip the macOS notification + spool on total failure
+#
+# Exit: 0 delivered · 1 undeliverable (spooled) · 2 usage/config error.
+
+set -uo pipefail
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+
+TO="${DISCORD_DM_TO:-}"
+SSH_HOST="${DISCORD_DM_SSH_HOST:-iblhoops.net}"
+BOT_PORT="${DISCORD_DM_PORT:-50000}"
+ATTEMPTS=6
+QUIET=0
+FALLBACK=1
+SPOOL="${DISCORD_DM_SPOOL:-$HOME/.claude/discord-dm-spool.log}"
+ID_FILE="$HOME/.iblbot-dm-id"
+
+# Backoff between attempts, in seconds. Sums to 315s (~5min15s) across the 6
+# default attempts — deliberately longer than a pm2 restart window, which is what
+# the one-shot senders kept losing messages to.
+BACKOFF=(15 30 60 90 120 120 120 120)
+
+MSG=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --to)          TO="${2:-}"; shift 2 ;;
+        --attempts)    ATTEMPTS="${2:-}"; shift 2 ;;
+        --host)        SSH_HOST="${2:-}"; shift 2 ;;
+        --quiet)       QUIET=1; shift ;;
+        --no-fallback) FALLBACK=0; shift ;;
+        -h|--help)     sed -n '2,31p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        -)             MSG=$(cat); shift ;;
+        --)            shift; MSG="$*"; break ;;
+        -*)            echo "discord-dm: unknown option $1" >&2; exit 2 ;;
+        *)             MSG="$1"; shift ;;
+    esac
+done
+
+[ -n "$MSG" ] || { echo "discord-dm: empty message (pass an argument or '-' for stdin)" >&2; exit 2; }
+
+if [ -z "$TO" ] && [ -f "$ID_FILE" ]; then
+    TO=$(tr -dc '0-9' < "$ID_FILE")
+fi
+if [ -z "$TO" ]; then
+    cat >&2 <<EOF
+discord-dm: no recipient. Set one of:
+  --to <snowflake>          per-call
+  DISCORD_DM_TO=<snowflake> per-environment
+  $ID_FILE   persistent default (one snowflake, no quotes)
+EOF
+    exit 2
+fi
+
+say() { [ "$QUIET" = 1 ] || printf 'discord-dm: %s\n' "$1" >&2; }
+
+# Discord caps a message at 2000 chars; leave room for the truncation marker.
+if [ "${#MSG}" -gt 1900 ]; then
+    MSG="${MSG:0:1900}"$'\n…(truncated)'
+fi
+
+# Snowflakes are 64-bit and MUST stay JSON strings end-to-end — jq --arg keeps
+# them strings; interpolating into a JSON literal would round-trip them through a
+# double and corrupt the low digits.
+PAYLOAD=$(jq -n --arg id "$TO" --arg msg "$MSG" \
+    '{content: {receivingUserDiscordID: $id, message: $msg}}') || exit 2
+
+# Remote leg. `-w` appends the status after the body so a failure is diagnosable
+# from the log alone; `-f` is deliberately absent (it hides the very status we
+# want). curl's own rc distinguishes "connection refused" (7) from an HTTP error.
+REMOTE_CMD="curl -s -m 20 -w '\nHTTP=%{http_code}' \
+-X POST http://localhost:${BOT_PORT}/discordDM \
+-H 'Content-Type: application/json' -d @-; printf ' curl_rc=%s\n' \"\$?\""
+
+http=""
+n=1
+while [ "$n" -le "$ATTEMPTS" ]; do
+    out=$(printf '%s' "$PAYLOAD" | ssh -o BatchMode=yes -o ConnectTimeout=10 \
+        "$SSH_HOST" "$REMOTE_CMD" 2>&1)
+    ssh_rc=$?
+    http=$(printf '%s' "$out" | sed -n 's/.*HTTP=\([0-9][0-9]*\).*/\1/p' | tail -1)
+    curl_rc=$(printf '%s' "$out" | sed -n 's/.*curl_rc=\([0-9][0-9]*\).*/\1/p' | tail -1)
+
+    if [ "$http" = "200" ]; then
+        say "delivered on attempt $n (HTTP 200)"
+        exit 0
+    fi
+
+    say "attempt $n/$ATTEMPTS failed — ssh_rc=$ssh_rc curl_rc=${curl_rc:-?} http=${http:-none}"
+    [ "$QUIET" = 1 ] || printf '  %s\n' "$(printf '%s' "$out" | tr '\n' ' ' | cut -c1-300)" >&2
+
+    # 4xx means the bot understood us and refused — a bad snowflake or an empty
+    # message. Retrying that just burns five minutes to reach the same answer.
+    case "${http:-}" in
+        4??) say "permanent failure (HTTP $http) — not retrying"; break ;;
+    esac
+
+    if [ "$n" -lt "$ATTEMPTS" ]; then
+        sleep "${BACKOFF[$(( n - 1 ))]:-120}"
+    fi
+    n=$(( n + 1 ))
+done
+
+# Total failure. The message is the whole point of the call, so never let it
+# evaporate: put it somewhere durable and somewhere visible, and exit non-zero so
+# a caller (or a launchd job) can tell delivery apart from success.
+if [ "$FALLBACK" = 1 ]; then
+    mkdir -p "$(dirname "$SPOOL")"
+    {
+        printf '=== %s — UNDELIVERED (to=%s http=%s) ===\n' \
+            "$(date '+%Y-%m-%d %H:%M:%S')" "$TO" "${http:-none}"
+        printf '%s\n\n' "$MSG"
+    } >> "$SPOOL"
+    say "spooled to $SPOOL"
+
+    NOTE=$(printf '%s' "$MSG" | head -1 | cut -c1-180 | sed 's/[\\"]/ /g')
+    osascript -e "display notification \"$NOTE\" with title \"Discord DM failed\" subtitle \"spooled — see the log\"" 2>/dev/null || true
+fi
+
+echo "discord-dm: UNDELIVERED after $(( n > ATTEMPTS ? ATTEMPTS : n )) attempt(s) — spooled to $SPOOL" >&2
+exit 1

--- a/bin/watch-automouse-plan
+++ b/bin/watch-automouse-plan
@@ -1,0 +1,247 @@
+#!/bin/bash
+# watch-automouse-plan — wait for an automouse plan to finish a phase, then DM.
+#
+# Generalised from a one-off watcher that fired correctly and then lost its
+# message to a single un-retried POST (2026-08-04, fix-sim-recap-game-of-that-day:
+# detected the finish in 52s, built the right message with the right PR link, and
+# dropped it). Delivery now goes through bin/discord-dm, which retries and spools.
+#
+# Usage:
+#   bin/watch-automouse-plan --slug <plan-slug> [options]
+#
+#   --slug <slug>      plan slug, i.e. ~/claude-plans/<slug>.md  (required)
+#   --phase <name>     phase to wait for: postplan (default) or impl
+#   --to <snowflake>   DM recipient (default: bin/discord-dm's own default)
+#   --poll <secs>      poll interval, default 60
+#   --timeout <secs>   phase backstop, default 21600 (6h — the runner's own
+#                      ceiling is 4h45m per plan plus retries). The clock starts
+#                      when the runner is first seen alive, not at launch.
+#   --wait <secs>      how long to wait for the runner to start at all, default
+#                      86400 (24h — launchd fires it overnight)
+#   --detach           re-exec under nohup and print the watcher log path
+#   --force            skip the "plan must currently be in queue/" precondition
+#
+# Exit: 0 notified · 1 notification undeliverable · 2 usage/precondition error.
+#
+# ── Why the predicates are what they are ────────────────────────────────────────
+# PRIMARY is the stream filter's own per-phase verdict line, emitted by
+# bin/lib/automouse-stream-filter the instant the phase's `claude -p` returns:
+#
+#   [00:45:00] <slug>/postplan exit: stop_reason=end_turn turns=61 ...
+#
+# It carries the slug, so it attributes correctly even when the queue holds
+# several plans — the runner's other marker ("--- Plan #N postplan finished ---",
+# bin/automouse-run) does NOT, and a watcher keyed on that fires on a *sibling*
+# plan's finish. Baseline-and-compare (count at start, fire when it rises) rather
+# than plain grep, so a same-slug line left in an older log from a previous run
+# can't fire us at t=0.
+#
+# BACKSTOPS exist because the primary can legitimately never appear:
+#   * stall-kill — the filter emits that line off the stream's `result` event, and
+#     a force-killed phase never produces one;
+#   * impl short-circuit — an already-merged plan goes straight to done/ and a
+#     stale one straight to skipped/, with no phase run at all.
+# So: a disposition move (queue → done/ | skipped/) and runner-exit are terminal
+# too, plus a wall-clock timeout.
+#
+# Two false-fires the generic version has to defend against that a hardcoded
+# watcher didn't: launching before the runner starts (runner-gone is terminal only
+# after we have SEEN it alive — the `saw_runner` latch), and launching when a
+# stale done/<slug> from a previous attempt is already sitting there (the queue/
+# precondition, overridable with --force).
+
+set -uo pipefail
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+
+REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+# AUTOMOUSE_DIR is an override so the predicates can be exercised against a temp
+# state dir without touching the real queue (same shape as bin/plan-now's
+# PLAN_NOW_PLANS_DIR). Nothing in production sets it.
+AM="${AUTOMOUSE_DIR:-$HOME/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/automouse}"
+LOG_DIR="$AM/logs"
+
+SLUG=""
+PHASE=postplan
+TO=""
+POLL=60
+MAX_SECS=21600
+WAIT_SECS=86400
+DETACH=0
+FORCE=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --slug)    SLUG="${2:-}"; shift 2 ;;
+        --phase)   PHASE="${2:-}"; shift 2 ;;
+        --to)      TO="${2:-}"; shift 2 ;;
+        --poll)    POLL="${2:-}"; shift 2 ;;
+        --timeout) MAX_SECS="${2:-}"; shift 2 ;;
+        --wait)    WAIT_SECS="${2:-}"; shift 2 ;;
+        --detach)  DETACH=1; shift ;;
+        --force)   FORCE=1; shift ;;
+        -h|--help) sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *)         echo "watch-automouse-plan: unknown argument $1" >&2; exit 2 ;;
+    esac
+done
+
+[ -n "$SLUG" ] || { echo "watch-automouse-plan: --slug is required" >&2; exit 2; }
+case "$PHASE" in
+    impl|postplan) ;;
+    *) echo "watch-automouse-plan: --phase must be impl or postplan" >&2; exit 2 ;;
+esac
+
+PLAN="$SLUG.md"
+WATCH_LOG="$AM/watch-$SLUG-$PHASE.log"
+SENTINEL="$AM/.notified-$SLUG-$PHASE"
+
+if [ "$DETACH" = 1 ]; then
+    args=(--slug "$SLUG" --phase "$PHASE" --poll "$POLL" --timeout "$MAX_SECS" --wait "$WAIT_SECS")
+    [ -n "$TO" ] && args+=(--to "$TO")
+    [ "$FORCE" = 1 ] && args+=(--force)
+    nohup "$REPO/bin/watch-automouse-plan" "${args[@]}" >> "$WATCH_LOG" 2>&1 &
+    disown
+    echo "watching $SLUG/$PHASE in background (pid $!) — log: $WATCH_LOG"
+    exit 0
+fi
+
+say() { printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1"; }
+
+# Integer hours read as "0h" for anything under an hour, which looks like a bug in
+# the message rather than a short --wait.
+dur() {
+    if [ "$1" -ge 3600 ]; then printf '%dh' $(( $1 / 3600 ))
+    elif [ "$1" -ge 60 ]; then printf '%dm' $(( $1 / 60 ))
+    else printf '%ds' "$1"; fi
+}
+
+# Plan symlinks point into ~/claude-plans/, so -e follows and fails on a dangling
+# link; test -L too. Exact filename only — the disposition dirs hold look-alike
+# slugs that a prefix glob would match.
+exists() { [ -e "$1" ] || [ -L "$1" ]; }
+
+if [ -e "$SENTINEL" ]; then
+    say "sentinel present ($SENTINEL) — already notified for $SLUG/$PHASE. Exiting."
+    exit 0
+fi
+
+if [ "$FORCE" != 1 ] && ! exists "$AM/queue/$PLAN"; then
+    if exists "$AM/done/$PLAN"; then
+        where="done/ (already shipped)"
+    elif exists "$AM/skipped/$PLAN"; then
+        where="skipped/"
+    else
+        where="nowhere in queue/, done/ or skipped/"
+    fi
+    cat >&2 <<EOF
+watch-automouse-plan: $PLAN is $where, not in queue/.
+Watching now would fire immediately on that stale state. Queue it first
+(bin/automouse-queue), or pass --force if you know what you're watching for.
+EOF
+    exit 2
+fi
+
+runner_pid() { pgrep -f 'automouse-run' 2>/dev/null | grep -v "^$$\$" | head -1; }
+
+# Baseline the slug-attributed verdict line; fire when the count rises.
+count_hits() {
+    local c
+    c=$(cat "$LOG_DIR"/*.log 2>/dev/null | grep -c -F -- "$SLUG/$PHASE exit:") || true
+    echo "${c:-0}"
+}
+
+pr_line() {
+    (cd "$REPO" && gh pr list --head "$SLUG" --state all \
+        --json number,url,state,title --limit 1 2>/dev/null \
+        | jq -r '.[0] | select(.) | "PR #\(.number) [\(.state)] \(.title)\n\(.url)"') || true
+}
+
+fire() { # verdict-line
+    local msg pr dm_args=()
+    pr=$(pr_line)
+    msg="$1"
+    [ -n "$pr" ] && msg="$msg"$'\n\n'"$pr"
+    msg="$msg"$'\n\n'"log: $LOG_DIR/$(date +%F).log"
+    [ -n "$TO" ] && dm_args=(--to "$TO")
+
+    # ${a[@]+"${a[@]}"} — macOS ships bash 3.2, where `set -u` treats an empty
+    # array's "${a[@]}" as unbound and aborts. Without --to that is every call.
+    if printf '%s' "$msg" | "$REPO/bin/discord-dm" ${dm_args[@]+"${dm_args[@]}"} -; then
+        say "notified."
+        date > "$SENTINEL"
+        exit 0
+    fi
+    # discord-dm already spooled it and raised a macOS notification; keep a copy
+    # here too and exit non-zero so a wrapper can tell this apart from success.
+    say "NOTIFICATION UNDELIVERED — message was:"
+    printf '%s\n' "$msg"
+    exit 1
+}
+
+# The disposition move is done by the phase's own agent, so it is already in place
+# by the time the verdict line lands — but re-check for a beat rather than
+# reporting "no disposition" on a filesystem race.
+settle_disposition() {
+    local tries=6
+    while [ "$tries" -gt 0 ]; do
+        exists "$AM/done/$PLAN" && { echo "done"; return; }
+        exists "$AM/skipped/$PLAN" && { echo "skipped"; return; }
+        tries=$(( tries - 1 ))
+        sleep 5
+    done
+    echo "none"
+}
+
+BASE_HITS=$(count_hits)
+LAUNCH_EPOCH=$(date +%s)
+START_EPOCH=$LAUNCH_EPOCH
+SAW_RUNNER=0
+RUNNER_STATE="not started yet"
+if [ -n "$(runner_pid)" ]; then
+    SAW_RUNNER=1
+    RUNNER_STATE="alive (pid $(runner_pid))"
+fi
+
+say "watching $SLUG/$PHASE — baseline hits=$BASE_HITS, runner $RUNNER_STATE, poll=${POLL}s, timeout=$(dur "$MAX_SECS")"
+
+while true; do
+    if [ "$(count_hits)" -gt "$BASE_HITS" ]; then
+        case "$(settle_disposition)" in
+            done)
+                fire "✅ automouse **$PHASE** complete for **$SLUG** — plan shipped (queue → done)." ;;
+            skipped)
+                fire "⚠️ automouse **$PHASE** finished for **$SLUG** but the plan landed in **skipped/** — needs a look." ;;
+            *)
+                fire "⚠️ automouse **$PHASE** finished for **$SLUG**, but the plan is still in queue/ (no done/skipped disposition) — needs a look." ;;
+        esac
+    fi
+
+    # Disposition with no verdict line — impl short-circuit, or a stall-killed
+    # phase whose stream never reached the `result` event.
+    if exists "$AM/done/$PLAN"; then
+        fire "✅ automouse finished **$SLUG** — plan landed in done/."
+    elif exists "$AM/skipped/$PLAN"; then
+        fire "⚠️ automouse gave up on **$SLUG** — plan landed in skipped/ after failed attempts."
+    fi
+
+    if [ -n "$(runner_pid)" ]; then
+        SAW_RUNNER=1
+    elif [ "$SAW_RUNNER" = 1 ]; then
+        fire "⚠️ automouse runner exited without a disposition for **$SLUG** (still in queue/ — likely an env stop / usage limit). $PHASE did not complete."
+    else
+        # The runner hasn't started yet — launchd fires it overnight, so a watcher
+        # launched at 6pm for a 1am run would otherwise burn its whole phase budget
+        # waiting and false-fire before the plan even began. --timeout budgets the
+        # PHASE; the wait for the runner is budgeted separately by --wait.
+        START_EPOCH=$(date +%s)
+    fi
+
+    if [ "$SAW_RUNNER" = 0 ] && [ $(( $(date +%s) - LAUNCH_EPOCH )) -gt "$WAIT_SECS" ]; then
+        fire "⏱ Watcher gave up after $(dur "$WAIT_SECS") on **$SLUG** — the automouse runner never started. Plan is still queued; check launchd."
+    fi
+
+    if [ $(( $(date +%s) - START_EPOCH )) -gt "$MAX_SECS" ]; then
+        fire "⏱ Watcher timed out after $(dur "$MAX_SECS") on **$SLUG** — the runner is alive but $PHASE has not finished. Watcher exiting; check the log."
+    fi
+
+    sleep "$POLL"
+done

--- a/bin/watch-automouse-plan
+++ b/bin/watch-automouse-plan
@@ -211,7 +211,18 @@ while true; do
             skipped)
                 fire "⚠️ automouse **$PHASE** finished for **$SLUG** but the plan landed in **skipped/** — needs a look." ;;
             *)
-                fire "⚠️ automouse **$PHASE** finished for **$SLUG**, but the plan is still in queue/ (no done/skipped disposition) — needs a look." ;;
+                # Still in queue/ means opposite things per phase. A healthy impl
+                # ALWAYS ends here — bin/automouse-run only moves the plan out of
+                # queue/ on a deliberate impl disposition (already-merged → done/,
+                # the rest → skipped/); a normal impl writes a handoff and leaves
+                # the plan queued for postplan, which is the phase that does the
+                # queue → done move. So "no disposition" is the success signal for
+                # impl and a genuine anomaly only for postplan.
+                if [ "$PHASE" = impl ]; then
+                    fire "✅ automouse **impl** complete for **$SLUG** — postplan next."
+                else
+                    fire "⚠️ automouse **$PHASE** finished for **$SLUG**, but the plan is still in queue/ (no done/skipped disposition) — needs a look."
+                fi ;;
         esac
     fi
 

--- a/ibl5/docs/decisions/0097-single-retrying-host-notification-transport.md
+++ b/ibl5/docs/decisions/0097-single-retrying-host-notification-transport.md
@@ -1,0 +1,39 @@
+---
+description: Host-side Discord notifications go through one retrying transport (bin/discord-dm) that never fails silently; callers never re-implement the ssh+curl recipe.
+last_verified: 2026-08-04
+---
+
+# ADR-0097: A single retrying host-side notification transport
+
+**Status:** Accepted
+**Date:** 2026-08-04
+
+## Context
+
+IBLbot binds `127.0.0.1:50000` on prod, so any host-side sender has to tunnel over ssh and POST to localhost. That recipe was copy-pasted per caller, one-shot, with `curl -sf` swallowing the HTTP status. On 2026-08-04 a watcher detected an automouse plan's finish in 52 seconds, built the correct message with the correct PR link, POSTed it once into a transient 500 during a `bin/iblbot-healthcheck` pm2 restart window, logged nothing legible, and exited 0. The notification was simply lost, and the only symptom was silence — the caller had no way to tell "delivered" from "dropped".
+
+## Decision
+
+Every host-side Discord notification goes through **`bin/discord-dm`**, the one place the ssh+curl recipe lives. It retries across a window longer than a pm2 restart (6 attempts, ~5min15s), logs `ssh_rc`/`curl_rc`/`http` on every attempt, treats 4xx as permanent and fails fast, and on total failure spools the message to a durable log, raises a macOS notification, and exits non-zero — so a caller can always distinguish delivery from loss. Callers pass the message on stdin and never construct the payload themselves; the recipient snowflake stays a JSON string end-to-end (`jq --arg`) and defaults from `~/.iblbot-dm-id`, which lives outside the repo so no snowflake is committed. `bin/watch-automouse-plan` is the first consumer.
+
+## Alternatives Considered
+
+- **Fix the retry in each caller** — add a loop where the recipe is pasted. Rejected because: the bug is the duplication; the next caller re-inherits it.
+- **Expose the bot on a public port and drop the ssh leg** — Rejected because: it turns a localhost-only service into an internet-facing one to save a hop.
+- **Let a failed send stay advisory (log and exit 0)** — Rejected because: that is exactly the failure mode being fixed; a notification that can vanish silently is worse than none, since it is trusted.
+- **Route through `.github/actions/notify-discord`** — Rejected because: that action is a GitHub Actions runner surface, not runnable from the host; `bin/discord-dm` is its host-side sibling.
+
+## Consequences
+
+- Positive: a lost notification is now impossible to miss — worst case it is spooled, flagged on screen, and signalled by a non-zero exit.
+- Positive: one place to change if the bot's port, host, or payload shape moves.
+- Negative: a **bad snowflake** costs the full ~5-minute retry window, because IBLbot answers an invalid recipient with **500**, not 4xx — indistinguishable from the transient failure the retries exist for. Accepted deliberately: 500 is exactly the code the originally-lost message returned, so refusing to retry it would reintroduce the bug this ADR closes.
+- Negative: delivery can now take minutes instead of failing instantly, so a caller that blocks on the send blocks longer.
+
+## References
+
+- `bin/discord-dm` — the transport; header documents the retry window and the 500 trade-off.
+- `bin/watch-automouse-plan` — first consumer; routes every notification through it.
+- `bin/iblbot-healthcheck` — the pm2 cron watchdog whose restart windows the retry budget is sized against.
+- `.github/actions/notify-discord` — the CI-side sibling.
+- `bin/README.md` — registers both scripts.

--- a/ibl5/docs/decisions/README.md
+++ b/ibl5/docs/decisions/README.md
@@ -1,6 +1,6 @@
 ---
 description: Index of IBL5 Architecture Decision Records (ADRs). Source of truth for every load-bearing decision and its rationale.
-last_verified: 2026-07-27
+last_verified: 2026-08-04
 ---
 
 # IBL5 Architecture Decision Records
@@ -31,6 +31,7 @@ Every load-bearing decision in IBL5 is captured here as a numbered ADR so that f
 | [0092](0092-postplan-harness-in-repo-with-python-ci.md) | Post-plan harness in-repo with dedicated Python CI | Accepted | Harness ships under `tools/postplan-harness/` gated by a path-scoped `python-tests.yml`; real-data dirs gitignored; `bin/post-plan-now` pinned to the main checkout. |
 | [0095](0095-retire-ibl6-svelte-frontend.md) | Retire the IBL6 SvelteKit frontend; site stays PHP+HTMX | Accepted | Ported IBL6's one page (boxscore) into IBL5 as a PHP module; deleted the second stack + all its CI/Docker/deploy/smoke surface. |
 | [0096](0096-headless-plan-autofire.md) | `/plan-prompt` auto-fires the planning run headlessly | Accepted | `bin/plan-now` runs the drafted prompt as a detached Sonnet 4.6 `/plan`; user-facing forks pre-resolved in-session, `bin/check-plan` verdict logged; the runner auto-queues for automouse by default, `--implement` opts out. |
+| [0097](0097-single-retrying-host-notification-transport.md) | A single retrying host-side notification transport | Accepted | All host-side Discord sends go through `bin/discord-dm` — retries past a pm2 restart window, spools + exits non-zero rather than dropping a message silently. |
 
 ## When an ADR is Required
 


### PR DESCRIPTION
## Summary

Adds two `bin/` scripts that close a silent-drop gap in automouse plan notifications:

- **`bin/discord-dm`** — reliable host-side Discord DM sender via IBLbot's SSH tunnel. Replaces ad-hoc `curl -sf` one-liners with retry logic (default 6 attempts over ~5 min — longer than a pm2 restart window), structured logging, 4xx fast-fail, and macOS notification + spool on total failure.

- **`bin/watch-automouse-plan`** — watches a running automouse plan phase and sends a DM on completion via `bin/discord-dm`. Generalised from a one-off watcher that fired correctly but then lost its message to a single un-retried POST (2026-08-04). Uses the stream filter's per-slug verdict line as primary signal (not the slug-unattributed runner marker), with two backstops for stall-kill and CI-skip paths.

- **`bin/README.md`** — entry added for both scripts.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.