### PR TITLE
fix(team-stats): match game_type in stats join

### DIFF
--- a/ibl5/classes/TeamOffDefStats/TeamOffDefStatsRepository.php
+++ b/ibl5/classes/TeamOffDefStats/TeamOffDefStatsRepository.php
@@ -335,6 +335,7 @@ class TeamOffDefStatsRepository extends \BaseMysqliRepository implements TeamOff
             AND my.visitor_teamid = opp.visitor_teamid
             AND my.home_teamid = opp.home_teamid
             AND my.game_of_that_day = opp.game_of_that_day
+            AND my.game_type = opp.game_type
             AND my.name <> opp.name
         JOIN `ibl_franchise_seasons` fs
             ON fs.team_name = my.name AND fs.season_ending_year = my.season_year


### PR DESCRIPTION
## Summary
- Add `game_type` constraint to TeamOffDefStats join condition
- Ensures stats comparisons exclude games of different types (e.g., regular vs. playoff)
- Fixes incorrect stats aggregation caused by cross-type game matching
