### PR TITLE
chore(backlog): drop roll-up count tables

### DIFF
--- a/.claude/skills/backlog-housekeep/SKILL.md
+++ b/.claude/skills/backlog-housekeep/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: backlog-housekeep
 description: "Ship backlog housekeeping with an implemented backlog item: flip its status, stamp discovered items with provenance, sweep sibling and cross-backlog redundancy, archive done items behind a dated pointer, and reconcile the README index — then self-verify via bin/check-docs."
-last_verified: 2026-07-25
+last_verified: 2026-08-05
 ---
 
 # Backlog Housekeeping
@@ -35,7 +35,7 @@ Both branches run the identical checklist below; only *who reads the files* diff
 3. **Sibling-scope edits.** Edit sibling items in the same backlog whose scope shifted because of this change (narrowed, split, or now-blocked), noting the shift in the entry.
 4. **Cross-backlog redundancy sweep.** Grep the OTHER backlogs for items this change makes redundant; on each, add the greppable field `**Superseded by:** <ref> — <reason>` (verbatim format — `<ref>` = this PR/plan, `<reason>` = one clause). Do NOT delete the superseded item; the stamp is the audit trail.
 5. **Archive move + dated pointer.** For every item now done or declined in a **body-status** backlog: move its body into the sibling archive file `archive/<x>-backlog-archive.md` (create it if absent — the gate's (b) invariant requires the canonical sibling), and replace the LIVE entry with a one-line dated pointer into that archive. Table-status backlogs (`maintenance-backlog.md`) archive too, in a different shape: append the removed row's `Evidence / note` cell **verbatim** to the archive's `### <id>` section as `**Table evidence (YYYY-MM-DD):** <cell>`, creating `### <id> — Finding <id>` with a `**Status:**` line if no section exists. Never reword, reflow, or de-duplicate the cell — the archive is the byte-faithful record, and the LIVE summary line keeps only the id.
-6. **README index/count reconciliation.** Update `ibl5/docs/backlog/README.md` counts and any index rows affected by the flips/additions/archives, and bump its `last_verified` to today (the convention this step follows is codified in that README).
+6. **README index reconciliation.** Update any index rows in `ibl5/docs/backlog/README.md` affected by the flips/additions/archives, and bump its `last_verified` to today (the convention this step follows is codified in that README).
 7. **Self-verify (mandatory gate).** Run `bin/check-docs --since=<base>` — the backstop that catches an unresolved pointer, a missing sibling, or an inline-done item. Fix every diagnostic before returning. This is the machine check that the housekeeping is internally consistent.
 
 If nothing qualifies (no flip, no discovery, no archive), **no-op** and say so in one line — never fabricate edits.

--- a/engine/docs/backlog/jsb-native-backlog.md
+++ b/engine/docs/backlog/jsb-native-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: JSB native-engine backlog — the count-axis cut-over blocker chain, static RE pins, faithful ports, and validation gates, each tagged with the model tier that owns its load-bearing reasoning (Fable-gated items marked).
-last_verified: 2026-07-30
+last_verified: 2026-08-05
 ---
 
 # JSB Native-Engine Backlog
@@ -53,18 +53,6 @@ J18 composite fidelity ports (✅ 2026-07-13 — all divergences merged; f/shrin
 ```
 
 The cut-over blocker — the wrong-signed Cov(lnFGA,lnPPS) — has a **named dominant carrier** (J2 session 1, 2026-07-10): a mechanical Cov injection from unfaithful foul share. PPS = PF/FGA counts FT points in the numerator while foul plays displace FGA from the denominator, so excess foul-share level/dispersion injects negative Cov directly; the engine ran foul share at **1.8× real** (37.8 vs 20.65 FTA/g, a pre-ADR-0082 legacy). Zeroing defQ moved gt2 Cov **−0.000774 → −0.000340** (real +0.000269) — 56% of the residual, ~15× any prior single lever; that A/B stands as measurement. **But J6 (same day) overturned the static premise underneath it:** J5's "defQ ≡ 0" was a store-enumeration blindspot — 5.60 builds the player record on the STACK (FUN_004cfa50 → FUN_00405970 write-back), so +0xDD0 (STL/MIN×44), +0xDE0 (usage-shrunk TOV/48), and +0xDC8 (AST/48) are all **live**. The faithful foul coupling is therefore roster-VARYING (defQ = Σ defenders' STL/MIN×44; offQ = Σ offense TOV/48 − HCA, TOV-coupled not volume-neutral), and J2's "symmetric U[0,0.6) both sides" verdict plus the J15 program must be re-adjudicated against the live-composite semantics before any port ships. "Mapped carriers exhausted" stays refuted; the map had a foul-path hole — and a method hole (see J6's caveat).
-
----
-
-## Roll-up
-
-| Status | Count |
-|--------|------:|
-| ⬜ Open | 5 |
-| 📋 Planned | 0 |
-| ◑ Partial | 2 |
-| ✅ Implemented | 23 |
-| 🚫 Declined | 1 |
 
 ---
 

--- a/ibl5/docs/backlog/ci-backlog.md
+++ b/ibl5/docs/backlog/ci-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: CI/GitHub-Actions workflow simplification backlog — duplicated setup/notify boilerplate, job consolidation, and verified-not-redundant workflows, with per-entry status + automouse-readiness.
-last_verified: 2026-07-31
+last_verified: 2026-08-05
 ---
 
 # CI Workflow Simplification Backlog
@@ -23,20 +23,7 @@ last_verified: 2026-07-31
 
 **Effort scale:** **S** — single PR, < 1 day. **M** — multi-step plan, 1-3 days. **L** — platform shift, likely needs an ADR.
 
----
-
-## Roll-up
-
-| Status | Count |
-|--------|------:|
-| ⬜ Open | 1 |
-| 📋 Planned | 2 |
-| ◑ Partial | 1 |
-| ✅ Implemented | 9 |
-| 🚫 Declined | 0 |
-
-> The 4 "verified-not-redundant" entries in Axis 4 are **decisions to keep**, not open work — they exist so a future audit does not re-flag them. Not counted above.
-> ✅ corrected from 8 → 9 on 2026-07-31: a recount from table rows (Axes 1–3, 5) found 9 implemented entries (3.5 had already folded into 1.1 but was still counted separately; 5.1 was the sole ⬜, not 2). ⬜ was 1 before the Axis 6 additions. [CORRECTED 2026-07-31]
+> The 4 "verified-not-redundant" entries in Axis 4 are **decisions to keep**, not open work — they exist so a future audit does not re-flag them.
 
 ---
 

--- a/ibl5/docs/backlog/dev-efficiency-backlog.md
+++ b/ibl5/docs/backlog/dev-efficiency-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Development-efficiency backlog — inner-loop speed (diff-scoped analysis, parallel tests), CI caching, dependency-bump batching, and worktree lifecycle automation, with per-entry status.
-last_verified: 2026-07-29
+last_verified: 2026-08-05
 ---
 
 # Development-Efficiency Backlog
@@ -20,18 +20,6 @@ last_verified: 2026-07-29
 **Automouse-readiness** (for items not ✅/🚫): same glyphs as [`ci-backlog.md`](ci-backlog.md) — 🟩 auto-mergeable · 🟦 automouse-safe, human-merge · 🟨 conditional · 🟥 not automouse-safe.
 
 **Effort scale:** **S** — single PR, < 1 day. **M** — multi-step plan, 1–3 days. **L** — platform shift, likely needs an ADR.
-
----
-
-## Roll-up
-
-| Status | Count |
-|--------|------:|
-| ⬜ Open | 4 |
-| 📋 Planned | 2 |
-| ◑ Partial | 2 |
-| ✅ Implemented | 4 |
-| 🚫 Declined | 0 |
 
 ---
 

--- a/ibl5/docs/backlog/e2e-backlog.md
+++ b/ibl5/docs/backlog/e2e-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: E2E (Playwright + api-e2e) test-quality backlog — refactoring, perf, weak/tautological assertions, tests that don't prove functionality, and flake-prone patterns, with per-entry status + automouse-readiness. Each open entry is a candidate for a /plan.
-last_verified: 2026-07-07
+last_verified: 2026-08-05
 ---
 
 # E2E Test-Quality Backlog
@@ -47,24 +47,6 @@ Effort scale:
 > **Planning note:** 🟨 items set `auto_merge: false` (STOP-guard, human signoff) — the plan must confirm the
 > happy path passes before treating a tightened assertion as green-green. Axis A, B, C, and E each package as
 > one plan apiece (single coherent worktree per axis); Axis D is planned per-cluster instead (see below).
-
-## Roll-up (66 findings)
-
-| Status | Count |
-|--------|------:|
-| ✅ Implemented | 3 |
-| ◑ Partial | 0 |
-| 📋 Planned | 0 |
-| ⬜ Open | 63 |
-| 🚫 Declined | 0 |
-
-| Axis | Findings | Theme |
-|------|---------:|-------|
-| A — DRY / WET refactoring | 8 | duplicated helpers / inline reimplementations |
-| B — Performance / combinable | 13 | redundant navigations, combinable tests |
-| C — Weak / tautological | 18 | assertions that can't fail |
-| D — Doesn't prove functionality | 15 | green tests not guarding the feature |
-| E — Flake-prone patterns | 12 | race-sensitive waits (not a measured flake rate) |
 
 > **Caveat on Axis E:** code cannot prove failure history (CI flake data is token-gated here). Axis E lists
 > race-sensitive *patterns*, not measured flake rates.

--- a/ibl5/docs/backlog/loop-engineering-backlog.md
+++ b/ibl5/docs/backlog/loop-engineering-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Loop-engineering backlog — automouse queue robustness (dependency ordering, circuit breakers, canaries, self-healing), autonomous intake loops, plan decomposition/tier-routing machinery, and the human comprehension counter-loop, with per-entry status.
-last_verified: 2026-07-31
+last_verified: 2026-08-05
 ---
 
 # Loop-Engineering Backlog
@@ -20,18 +20,6 @@ last_verified: 2026-07-31
 **Automouse-readiness** (for items not ✅/🚫): same glyphs as [`ci-backlog.md`](ci-backlog.md) — 🟩 auto-mergeable · 🟦 automouse-safe, human-merge · 🟨 conditional · 🟥 not automouse-safe. (Ironic but real: changes to the loop machinery itself mostly want a human merge — a bug here burns whole nights.)
 
 **Effort scale:** **S** — single PR, < 1 day. **M** — multi-step plan, 1–3 days. **L** — platform shift, likely needs an ADR.
-
----
-
-## Roll-up
-
-| Status | Count |
-|--------|------:|
-| ⬜ Open | 10 |
-| 📋 Planned | 6 |
-| ◑ Partial | 2 |
-| ✅ Implemented | 9 |
-| 🚫 Declined | 0 |
 
 ---
 

--- a/ibl5/docs/backlog/maintenance-backlog.md
+++ b/ibl5/docs/backlog/maintenance-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Long-running backlog of maintenance-cost reduction opportunities, organized by axis. Each item is a candidate for a future plan.
-last_verified: 2026-08-04
+last_verified: 2026-08-05
 ---
 
 # Maintenance-Cost Reduction Backlog
@@ -43,28 +43,15 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 
 > A file still >500 LOC after a ✅ does **not** reopen the finding when the finding's named concern was narrower than "shrink below 500 LOC"; residual size is noted, not re-flagged.
 
-### Roll-up (333 findings)
-
-| Status | Count |
-|--------|------:|
-| ✅ Implemented | 240 |
-| ◑ Partial | 24 |
-| 📋 Planned (plan queued / PR open) | 1 |
-| ⬜ Open | 58 |
-| 🚫 Declined | 10 |
-
-> Status counts re-verified 2026-06-28 (exact, from the per-axis tables); **6.20 / 6.21 added 2026-06-29** from the PR #1107 review (⬜ Open +2); **6.22 added 2026-06-29** from the #1066 reject-IDOR review (⬜ Open +1). Two stale-Open rows were flipped directly (no plan owned them): **13.3**, **13.9** (✅ +2, ⬜ −2 vs the master re-count). **1.21–1.31 added 2026-07-24** from the hot-files comment→backlog migration (⬜ Open +11: 8 🟩 auto-mergeable, 3 🟨 conditional — 1.23/1.25/1.31 need characterization/endpoint pins). **Ground-truth audit 2026-07-24:** 7 stale-Open items flipped ✅, 2 false findings marked 🚫, 5 new Axis-1 rows seeded (1.32–1.36); IDOR PRs #1107–1110 merged 2026-06-29 (unblocking 2.10/2.13/2.14/2.25/7.7/14.6); PRs #1240/#1230/#1204 merged (2.6/2.31/2.32/5.18 already ✅/Open on own merits). **9.19 and 9.20 implemented 2026-07-24** — added READMEs to all 68 missing class dirs + frontmatter to all 16 existing class READMEs that lacked it; extended bin/check-docs IN_SCOPE_GLOBS (✅ +2, ⬜ −2); roll-up recomputed from grep (331 rows total, unchanged). **6.16 flipped ✅ 2026-07-24** (all Api data repos + JsonResponder + SystemClock tested; ✅ +1, ◑ −1). **6.14 Status updated 2026-07-24** (ProcessBoxscoresStep/GenerateSeasonAwardsStep/ParseJsbFilesStep added; still ◑). **Resolved rows collapsed 2026-07-25** — ✅/🚫 findings no longer appear as table rows; each axis carries a `> ✅ resolved (N): …` / `> 🚫 declined (N): …` summary line and their evidence lives in [archive/maintenance-backlog-archive.md](archive/maintenance-backlog-archive.md). **Recount recipe:** resolved = sum of the `(N)` in the per-axis summary lines; open = grep of the per-axis table rows; total = the two added. Counts above are unchanged by the collapse (238 + 93 = 331). **1.36 and 7.7 flipped ✅ 2026-07-26** (✅ +2, ⬜ −1, ◑ −1); total tracked rows unchanged at 331. **1.29 flipped ✅ 2026-07-26 (PR #1679)** (✅ +1, ⬜ −1); total tracked rows unchanged at 331. **1.27 flipped ✅ 2026-07-27** — extracted 10 per-entity collaborators into `ibl5/classes/JsbParser/Repositories/`; JsbImportRepository reduced to thin facade (✅ +1, ⬜ −1); total tracked rows unchanged at 331. **1.23 flipped ✅ 2026-07-27 (`oneonone-1-23-pins-and-extract`)** (✅ +1, ⬜ −1); total tracked rows unchanged at 331. **1.31 flipped ✅ 2026-07-27** — extracted `TradeRosterPreviewParamValidator` + `TradeRosterPreviewCashRowBuilder` collaborators; DB characterization pin + validator/cash-row unit suites landed (✅ +1, ⬜ −1). **2.39 seeded 2026-07-27** — cash-year range unbounded/unordered in `TradeRosterPreviewCashRowBuilder::buildCashRows()`; cashStartYear/cashEndYear come from `$_GET` with no upper bound (discovered during trading-1-31-api-handler-extract) (⬜ +1); **1.19 flipped ✅ 2026-07-27** — characterization pins + `executePlayerLoop` merge shipped; `processPlrData`/`processPlrDataForYear` deduped (✅ +1, ⬜ −1); total tracked: 332 (✅ 236, ◑ 24, 📋 1, ⬜ 61, 🚫 10). **14.6 flipped ◑ Partial 2026-07-28 (#1712)** — batch 1 (17 Api/Controller/*) converted to DI; batch 2 pending (◑ +1, ⬜ −1); total tracked: 332 (✅ 236, ◑ 25, 📋 1, ⬜ 60, 🚫 10). **14.9 flipped ✅ 2026-07-27** — replaced 21 `$cookie[1]` occurrences across 11 files with `AuthService::getUsername()` (✅ +1, ⬜ −1); total tracked: 332 (✅ 237, ◑ 25, 📋 1, ⬜ 59, 🚫 10). **11.16 flipped ✅ 2026-07-27** — moved page-specific JS loaders (`offer-salary-hints.js`, `contract-hint.js`) from PageLayout global bundle to per-view injection in NegotiationService and TradingView; E2E behavioral pins + VR manifest row added (✅ +1, ⬜ −1); total tracked: 332 (✅ 238, ◑ 25, 📋 1, ⬜ 58, 🚫 10). **6.2 and 6.4 flipped ✅ 2026-07-27** (PR #1671 tests verified; ✅ +2, ⬜ −1, ◑ −1); total tracked: 332 (✅ 240, ◑ 24, 📋 1, ⬜ 57, 🚫 10). **15.24 seeded 2026-08-04** — pre-existing duplicate player box-score rows in `ibl_box_scores` for seasons 1993/1994/2002/2004 (discovered during the PR #1771 review) (⬜ +1).
 
 **Automouse-readiness of the not-yet-complete (⬜/◑/📋) items:**
 
-| Bucket | Count | What it means |
-|--------|------:|---------------|
-| 🟩 Auto-mergeable | ~110 | green-green + pinnable; arms unattended |
-| 🟦 Safe, human-merge | 11 | gate-14 trigger (security / UI-UX / destructive schema) → `auto_merge: false` |
-| 🟨 Conditional | 37 | needs one mechanical-scope add, one upfront decision, or a collision-PR to merge first |
-| 🟥 Not automouse-safe | 1 | 12.11 — `git filter-repo` history rewrite (irreversible, coordinated) |
-
-(A few ✅ rows also carry a 🟩 for an *optional* residual burndown — e.g. PHPStan-rule baselines — so automouse tags slightly exceed the not-done count. Counts verified by grep of the per-axis tables; treat as ±2.)
+| Bucket | What it means |
+|--------|---------------|
+| 🟩 Auto-mergeable | green-green + pinnable; arms unattended |
+| 🟦 Safe, human-merge | gate-14 trigger (security / UI-UX / destructive schema) → `auto_merge: false` |
+| 🟨 Conditional | needs one mechanical-scope add, one upfront decision, or a collision-PR to merge first |
+| 🟥 Not automouse-safe | 12.11 — `git filter-repo` history rewrite (irreversible, coordinated) |
 
 **Highest-leverage 🟩 auto-mergeable clusters** (no human needed): the open god-class extractions (1.3/1.9/1.11/1.13/1.17/1.18/1.20, 7.14/7.15, 1.32–1.36), the entire Axis-6 coverage backlog (bar 6.21, now 🟨), the Axis-9 docs items, and the PHPStan-baseline burndowns (10.12/10.13/10.19/10.21).
 

--- a/ibl5/docs/backlog/token-spend-backlog.md
+++ b/ibl5/docs/backlog/token-spend-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Token-spend reduction backlog — resident-context diet, caching economics, output-spend guards, and LSP-first navigation for the Claude Code harness, with per-entry status.
-last_verified: 2026-07-17
+last_verified: 2026-08-05
 ---
 
 # Token-Spend Reduction Backlog
@@ -24,20 +24,6 @@ last_verified: 2026-07-17
 - **repo** — normal worktree → PR path.
 
 **Effort scale:** **S** — one sitting. **M** — multi-step, 1–3 days. **L** — restructure, likely needs an ADR.
-
----
-
-## Roll-up
-
-| Status | Count |
-|--------|------:|
-| ⬜ Open | 0 |
-| 📋 Planned | 0 |
-| ◑ Partial | 0 |
-| ✅ Implemented | 16 |
-| 🚫 Declined | 0 |
-
-Archived entries (✅ Implemented): see [token-spend-backlog-archive.md](archive/token-spend-backlog-archive.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- Removed roll-up status count tables from 7 backlog files
- Removed count-reconciliation step from backlog-housekeep skill documentation
- Simplified automouse-readiness table in maintenance backlog (removed Count column)
- Updated last_verified timestamps to 2026-08-05

## Manual Testing

No manual testing needed — verified by automated tests.
