### PR TITLE
chore(phpstan): disable unnecessaryNullCoalesce

### DIFF
--- a/ibl5/composer.lock
+++ b/ibl5/composer.lock
@@ -1908,11 +1908,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.5",
+            "version": "2.2.8",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
-                "reference": "909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e285254e60f33c21902efef4a926ca0987c06804",
+                "reference": "e285254e60f33c21902efef4a926ca0987c06804",
                 "shasum": ""
             },
             "require": {
@@ -1968,7 +1968,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-05T06:31:06+00:00"
+            "time": "2026-08-04T22:21:45+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",

--- a/ibl5/phpstan-tests.neon
+++ b/ibl5/phpstan-tests.neon
@@ -27,6 +27,13 @@ parameters:
         - phpstan-stubs/mock-aliases.stub.php
     phpVersion: 80300
     treatPhpDocTypesAsCertain: false
+    featureToggles:
+        # Mirrors phpstan.neon — see the full rationale there. bleedingEdge enabled
+        # `unnecessaryNullCoalesce` in phpstan 2.2.6; it derives certainty from PHPDoc
+        # array shapes and ignores `treatPhpDocTypesAsCertain: false` above. No test file
+        # trips it today, so this is pre-emptive: it keeps the two configs stating the
+        # same PHPDoc-certainty policy instead of leaving tests silently opted in.
+        unnecessaryNullCoalesce: false
 
 services:
     -

--- a/ibl5/phpstan.neon
+++ b/ibl5/phpstan.neon
@@ -27,6 +27,22 @@ parameters:
         - phpstan-stubs/nuke-globals.stub.php
     phpVersion: 80300
     treatPhpDocTypesAsCertain: false
+    featureToggles:
+        # bleedingEdge enabled `unnecessaryNullCoalesce` in phpstan 2.2.6. It reports
+        # `$arr['key'] ?? null` as redundant using certainty derived from PHPDoc array
+        # shapes (`@phpstan-type`) — ignoring `treatPhpDocTypesAsCertain: false` above.
+        # Verified: on the same expression, `function.alreadyNarrowedType` IS correctly
+        # suppressed by that setting while `nullCoalesce.unnecessary` is not.
+        #
+        # Our `@phpstan-type` shapes describe the happy path of config files and SELECT
+        # rows whose keys can genuinely be absent at runtime, so the `?? null` inside
+        # `is_string(...)`/`is_int(...)` guards is load-bearing: PR #1785 removed it and
+        # PHP emitted "Undefined array key" warnings, which fail PHPUnit with exit 1.
+        #
+        # Disabling this toggle restores the repo's stated PHPDoc-certainty policy. The
+        # native-type equivalent (`nullCoalesce.offset`) stays on and still catches a
+        # genuinely redundant `??`.
+        unnecessaryNullCoalesce: false
 
 services:
     -

--- a/ibl5/tests/Auth/DevAutoLoginTest.php
+++ b/ibl5/tests/Auth/DevAutoLoginTest.php
@@ -64,11 +64,11 @@ class DevAutoLoginTest extends TestCase
 
         // Session should remain unchanged — not overwritten with the env var user.
         // Both halves of the contract are asserted: tryAutoLogin() must leave the
-        // existing user id AND username untouched. PHPStan narrows the session slot to
-        // the literal 42 from the assignment above and cannot see that tryAutoLogin()
-        // might overwrite it, so the id assertion looks statically tautological — but it
-        // is runtime-meaningful (it fails if the call mutates auth_user_id).
-        self::assertSame($originalUserId, $_SESSION['auth_user_id']); /** @phpstan-ignore staticMethod.alreadyNarrowedType (PHPStan narrows the session slot to 42; tryAutoLogin() could overwrite it at runtime) */
+        // existing user id AND username untouched. The id assertion is runtime-meaningful
+        // (it fails if the call mutates auth_user_id) even though the value was assigned
+        // above; phpstan 2.2.5 and earlier narrowed the session slot to the literal 42 and
+        // needed a staticMethod.alreadyNarrowedType ignore here, which 2.2.6 made stale.
+        self::assertSame($originalUserId, $_SESSION['auth_user_id']);
         self::assertSame('ExistingUser', $_SESSION['auth_username']);
     }
 

--- a/ibl5/tests/DatabaseIntegration/ProjectedDraftOrderRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/ProjectedDraftOrderRepositoryTest.php
@@ -167,8 +167,12 @@ class ProjectedDraftOrderRepositoryTest extends DatabaseTestCase
             }
         }
         self::assertNotNull($metros);
-        self::assertSame(205.0, (float) $metros['pointsFor']); /** @phpstan-ignore cast.useless (mysqli returns SUM as numeric-string; @var float annotation overstates the type) */ // 110 + 95
-        self::assertSame(190.0, (float) $metros['pointsAgainst']); /** @phpstan-ignore cast.useless (mysqli returns SUM as numeric-string; @var float annotation overstates the type) */ // 90 + 100
+        // The casts are load-bearing: mysqli returns SUM as a numeric-string, which the
+        // @var float annotation overstates. phpstan 2.2.5 and earlier trusted that
+        // annotation and called them useless; 2.2.6 honours treatPhpDocTypesAsCertain
+        // here, so the ignores it needed are now stale.
+        self::assertSame(205.0, (float) $metros['pointsFor']); // 110 + 95
+        self::assertSame(190.0, (float) $metros['pointsAgainst']); // 90 + 100
     }
 
     public function testIsDraftOrderFinalizedReturnsFalse(): void

--- a/ibl5/tests/DatabaseIntegration/RecordHoldersRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/RecordHoldersRepositoryTest.php
@@ -664,7 +664,7 @@ class RecordHoldersRepositoryTest extends DatabaseTestCase
         self::assertArrayHasKey('count', $first);
         self::assertArrayHasKey('years', $first);
         self::assertSame('Metros', $first['team_name']);
-        self::assertSame(2, (int) $first['count']); // @phpstan-ignore cast.useless
+        self::assertSame(2, (int) $first['count']);
         self::assertSame('2097, 2098', $first['years']);
     }
 


### PR DESCRIPTION
## Summary
- Disable `unnecessaryNullCoalesce` feature toggle (phpstan 2.2.6) which reports PHPDoc-derived certainty while ignoring `treatPhpDocTypesAsCertain: false`
- Align config policies across `phpstan.neon` and `phpstan-tests.neon` with detailed rationale
- Remove stale `@phpstan-ignore` comments from tests

## Manual Testing

No manual testing needed — verified by automated tests.
