### PR TITLE
chore(backlog): update verification dates and archive completed items

### DIFF
--- a/ibl5/docs/backlog/a11y-backlog.md
+++ b/ibl5/docs/backlog/a11y-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: WCAG 2.x full-rule (non-contrast) accessibility failure inventory and burn-down backlog per axe rule, with audited per-entry implementation + automouse-readiness status. Companion to a11y-contrast-backlog.md.
-last_verified: 2026-07-13
+last_verified: 2026-08-08
 ---
 
 # A11y Full-Rule Backlog (non-contrast)
@@ -38,8 +38,8 @@ This audit (2026-06-20, verified against the live `accessibility.spec.ts` `KNOWN
 | **page-has-heading-one** — single-title views | ✅ Implemented | — | `a11y-2` (#1103) merged. |
 | **page-has-heading-one** — training camp ratings diff | ✅ Implemented | — | `a11y-4` (#1158) merged. |
 | **page-has-heading-one** — 4 leaderboard/db promotes + team-page banner-`<h1>` | ✅ Implemented | — | `a11y-5` (#1163): the 4 `h2.ibl-title`→`h1` promotes + Team-page banner-as-`<h1>` redesign (logo wrapped in `<h1>`; year demoted to `<h2>`); Free-Agents text-`<h1>` retained — removed from `KNOWN_FAILING`. |
-| **page-has-heading-one** — next sim (single-title promote) | ⬜ Open | 🟩 auto-mergeable | `NextSimView.php:54` emits a single `<h2 class="ibl-title">Next Sim</h2>` → plain promote to `<h1>` (VR-identical). An unplanned single-title view a11y-2/4 didn't sweep. |
-| **page-has-heading-one** — schedule + team schedule (STALE allowlist) | ⬜ Open | 🟩 auto-mergeable | **Re-checked:** both Views already emit `<h1 class="ibl-title">Schedule</h1>` **unconditionally** (`LeagueScheduleView.php:51`, `TeamScheduleView.php:101`). The pages already pass `page-has-heading-one`; the allowlist entries are **stale** → verify-and-remove (no code change), clicks the ratchet. |
+| **page-has-heading-one** — next sim (single-title promote) | ✅ Implemented | — | PR #1175 merged 2026-06-21. |
+| **page-has-heading-one** — schedule + team schedule (STALE allowlist) | ✅ Implemented | — | PR #1180 merged 2026-06-21: stale allowlist entries removed; confirmed green. |
 | **page-has-heading-one** — multi-title / loop-rendered (standings, trading, season archive, franchise record book, compare players, waivers, depth chart entry, voting results, olympics standings; **big board, trade block — blocked on Phase-4 re-land**) | ◑ Partial | 🟨 decision | **DONE:** trading, season archive, franchise record book, compare players, waivers, depth chart entry promoted to `<h1>` (record book + `heading-order` h3→h2 co-fix). **DONE:** standings (`<h1>Standings</h1>`) + voting results (`All-Star` / `End-of-Year Voting Results`) — page-level `<h1>` added, `a11y-heading-one-standings-voting` (VR → human merge). **STILL OPEN:** olympics standings (not spec-tracked); big board / trade block blocked on Phase-4 re-land. |
 | **page-has-heading-one** — title-less add (homepage, player page, your account, voting ASG/EOY ballot, news index/categories/article) | ⬜ Open | 🟨 decision → 🟦 | Needs an `<h1>` **added** with invented title text (decision) **and** the new visible heading changes VR baselines (human review). After the text decision, lands as 🟦 (not auto-mergeable). |
 | **link-name** (homepage, news index/categories/article) | ◑ Partial | 🟨 scope | `aria-label` add is invisible → auto-mergeable in principle, **but** seed-dependent: add a CI-seed reproduce phase first. News-template subset → 🟩 once reproduced; homepage sim-recap subset is data-dependent (may go green with no fix). **DONE (this plan):** News pages (index/categories/article) — links already carried aria-labels; reproduce-gated stale-allowlist removal, rule now enforced. **STILL OPEN:** homepage last-sim-recap team links (data-dependent, out of scope). |
@@ -47,15 +47,15 @@ This audit (2026-06-20, verified against the live `accessibility.spec.ts` `KNOWN
 | **landmark-unique** — standings | ✅ Implemented | — | #1164 merged; `StandingsView::renderHeader()` derives per-region `aria-label`; removed from `KNOWN_FAILING`. |
 | **landmark-unique** — schedule + team schedule | ✅ Implemented | — | **Re-checked:** the duplicate is each schedule View's **own** `<nav class="ibl-jump-menu">` (`LeagueScheduleView.php:84`, `TeamScheduleView.php:144`) colliding with the site nav — NOT a shared-nav change. One invisible `aria-label` per View (e.g. "Jump to month") → like standings. **DONE:** each schedule View's jump-menu nav now carries `aria-label="Jump to month"`; removed from `KNOWN_FAILING['landmark-unique']`. |
 | **landmark-unique** — league starters + next sim | ✅ Implemented | — | **DONE:** league-starters threads per-position `aria-label` through the shared renderers (optional param, char-pinned); next-sim sets an inline per-position `aria-label`; both removed from `KNOWN_FAILING['landmark-unique']`. |
-| **label** (leagueControlPanel `.ibl-input`) | 📋 Planned | 🟩 auto-mergeable | Plan `leaguecontrolpanel-aria-label-a11y` **queued** (automouse); aria-label-only (invisible), admin-gate/CSRF/handler untouched, auto-merge eligible. |
-| **select-name** (leagueControlPanel `<select>` ×6) | 📋 Planned | 🟩 auto-mergeable | Same plan, bundled. |
+| **label** (leagueControlPanel `.ibl-input`) | ✅ Implemented | — | PR #1169 merged 2026-06-21. |
+| **select-name** (leagueControlPanel `<select>` ×6) | ✅ Implemented | — | Same plan as label, bundled (PR #1169). |
 | **landmark-one-main** (leagueControlPanel) | ⬜ Open | 🟥 not safe | Needs a `<main>` landmark, which means routing the legacy root page through `PageLayout` — the maintenance-2.27 module conversion. Refactor-scale. (The page IS now ratchet-tracked — allowlisted — via the `label`/`select-name` plan.) |
 | **landmark-one-main** / **region** / **html-has-lang** (faprep) | ⬜ Open | 🟥 delete instead | `faprep.php` is slated for **deletion** (maintenance 3.9). Fixing is wasted. |
 | **region** (leagueControlPanel, 13 nodes) | ⬜ Open | 🟥 not safe | Same as landmark-one-main: PHP-Nuke table-layout content sits outside any landmark; refactor-scale (2.27). |
 | **color-contrast** | ⬜ out of scope | — | Tracked in [`a11y-contrast-backlog.md`](a11y-contrast-backlog.md). |
 
 **One-line takeaways for picking work:**
-- **Ready to plan as auto-mergeable now:** `page-has-heading-one` next sim (single-title promote) **and** schedule/team-schedule (stale allowlist removal — no code change). `label`/`select-name` already planned + queued.
+- **Recently shipped (auto-mergeable):** `page-has-heading-one` next sim (PR #1175, 2026-06-21), schedule/team-schedule stale allowlist removal (PR #1180, 2026-06-21), `label`/`select-name` via aria-label (PR #1169, 2026-06-21).
 - **Auto-mergeable after a small scope/decision:** `page-has-heading-one` multi-title (which-`h2` decision).
 - **Automouse-safe but a human must merge:** `page-has-heading-one` title-less (VR). (`target-size` — ✅ Implemented, #1428.)
 - **Not automouse-safe:** `landmark-one-main` + `region` on leagueControlPanel (2.27 refactor); everything on `faprep.php` (delete).
@@ -78,8 +78,8 @@ This audit (2026-06-20, verified against the live `accessibility.spec.ts` `KNOWN
 |-----------|--------------------|
 | **Single-title views** (draft history, cap space, activity tracker, all-star appearances, contract list, draft, draft pick locator, franchise history, free agency preview, gm contact list, injuries, league starters, one-on-one game, player movement, projected draft order, record holders, season highs, series records, team off/def stats, transaction history, search, topics, free agency, training camp ratings diff) | ✅ Implemented — `a11y-2` + `a11y-4` merged. **watchlist** half BLOCKED on the Phase-4 GM re-land (Watchlist reverted in `503d1fa85`) — fix when that module re-lands. |
 | **4 promotes + Team-page banner-`<h1>`** (season leaderboards, career leaderboards, award history, player database; team page) | ✅ Implemented — `a11y-5` (#1163): 4 `h2.ibl-title`→`h1` promotes (VR-identical) + Team-page banner-as-`<h1>` redesign — the logo banner is the page `<h1>`, the year title is demoted to an `<h2>` row between the banner and the roster table, and Free Agents keeps a literal text `<h1>`. The Team `<h1>` exposed a latent `heading-order` skip (section cards were `h3` with no `h2`), co-fixed by demoting card titles `h3`→`h2` and franchise sub-columns `h4`→`h3` (class-styled, VR-identical). Removed from `KNOWN_FAILING`. |
-| **next sim** (single `<h2 class="ibl-title">Next Sim</h2>`, `NextSimView.php:54`) | ⬜ Open — 🟩 plain promote (VR-identical); an unplanned single-title view. |
-| **schedule + team schedule** (already emit `<h1>` unconditionally — `LeagueScheduleView.php:51`, `TeamScheduleView.php:101`) | ⬜ Open — 🟩 **stale allowlist entry**: page already passes; remove from `KNOWN_FAILING` and confirm green (no code change). |
+| **next sim** (single `<h2 class="ibl-title">Next Sim</h2>`, `NextSimView.php:54`) | ✅ Implemented — PR #1175 merged 2026-06-21. |
+| **schedule + team schedule** (already emit `<h1>` unconditionally — `LeagueScheduleView.php:51`, `TeamScheduleView.php:101`) | ✅ Implemented — PR #1180 merged 2026-06-21: stale allowlist entries removed; confirmed green. |
 | **Multi-title — promoted** (trading, season archive, franchise record book, compare players, waivers, depth chart entry) | ✅ Implemented — topmost `h2.ibl-title`→`h1` (record book + `heading-order` h3→h2 co-fix). |
 | **Multi-title — page-level `<h1>` added** (standings, voting results; uncovered: olympics standings) | ✅ Implemented — `StandingsView::render()` prepends `<h1 class="ibl-title">Standings</h1>`; `VotingResultsView::renderTables()` prepends `<h1>` via optional `$pageTitle` threaded from the controller (`All-Star Voting Results` / `End-of-Year Voting Results`). VR baseline regen → human merge. Olympics standings uncovered (not spec-tracked). |
 | **Multi-title — blocked** (big board, trade block) | ⬜ Open — 🟥 blocked on Phase-4 GM re-land (reverted; PR #1084 / #1082) — don't plan until the module re-lands. |
@@ -110,11 +110,11 @@ Was a single `<h4>`-after-`<h2>` skip on `record holders`; fixed in `a11y-2-head
 ### region — best-practice, moderate — ⬜ Open, 🟥 not safe
 **leagueControlPanel** (13 nodes): PHP-Nuke table-layout content sits outside any landmark region. Same root cause and same resolution as landmark-one-main (couple to 2.27). **faprep** (1): → delete.
 
-### label — wcag2a (level A), **critical** — 📋 Planned, 🟩 auto-mergeable
-**leagueControlPanel** `.ibl-input` with no programmatic label. Plan `leaguecontrolpanel-aria-label-a11y` (queued for automouse) adds a static `aria-label` to every input; aria-label-only (invisible, no VR), admin-gate/CSRF/POST handler untouched → auto-merge eligible. Adds the page to the ratchet enforcing `label`.
+### label — wcag2a (level A), **critical** — ✅ Implemented, PR #1169 (2026-06-21)
+**leagueControlPanel** `.ibl-input` — static `aria-label` added to every input via plan `leaguecontrolpanel-aria-label-a11y`; aria-label-only (invisible, no VR), admin-gate/CSRF/POST handler untouched; page added to the ratchet enforcing `label`.
 
-### select-name — wcag2a (level A), **critical** — 📋 Planned, 🟩 auto-mergeable
-**leagueControlPanel** `<select>` ×6 (incl. `SeasonPhase`, the league switcher) with no accessible name. Bundled into the same queued plan; `aria-label` per select.
+### select-name — wcag2a (level A), **critical** — ✅ Implemented, PR #1169 (2026-06-21)
+**leagueControlPanel** `<select>` ×6 (incl. `SeasonPhase`, the league switcher) — `aria-label` added per select. Bundled into the same plan as `label` (`leaguecontrolpanel-aria-label-a11y`).
 
 ### html-has-lang — wcag2a (level A), serious — ⬜ Open, 🟥 delete instead
 **faprep** `<html>` with no `lang` (doesn't use `PageLayout`, which sets `lang`). `faprep.php` is slated for **deletion** (maintenance 3.9 / 2.28) — fix is wasted.
@@ -142,7 +142,7 @@ Tracked separately in [`a11y-contrast-backlog.md`](a11y-contrast-backlog.md). Th
 | `standings-landmark-unique-aria-label` | ✅ superseded — the standings fix already merged independently as **#1164**; the plan file is redundant (not queued). |
 | `a11y-landmark-unique-schedule` | ✅ Implemented — schedule + team-schedule jump-menu `aria-label`; auto-merge eligible. |
 | `a11y-landmark-unique-starters-sim` | ✅ Implemented — per-table `aria-label` via shared-renderer optional param + next-sim inline; both pages removed from `KNOWN_FAILING['landmark-unique']`; auto-merge eligible. |
-| `leaguecontrolpanel-aria-label-a11y` | 📋 queued for automouse — `label` + `select-name` via aria-label; auto-merge eligible. |
+| `leaguecontrolpanel-aria-label-a11y` | ✅ Implemented (2026-06-21) — PR #1169: `label` + `select-name` via aria-label; auto-merged. |
 | `a11y-heading-one-multi-title` | ✅ Implemented — 6 multi-title pages promoted; standings + voting results deferred (page-level `<h1>` decision). |
 | `a11y-heading-one-standings-voting` | ✅ Implemented — page-level `<h1>` added to standings + voting results (VR change → human merge). |
 | `a11y-link-name-news` | ✅ Implemented — News-page `link-name` reproduce-gated removal (links already labeled); homepage deferred. |

--- a/ibl5/docs/backlog/archive/ci-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/ci-backlog-archive.md
@@ -1,6 +1,6 @@
 ---
 description: Historical archive: completed/declined CI workflow simplification entries, extracted from ci-backlog.md.
-last_verified: 2026-07-11
+last_verified: 2026-08-08
 ---
 
 # CI Workflow Simplification Backlog — Archive
@@ -51,3 +51,12 @@ Read-only historical record of ✅ Implemented / 🚫 Declined findings. For OPE
 **Risk if untouched:** Cognitive overhead; subtle trigger-gap bugs.
 **Status (2026-07-11):** ✅ Implemented — 🟩 (per-workflow audit done; mechanisms are intentional, no standardization applied).
 **Audit outcome:** The three mechanisms are NOT interchangeable — each workflow uses the correct one. `dorny/paths-filter` (codeql/engine/eslint) is language/tool-scoped: run CodeQL only on JS/TS changes, engine CI only on Go changes, ESLint only on e2e/tooling changes. `bin/website-affecting` (e2e-tests/lighthouse `src`) encodes domain logic — "does this diff affect app rendering?" — via deny-regex + carve-outs + CI-meta-exempt list that a static glob cannot replicate; switching those to dorny would mis-fire (PHP-only PRs would wrongly skip, CI-meta edits would wrongly trigger). Switching codeql/engine/eslint to `website-affecting` would also be wrong (a PHP-only PR would trigger CodeQL). Static `paths:` on `on: push` triggers is a GitHub Actions constraint (scripts can't run in `on:` triggers), so dorny/website-affecting are inherently PR-only. Deliverable was rationale comments added to each affected workflow (#1424) documenting why each mechanism is the right one; no mechanical change was semantically valid.
+
+### 6.2 `ibl5/scripts/` excluded from phpstan; script fatals degrade silently
+*(discovered 2026-07-31 during #1753)*
+**Location:** `ibl5/phpstan.neon` `paths:` (currently lists `classes`, `phpstan-rules`, and extension-less `bin/` scripts — zero mention of `scripts`); no `php -l` sweep exists anywhere in `.github/` or `bin/`.
+**Problem:** A broken class reference in any `ibl5/scripts/*.php` file exits 255 while a guard unit test (e.g. `SimRecapContextGuardTest`) reports OK — the guard test is regex-only over source text and cannot catch a class-resolution failure. In prod, that fatal degrades silently: `simRecapContext.php` (example) would return exit 255 and the caller wraps the failure as `{}`, shipping a roster-blind recap. Proven by mutation during the #1753 audit. Also pending: a stale ADR-0092 citation in `ibl5/scripts/simRecapQueue.php`'s docblock (correct ADR is 0093) — fold into this PR if it does not trip `bin/check-docs` freshness, otherwise its own trivial fix.
+**Suggested direction:** Add `scripts` to `ibl5/phpstan.neon` `paths:` and generate a baseline (`ibl5/phpstan-baseline.neon`) to absorb pre-existing findings. Optionally add a `php -l` sweep. Ad-hoc — an existing pattern (add path + generate baseline) covers this; no `/plan` needed.
+**Risk if untouched:** Any syntax or class-reference error in `ibl5/scripts/*.php` is invisible to CI. It surfaces only as a prod degradation (the exact bug class PR #1753 fixed).
+**Closes gap:** #1 (static-analysis half) from `$HOME/claude-plans/sim-recap-testing-gaps-breakdown.md`
+**Status (2026-08-05):** ✅ Implemented — PR #1759 (`phpstan-scripts-dir-coverage`): `scripts` dir added to `ibl5/phpstan.neon` `paths:`; phpstan baseline generated; ADR-0092→0093 docblock fix included.

--- a/ibl5/docs/backlog/archive/dev-efficiency-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/dev-efficiency-backlog-archive.md
@@ -1,6 +1,6 @@
 ---
 description: Historical archive: completed development-efficiency backlog entries, extracted from dev-efficiency-backlog.md.
-last_verified: 2026-07-14
+last_verified: 2026-08-08
 ---
 
 # Development-Efficiency Backlog — Archive
@@ -18,3 +18,17 @@ Read-only historical record of ✅ Implemented / 🚫 Declined entries. For OPEN
 **Location:** `.github/workflows/tests.yml` (the `phpstan` job).
 **What shipped:** A `Cache PHPStan result cache` step (`actions/cache` v6.1.0) persists `ibl5/tmp` + `ibl5/tmp-tests` (the `phpstan.neon`/`phpstan-tests.neon` `tmpDir`s where PHPStan writes `resultCache.php`), keyed on the phpstan config files + `phpstan-rules/**`. PHPStan's own file-hash invalidation keeps results correct across restores. Only `tests.yml` runs `composer run analyse`/`analyse:tests`; `pr-meta-checks.yml`/`mutation.yml` don't invoke PHPStan.
 **Status (2026-07-03):** ✅ Implemented — shipped in PR #1309 (predates the entry's own 2026-07-07 "verified" claim; the entry was stale).
+
+### E9 Meta-tooling growth bar
+**Location:** Plan: `$HOME/claude-plans/meta-tooling-bar.md` (queued) — extend-before-add rule + quarterly cull.
+**Problem:** ~27 of 101 `bin/` scripts exist to test the other scripts; the gate layer itself has had bugs. Nothing pushes back on meta-tooling growth.
+**Suggested direction:** Extend-before-add policy gate + quarterly cull process.
+**Risk if untouched:** Unbounded meta-tooling growth; gate layer debt accumulates.
+**Status (2026-07-09):** ✅ Implemented — PR #1387 (`meta-tooling-bar`): extend-before-add rule + quarterly cull automation shipped.
+
+### E11 In-PR pre-baked image build
+**Location:** Plan: `$HOME/claude-plans/in-pr-prebaked-image-build.md` (queued). Today only `.github/workflows/cache-dependencies.yml` builds the image, on schedule/push — never in-PR.
+**Problem:** A PR changing the Dockerfile or composer deps is E2E-tested against the *previous* master image; the mismatch surfaces only after merge.
+**Suggested direction:** Build the Docker image in-PR for PRs touching the Dockerfile or composer deps (paths-filtered so normal PRs are unaffected).
+**Risk if untouched:** Dockerfile/dep changes are validated against a stale image; mismatch only surfaces post-merge.
+**Status (2026-07-09):** ✅ Implemented — PR #1386 (`in-pr-prebaked-image-build`): in-PR image build wired via paths-filter; normal PRs unaffected.

--- a/ibl5/docs/backlog/archive/loop-engineering-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/loop-engineering-backlog-archive.md
@@ -1,6 +1,6 @@
 ---
 description: Historical archive: completed autonomous-loop engineering entries, extracted from loop-engineering-backlog.md.
-last_verified: 2026-08-05
+last_verified: 2026-08-08
 ---
 
 # Autonomous-Loop Engineering Backlog — Archive
@@ -92,3 +92,24 @@ Read-only historical record of ✅ Implemented entries. For OPEN items see ../lo
 **Closes gap:** #9 (meta-tooling — prevents future versions of this class) from `$HOME/claude-plans/sim-recap-testing-gaps-breakdown.md`
 **Dedup:** reconciled 2026-07-31 — uncovered by #1668 / #1665 / #1667 / #1714.
 **Status (2026-08-04):** ✅ Implemented — gate 15 in `plan/SKILL.md` gains a second unconditional arm keyed on the *diff* rather than on the hold's justification: a new silent-fallback or degraded path in a synchronous sim path or a `bin/*-tick` script requires a loud failure signal (Discord, a required-blocking CI check, or an equivalent alarm), regardless of whether the hold is security-, destructive-migration-, UI/UX- or verification-gap-motivated. PR #1765.
+
+### L7 Queue-add shift-left preflight
+**Location:** `bin/automouse-queue` `add` runs zero preflight (verified); staleness is caught only at 2am by the impl agent, then self-heal requeues (L8). Plan: `$HOME/claude-plans/staleness-guard-fp-fix-and-queue-check.md` (not yet queued).
+**Problem (was):** A stale anchor costs a night when it could be fixed in 30 seconds at queue-add time, while a human is at the keyboard.
+**Suggested direction (per the plan):** Run `bin/check-plan` + `bin/check-plan-staleness` at add time; also fixes known staleness-check false positives.
+**Risk if untouched (was):** Recurring burned queue slots for trivially-fixable staleness.
+**Status (2026-06-27):** ✅ Implemented — PR #1225: `bin/automouse-queue add` now runs `bin/check-plan` + `bin/check-plan-staleness` as a shift-left preflight; staleness false-positive fixes included.
+
+### L10 Discord intake loop
+**Location:** `bin/bug-pipeline-tick`, `bin/bug-pipeline-cron-setup`, `bin/bug-pipeline-classify-prompt`, `bin/bug-pipeline-gather-prompt` (live); remainder of the 6-PR Discord bug pipeline program per its shared-context spec.
+**Problem (was):** Bug reports ended at a human reading Discord.
+**Suggested direction (was):** Automated gather → classify → hunter pipeline with Discord as the intake channel; human checkpoints (plan review + `feat:` signoff gate) stay in place by design.
+**Risk if untouched (was):** Bug reports manually triaged from Discord; no persistent pipeline.
+**Status (2026-07-11):** ✅ Implemented — 7 pipeline PRs: #1327 (2026-07-05), #1326 (2026-07-05), #1353 (2026-07-06), #1354 (2026-07-06), #1356 (2026-07-06), #1355 (2026-07-07), #1418 (2026-07-11). Full gather/classify/tick machinery merged and cron-installable; hunter stages complete. Human checkpoints (plan review + `feat:` signoff gate) in place. The residual program is tracked in its own pipeline, not re-planned here.
+
+### L16 Context-budget gate v2 (work-size proxies + measured calibration)
+**Location:** `bin/check-plan` gate `[C]` (≥ 500 lines OR ≥ 12 numbered phases — thresholds hand-set once from the 2026-07-07 automouse-corpus audit); the T1 per-phase cost rows carry no peak-context column.
+**Problem (was):** Two blind spots. (1) Plan size ≠ work size: a 100-line plan phase saying "sweep every call site" triggers a marathon implementation the gate can't see, while a reference-heavy plan false-trips and gets papered over with a `context-budget:` marker. (2) No feedback loop: nothing re-checks the thresholds as plan style evolves, so the gate drifts from the dumb-zone reality it proxies.
+**Suggested direction (was):** (a) Add work-size proxies — Verification-Matrix row count, Critical-Files change-target count, and sweep-verb detection ("all call sites", "every occurrence") in a phase without a delegation packet. (b) Log peak context tokens per impl run into the T1 ledger (the stream-json usage events already carry them) and add a report correlating plan proxies against measured peaks — recalibrate thresholds from data, and flag any run breaching ~150K as a Step 2.5 split miss for the retro.
+**Risk if untouched (was):** Dumb-zone breaches keep happening under the gate's radar, and the thresholds stay a one-shot guess.
+**Status (2026-07-15):** ✅ Implemented — PR #1479 (`context-budget-gate-v2`): `bin/check-plan` [C] proxy counts (VM rows, CF change-target count, sweep-verb advisory [W]), stream-filter `peak_ctx` tracking, and `costs.md` Peak Ctx column shipped.

--- a/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
@@ -1,6 +1,6 @@
 ---
 description: Historical archive: completed/declined maintenance-audit findings, extracted from maintenance-backlog.md.
-last_verified: 2026-07-29
+last_verified: 2026-08-08
 ---
 
 # Maintenance-Cost Reduction Backlog — Archive
@@ -464,6 +464,37 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 
 
 **Table evidence (2026-07-25):** `Topics/copyright.php` deleted.
+
+### 2.3 FranchiseHistory / PlayerMovement — No Service Layer
+**Location:** `classes/FranchiseHistory/`, `classes/PlayerMovement/`
+**Problem:** Repository + View, no Service. `FranchiseHistoryRepository` likely computes derived fields inline.
+**Suggested direction:** Add a Service even as a pass-through to maintain pattern consistency.
+**Est. effort:** S each
+**Risk if untouched:** Same as 2.2.
+**Status:** 🚫 Declined (2026-08-08) — FranchiseHistory Service implemented (C7b, maintenance-48b): `getAllFranchiseHistory()` assembly extracted from Repository into `FranchiseHistoryService` (raw-fetch Repo + assembly Service). PlayerMovement Service declined: `PlayerMovementRepository::getPlayerMovements()` is a single JOIN with zero PHP assembly; a Service would be pass-through ceremony (cf. 2.9/2.11).
+
+**Table evidence (2026-08-08):** FranchiseHistory Service built (#1091); PlayerMovement declined (single JOIN, pass-through ceremony).
+
+### 2.5 Boxscore — No Service Layer; Processor Mis-Named
+**Location:** `classes/Boxscore/`
+**Problem:** Has `Boxscore.php`, `BoxscoreProcessor`, `BoxscoreRepository` but no `BoxscoreService`. Processor implies mutating ops (like Waivers) but is doing service work. `Contracts/` missing `BoxscoreViewInterface`.
+**Suggested direction:** Rename Processor → Service for read-heavy modules; add ViewInterface.
+**Est. effort:** S
+**Risk if untouched:** Naming confuses new contributors; missing view interface blocks integration tests.
+**Status:** 🚫 Declined (2026-08-08) — `BoxscoreViewInterface` added (2026-06-26). Processor→Service rename declined: every `BoxscoreProcessor` method mutates (it is a .sco import pipeline used by `Updater\Steps\ProcessBoxscoresStep`); a Service would be pass-through ceremony (cf. 2.8/2.3). `Processor` is the correct house name (Waivers S1+P1).
+
+**Table evidence (2026-08-08):** BoxscoreViewInterface added. Processor→Service rename declined (mutating .sco import pipeline; Processor is the correct house name).
+
+### 2.31 UI/ — 15 Files; Only 1 Interface in Contracts
+**Location:** `classes/UI/`
+**Problem:** 15 files across `Components/` and `Tables/` plus root-level files (`AlertRenderer`, `DebugOutput`, `TableStyles`, `TeamCellHelper`). Only `TeamCellHelperInterface` exists.
+**Suggested direction:** Add interfaces systematically; clarify Tables/ common interface; move `DebugOutput` to `classes/Debug/`.
+**Est. effort:** M
+**Risk if untouched:** 14 of 15 UI classes unmockable; changes can't be isolated in tests.
+**Status:** ✅ Implemented (2026-06-29) — PR #1230: interfaces added systematically.
+
+**Table evidence (2026-06-29):** UI/ 1 interface of 15; add interfaces systematically. Additive. → PR #1230.
+
 ## Axis 3: Top-Level Legacy PHP Files
 
 ### 3.2 `DEMO_LOGIN_TOKEN` Hardcoded to `'demo'`
@@ -2106,8 +2137,12 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 
 **Table evidence (2026-07-25):** Lazy PDO factory injected (#1042).
 
-### 14.9 — Finding 14.9
-
+### 14.9 `$cookie[1]` Username Ritual — 21 Occurrences Across 11 Files
+**Location:** `modules/Trading/index.php` lines 74, 91, 111; `modules/FreeAgency/index.php`; `modules/Player/index.php` etc. (21 occurrences across 11 files, verified 2026-07-24)
+**Problem:** Controllers call `cookiedecode($user)` to populate `global $cookie`, then read `$cookie[1]` — despite `AuthService::getUsername()` existing at `classes/Auth/AuthService.php:111`. The original audit listed 17 sites; a 2026-07-24 rescan found 21 occurrences across 11 files.
+**Suggested direction:** Replace with `$authService->getUsername()` injected from container; `AuthService` already exists and is already injected in some controllers.
+**Est. effort:** M
+**Risk if untouched:** Every new controller replicates the ritual; ordering bug in 14.10 spreads.
 **Status:** ✅ Implemented 2026-07-27 — PR `auth-14-9-cookie-to-authservice`.
 
 **Table evidence (2026-07-27):** `$cookie[1]` ritual — 21 occurrences across 11 files → injected `AuthService::getUsername()` (already exists at `classes/Auth/AuthService.php:111`); green-green call-site burndown.
@@ -2149,6 +2184,17 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 
 
 **Table evidence (2026-07-25):** Premise invalid: `modules.php` already has two guards — `preg_match('/^[a-zA-Z0-9_]+$/', $name)` at line 26 AND `ModuleRegistry::isValid($name)` (42-entry allowlist) at line 31; `index.php:50` also uses `ModuleRegistry::isValid`. The "single `str_contains('..')`" description was wrong; no `str_contains` exists.
+
+### 14.15 `AppPaths::root()` Stateful Static Singleton
+**Location:** `Bootstrap/AppPaths.php`; actual consumers (repo-wide sweep 2026-06-09): `Updater/ScheduleUpdater.php:149,234`, `PageLayout/PageLayout.php:78,111`. The previously listed consumers (`Cache/PageCache.php`, `Mail/MailService.php`, `Logging/LoggerFactory.php`, `Auth/DevAutoLogin.php`) use raw `dirname(__DIR__, 2)` / `__DIR__` — not `AppPaths::root()`.
+**Problem:** Global mutable state for path resolution; not injectable.
+**Suggested direction:** Constructor-injected `string $basePath` from container.
+**Est. effort:** S
+**Risk if untouched:** Path-dependent classes untestable without filesystem coupling.
+**Status:** 🚫 Declined (2026-08-08) — ScheduleUpdater basePath injected (2026-06-09, `?string $basePath = null` fallback); PageLayout remainder declined by user (2026-06-13): disproportionate (155 static call sites, no DI seam); DevAutoLogin completed separately (static→instance, merged #1095).
+
+**Table evidence (2026-08-08):** ScheduleUpdater basePath injected; PageLayout remainder declined (user 2026-06-13 — disproportionate).
+
 ## Axis 15: Migrations and Schema Clarity
 
 ### 15.2 `ibl_box_scores.teamID` — Stranded Camel Case Omitted From Migration 121

--- a/ibl5/docs/backlog/ci-backlog.md
+++ b/ibl5/docs/backlog/ci-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: CI/GitHub-Actions workflow simplification backlog — duplicated setup/notify boilerplate, job consolidation, and verified-not-redundant workflows, with per-entry status + automouse-readiness.
-last_verified: 2026-08-05
+last_verified: 2026-08-08
 ---
 
 # CI Workflow Simplification Backlog
@@ -126,7 +126,7 @@ Entries 6.1 and 6.2 are CI/coverage gaps surfaced by the 2026-07-31 audit of PR 
 | # | Title | Status | Automouse | Effort |
 |---|-------|--------|-----------|-------:|
 | 6.1 | CI path-filter coupling splits sim-recap producer from consumer | 📋 Planned | 🟦 | M |
-| 6.2 | `ibl5/scripts/` excluded from phpstan; script fatals degrade silently | ◑ Partial | 🟦 | S |
+| 6.2 | `ibl5/scripts/` excluded from phpstan; script fatals degrade silently | ✅ Implemented | — | S |
 | 6.3 | `SimRecapPayload` accepts `game_of_that_day < 1`; `SimSummaryRepository` silently drops those rows | 📋 Planned | 🟥 | M |
 
 ### 6.1 CI path-filter coupling splits sim-recap producer from consumer
@@ -138,14 +138,7 @@ Entries 6.1 and 6.2 are CI/coverage gaps surfaced by the 2026-07-31 audit of PR 
 **Closes gap:** #4 from `$HOME/claude-plans/sim-recap-testing-gaps-breakdown.md`
 **Status (2026-07-31):** 📋 Planned — `~/claude-plans/ci-path-filter-sim-recap-coupling.md` (written 2026-07-31, routed `plan-architect-xhigh` as a ship-pipeline invariant). Not yet implemented. 🟦.
 
-### 6.2 `ibl5/scripts/` excluded from phpstan; script fatals degrade silently
-*(discovered 2026-07-31 during #1753)*
-**Location:** `ibl5/phpstan.neon` `paths:` (currently lists `classes`, `phpstan-rules`, and extension-less `bin/` scripts — zero mention of `scripts`); no `php -l` sweep exists anywhere in `.github/` or `bin/`.
-**Problem:** A broken class reference in any `ibl5/scripts/*.php` file exits 255 while a guard unit test (e.g. `SimRecapContextGuardTest`) reports OK — the guard test is regex-only over source text and cannot catch a class-resolution failure. In prod, that fatal degrades silently: `simRecapContext.php` (example) would return exit 255 and the caller wraps the failure as `{}`, shipping a roster-blind recap. Proven by mutation during the #1753 audit. Also pending: a stale ADR-0092 citation in `ibl5/scripts/simRecapQueue.php`'s docblock (correct ADR is 0093) — fold into this PR if it does not trip `bin/check-docs` freshness, otherwise its own trivial fix.
-**Suggested direction:** Add `scripts` to `ibl5/phpstan.neon` `paths:` and generate a baseline (`ibl5/phpstan-baseline.neon`) to absorb pre-existing findings. Optionally add a `php -l` sweep. Ad-hoc — an existing pattern (add path + generate baseline) covers this; no `/plan` needed.
-**Risk if untouched:** Any syntax or class-reference error in `ibl5/scripts/*.php` is invisible to CI. It surfaces only as a prod degradation (the exact bug class PR #1753 fixed).
-**Closes gap:** #1 (static-analysis half) from `$HOME/claude-plans/sim-recap-testing-gaps-breakdown.md`
-**Status (2026-07-31):** ◑ Partial — implemented 2026-07-31 in worktree `phpstan-scripts-dir-coverage` (phpstan `paths:` + baseline + the ADR-0092→0093 docblock fix); not yet merged. 🟦.
+➜ 6.2 `ibl5/scripts/` excluded from phpstan; script fatals degrade silently — ✅ Implemented (2026-08-05): see [archive](archive/ci-backlog-archive.md).
 
 ### 6.3 `SimRecapPayload` accepts `game_of_that_day < 1`; `SimSummaryRepository` silently drops those rows
 *(discovered 2026-07-31 during #1753)*

--- a/ibl5/docs/backlog/dev-efficiency-backlog.md
+++ b/ibl5/docs/backlog/dev-efficiency-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Development-efficiency backlog — inner-loop speed (diff-scoped analysis, parallel tests), CI caching, dependency-bump batching, and worktree lifecycle automation, with per-entry status.
-last_verified: 2026-08-05
+last_verified: 2026-08-08
 ---
 
 # Development-Efficiency Backlog
@@ -35,9 +35,9 @@ last_verified: 2026-08-05
 | E6 | Diff-scoped PHPStan wrapper | ✅ Implemented | — | S |
 | E7 | Parallel PHPUnit | ✅ Implemented | — | M |
 | E8 | Memory lines → mechanical gates (umbrella) | ◑ Partial | 🟨 | M |
-| E9 | Meta-tooling growth bar | 📋 Planned | 🟦 | S |
+| E9 | Meta-tooling growth bar | ✅ Implemented | — | S |
 | E10 | Schema baseline auto-regen | ✅ Implemented | — | M |
-| E11 | In-PR pre-baked image build | 📋 Planned | 🟦 | M |
+| E11 | In-PR pre-baked image build | ✅ Implemented | — | M |
 | E12 | `bin/wt-new` fails with misleading error when invoked from inside a worktree | ⬜ Open | 🟨 | S |
 
 ### E1 Warm-standby worktree pool
@@ -85,20 +85,14 @@ last_verified: 2026-08-05
 **Risk if untouched:** Recall dilution plus repeat failures the gates would have caught.
 **Status (2026-07-14):** ◑ Partial — cheap-gate well exhausted; the only remaining item (free-agents guard) is a standalone `/plan`. 🟨.
 
-### E9 Meta-tooling growth bar
-**Location:** Plan: `$HOME/claude-plans/meta-tooling-bar.md` (queued) — extend-before-add rule + quarterly cull.
-**Problem:** ~27 of 101 `bin/` scripts exist to test the other scripts; the gate layer itself has had bugs. Nothing pushes back on meta-tooling growth.
-**Status (2026-07-07):** 📋 Planned — queued. 🟦 (rule authoring wants human eyes on merge).
+➜ E9 Meta-tooling growth bar — ✅ Implemented (2026-07-09): see [archive](archive/dev-efficiency-backlog-archive.md).
 
 ### E10 Schema baseline auto-regen
 **Location:** `.github/workflows/migration-safety.yml` (`regen-schema-dump` job) + `bin/regen-schema-dump`.
 **Problem (was):** The schema reference was a stale March snapshot; every schema question paid a verify-against-migrations tax.
 **Status (2026-07-07):** ✅ Implemented — on every master push, CI rebuilds the schema from migrations and auto-commits `ibl5/docs/schema/current-schema.sql` if changed. (The `000_baseline` migration snapshot itself is intentionally untouched — the regenerated dump is the source of truth for schema questions.)
 
-### E11 In-PR pre-baked image build
-**Location:** Plan: `$HOME/claude-plans/in-pr-prebaked-image-build.md` (queued). Today only `.github/workflows/cache-dependencies.yml` builds the image, on schedule/push — never in-PR.
-**Problem:** A PR changing the Dockerfile or composer deps is E2E-tested against the *previous* master image; the mismatch surfaces only after merge.
-**Status (2026-07-07):** 📋 Planned — queued; paths-filtered so normal PRs are unaffected. 🟦.
+➜ E11 In-PR pre-baked image build — ✅ Implemented (2026-07-09): see [archive](archive/dev-efficiency-backlog-archive.md).
 
 ### E12 `bin/wt-new` fails with misleading error when invoked from inside a worktree
 **Location:** `bin/wt-new:9` (`REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"`) and `bin/wt-new:57` (`git -C "$REPO_ROOT" merge --ff-only "origin/$BASE_BRANCH"`).

--- a/ibl5/docs/backlog/loop-engineering-backlog.md
+++ b/ibl5/docs/backlog/loop-engineering-backlog.md
@@ -33,16 +33,16 @@ last_verified: 2026-08-08
 | L4 | Retro-miner | ⬜ Open | 🟥 | M |
 | L5 | Master-canary between runs | ⬜ Open | 🟦 | M |
 | L6 | Auto-update-branch unsticker | ✅ Implemented | — | S |
-| L7 | Queue-add shift-left preflight | 📋 Planned | 🟦 | S |
+| L7 | Queue-add shift-left preflight | ✅ Implemented | — | S |
 | L8 | Failure self-heal / requeue | ✅ Implemented | — | M |
 | L9 | JSB AutoResearch loop | ✅ Implemented | — | L |
-| L10 | Discord intake loop | ◑ Partial | 🟦 | L |
+| L10 | Discord intake loop | ✅ Implemented | — | L |
 | L11 | Comprehension-debt digest | ⬜ Open | 🟦 | S |
 | L12 | Autonomy contracts in plan frontmatter | ◑ Partial | 🟦 | M |
 | L13 | Per-phase impl-model routing | ✅ Implemented | — | M |
 | L14 | Escalate-on-retry (Sonnet-first, just-in-time Opus) | ✅ Implemented | — | S |
 | L15 | Sonnet-recipe completeness lint | ✅ Implemented | — | S |
-| L16 | Context-budget gate v2 (work-size proxies + measured calibration) | 📋 Planned | 🟦 | M |
+| L16 | Context-budget gate v2 (work-size proxies + measured calibration) | ✅ Implemented | — | M |
 | L17 | Shared-context artifact for multi-plan splits | ✅ Implemented | — | S |
 | L18 | Tier-default correction (`impl_model:` fails open to Opus) | ✅ Implemented | — | S |
 | L19 | Weekly product-analytics review | ⬜ Open | 🟦 | M |
@@ -92,12 +92,7 @@ last_verified: 2026-08-08
 **Location:** `.github/workflows/update-behind-prs.yml` — scheduled every 15 min; calls the GitHub `update-branch` API for armed auto-merge PRs stuck BEHIND master. ADR-0081 records the CI_PAT token strategy, merge-vs-rebase decision, and loop-safety design.
 **Status (2026-07-10):** ✅ Implemented — merged PR #1390.
 
-### L7 Queue-add shift-left preflight
-**Location:** `bin/automouse-queue` `add` runs zero preflight (verified); staleness is caught only at 2am by the impl agent, then self-heal requeues (L8). Plan: `$HOME/claude-plans/staleness-guard-fp-fix-and-queue-check.md` (not yet queued).
-**Problem:** A stale anchor costs a night when it could be fixed in 30 seconds at queue-add time, while a human is at the keyboard.
-**Suggested direction (per the plan):** Run `bin/check-plan` + `bin/check-plan-staleness` at add time; also fixes known staleness-check false positives.
-**Risk if untouched:** Recurring burned queue slots for trivially-fixable staleness.
-**Status (2026-07-07):** 📋 Planned — not queued. 🟦.
+➜ L7 Queue-add shift-left preflight — ✅ Implemented (2026-06-27): see [loop-engineering-backlog-archive.md](archive/loop-engineering-backlog-archive.md).
 
 ### L8 Failure self-heal / requeue
 **Location:** `bin/automouse-run` + `bin/automouse-self-heal`.
@@ -106,10 +101,7 @@ last_verified: 2026-08-08
 ### L9 JSB AutoResearch loop
 ➜ L9 JSB AutoResearch loop — ✅ Implemented (2026-07-23): see [loop-engineering-backlog-archive.md](archive/loop-engineering-backlog-archive.md).
 
-### L10 Discord intake loop
-**Location:** `bin/bug-pipeline-tick`, `bin/bug-pipeline-cron-setup`, `bin/bug-pipeline-classify-prompt`, `bin/bug-pipeline-gather-prompt` (live); remainder of the 6-PR Discord bug pipeline program per its shared-context spec.
-**Problem (was):** Bug reports ended at a human reading Discord.
-**Status (2026-07-07):** ◑ Partial — gather/classify/tick machinery merged and cron-installable; the residual program (hunter stages) is tracked in its own pipeline, not re-planned here. Human checkpoints (plan review + `feat:` signoff gate) stay in place by design. 🟦.
+➜ L10 Discord intake loop — ✅ Implemented (2026-07-11): see [loop-engineering-backlog-archive.md](archive/loop-engineering-backlog-archive.md).
 
 ### L11 Comprehension-debt digest
 **Location:** No weekly merged-diff digest exists (verified — automouse reports are per-run, not per-week).
@@ -134,12 +126,7 @@ last_verified: 2026-08-08
 ### L15 Sonnet-recipe completeness lint
 ✅ Implemented (2026-07-15) — see [loop-engineering-backlog-archive.md](archive/loop-engineering-backlog-archive.md).
 
-### L16 Context-budget gate v2 (work-size proxies + measured calibration)
-**Location:** `bin/check-plan` gate `[C]` (≥ 500 lines OR ≥ 12 numbered phases — thresholds hand-set once from the 2026-07-07 automouse-corpus audit); the T1 per-phase cost rows carry no peak-context column.
-**Problem:** Two blind spots. (1) Plan size ≠ work size: a 100-line plan phase saying "sweep every call site" triggers a marathon implementation the gate can't see, while a reference-heavy plan false-trips and gets papered over with a `context-budget:` marker. (2) No feedback loop: nothing re-checks the thresholds as plan style evolves, so the gate drifts from the dumb-zone reality it proxies.
-**Suggested direction:** (a) Add work-size proxies — Verification-Matrix row count, Critical-Files change-target count, and sweep-verb detection ("all call sites", "every occurrence") in a phase without a delegation packet. (b) Log peak context tokens per impl run into the T1 ledger (the stream-json usage events already carry them) and add a report correlating plan proxies against measured peaks — recalibrate thresholds from data, and flag any run breaching ~150K as a Step 2.5 split miss for the retro.
-**Risk if untouched:** Dumb-zone breaches keep happening under the gate's radar, and the thresholds stay a one-shot guess.
-**Status (2026-07-14):** 📋 Planned — plan slug `context-budget-gate-v2`; ships check-plan [C] proxy counts, [W] sweep-verb advisory, stream-filter peak_ctx tracking, and costs.md Peak Ctx column.
+➜ L16 Context-budget gate v2 — ✅ Implemented (2026-07-15): see [loop-engineering-backlog-archive.md](archive/loop-engineering-backlog-archive.md).
 
 ### L17 Shared-context artifact for multi-plan splits
 ✅ Implemented (2026-07-11) — see [loop-engineering-backlog-archive.md](archive/loop-engineering-backlog-archive.md).

--- a/ibl5/docs/backlog/maintenance-backlog.md
+++ b/ibl5/docs/backlog/maintenance-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Long-running backlog of maintenance-cost reduction opportunities, organized by axis. Each item is a candidate for a future plan.
-last_verified: 2026-08-05
+last_verified: 2026-08-08
 ---
 
 # Maintenance-Cost Reduction Backlog
@@ -169,14 +169,12 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 
 **Automouse audit (verified 2026-06-20):**
 
-> ✅ resolved (19): 2.6, 2.7, 2.11, 2.12, 2.16, 2.17, 2.19, 2.20, 2.22, 2.23, 2.24, 2.26, 2.30, 2.33, 2.34, 2.35, 2.36, 2.37, 2.38 — evidence in [archive](archive/maintenance-backlog-archive.md)
-> 🚫 declined (4): 2.2, 2.4, 2.8, 2.9 — evidence in [archive](archive/maintenance-backlog-archive.md)
+> ✅ resolved (20): 2.6, 2.7, 2.11, 2.12, 2.16, 2.17, 2.19, 2.20, 2.22, 2.23, 2.24, 2.26, 2.30, 2.31, 2.33, 2.34, 2.35, 2.36, 2.37, 2.38 — evidence in [archive](archive/maintenance-backlog-archive.md)
+> 🚫 declined (6): 2.2, 2.3, 2.4, 2.5, 2.8, 2.9 — evidence in [archive](archive/maintenance-backlog-archive.md)
 
 | # | Status | Automouse | Evidence / note |
 |---|--------|-----------|-----------------|
 | 2.1 | ⬜ Open | 🟩 | Globals still in 5 (Voting, Waivers, ComparePlayers, ApiKeys, News). Extract→Controller, green-green E2E pin. |
-| 2.3 | ◑ Partial | — | FranchiseHistory Service built (#1091); PlayerMovement **declined** (single JOIN, pass-through ceremony). |
-| 2.5 | ◑ Partial | — | BoxscoreViewInterface added (this PR). Processor→Service rename **declined**: BoxscoreProcessor is a mutating .sco import pipeline (cf. 2.8/2.3 pass-through declines; Waivers carries S1+P1). Residual = declined rename. |
 | 2.10 | ⬜ Open | 🟨 | Extension R+S+P+Vl, no View. Upfront decision (own module vs Player sub-action) still needed. |
 | 2.13 | 📋 Planned | 🟨 | Characterization-pins plan queued (`freeagency-2-13-characterization-pins`); the admin/user split touches admin-mutation surface (→ human-merge). |
 | 2.14 | ◑ Partial | 🟨 | TradingController+Service exist (#802) but `maketradeoffer/accepttradeoffer/rejecttradeoffer.php` standalone endpoints remain (verified). Promoting touches trade-mutation surface → upfront decision needed. |
@@ -187,7 +185,6 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 | 2.27 | ⬜ Open | 🟦 | Root `leagueControlPanel.php`→module bypasses `ModuleAccessControl`; converting changes admin-auth path (security surface) → human-merge. (a11y fix kept standalone deliberately.) |
 | 2.28 | ⬜ Open | 🟨 | `faprep.php` exists (verified), inline SQL + unescaped output. Resolve with 3.9 (delete); if absorbed instead, XSS/admin-SQL = human-merge. |
 | 2.29 | ⬜ Open | 🟨 | DEFERRED — global-namespace elimination: JSB 291 callers, BaseMysqliRepository 257, ContractRules 37 (585 caller files). L-effort, high-collision; needs its own sequenced PR (one class at a time), not an unattended wave item. |
-| 2.31 | ⬜ Open | 🟩 | UI/ 1 interface of 15; add interfaces systematically. Additive. |
 | 2.32 | ◑ Partial | 🟩 | Shipped: common `Api\Contracts\TransformerInterface` (7 uniform transformers) + flattened `Middleware/Contracts/`→`Api/Contracts/`. **Status:** partial 2026-06-26; residual = divergent-transformer interfaces (Boxscore/PlayerStats), responder interfaces (Csv/Json — disjoint shapes), `Response/Contracts/` flatten. |
 | 2.39 | ⬜ Open | 🟨 | `TradeRosterPreviewCashRowBuilder::buildCashRows()` iterates `cashStartYear`..`cashEndYear` from `$_GET` with no upper bound and no ordering check — `cashStartYear=1&cashEndYear=999999` drives an ~1M-iteration loop. Add bounds + ordering enforcement; upfront: choose max-year cap. (discovered 2026-07-27 during trading-1-31-api-handler-extract) |
 
@@ -197,22 +194,6 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 **Suggested direction:** Extract into `<Module>Controller::handle()`; reduce `index.php` to 5-line bootstrap.
 **Est. effort:** S per module (M for News, 3 entrypoints)
 **Risk if untouched:** Logic invisible to PHPStan; unmockable; un-findable via class search.
-
-### 2.3 FranchiseHistory / PlayerMovement — No Service Layer
-**Location:** `classes/FranchiseHistory/`, `classes/PlayerMovement/`
-**Problem:** Repository + View, no Service. `FranchiseHistoryRepository` likely computes derived fields inline.
-**Suggested direction:** Add a Service even as a pass-through to maintain pattern consistency.
-**Est. effort:** S each
-**Risk if untouched:** Same as 2.2.
-**Status:** Split (C7b, maintenance-48b) — FranchiseHistory: Service built; `getAllFranchiseHistory()` assembly extracted from the Repository into `FranchiseHistoryService` (raw-fetch Repo + assembly Service), unblocking DB-free unit tests of the winpct/default/merge branches. PlayerMovement: Declined — `PlayerMovementRepository::getPlayerMovements()` is a single JOIN with zero PHP assembly; a Service would be pass-through ceremony (cf. 2.9/2.11).
-
-### 2.5 Boxscore — No Service Layer; Processor Mis-Named
-**Location:** `classes/Boxscore/`
-**Problem:** Has `Boxscore.php`, `BoxscoreProcessor`, `BoxscoreRepository` but no `BoxscoreService`. Processor implies mutating ops (like Waivers) but is doing service work. `Contracts/` missing `BoxscoreViewInterface`.
-**Suggested direction:** Rename Processor → Service for read-heavy modules; add ViewInterface.
-**Est. effort:** S
-**Risk if untouched:** Naming confuses new contributors; missing view interface blocks integration tests.
-**Status:** ◑ Partial (2026-06-26) — `BoxscoreViewInterface` added. Processor→Service rename declined: every `BoxscoreProcessor` method mutates (it is a .sco import pipeline used by `Updater\Steps\ProcessBoxscoresStep`), so a Service would be pass-through ceremony (cf. 2.8/2.3). `Processor` is the correct house name (Waivers S1+P1).
 
 ### 2.10 Extension — No View; Routed Through modules/Player
 **Location:** `classes/Extension/`, `modules/Player/extension.php`
@@ -283,13 +264,6 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 **Suggested direction:** `JSB` → `JsbParser\JsbConstants` or `League\JsbConstants`; `ContractRules` → `League/`; `BaseMysqliRepository` → `Database/`.
 **Est. effort:** M (namespace sweep)
 **Risk if untouched:** Global class-name collision risk; PHPStan ban rules don't protect root files.
-
-### 2.31 UI/ — 15 Files; Only 1 Interface in Contracts
-**Location:** `classes/UI/`
-**Problem:** 15 files across `Components/` and `Tables/` plus root-level files (`AlertRenderer`, `DebugOutput`, `TableStyles`, `TeamCellHelper`). Only `TeamCellHelperInterface` exists.
-**Suggested direction:** Add interfaces systematically; clarify Tables/ common interface; move `DebugOutput` to `classes/Debug/`.
-**Est. effort:** M
-**Risk if untouched:** 14 of 15 UI classes unmockable; changes can't be isolated in tests.
 
 ### 2.32 Api/ — Internal Subdirectory Structure Diverges
 **Location:** `classes/Api/`
@@ -776,7 +750,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 **Automouse audit (verified 2026-06-20):** The big bootstrap consolidation (14.1–14.4, 14.7, 14.11, 14.13, 14.14) is done (ADR-0030). Remaining items are large DI sweeps that overlap open IDOR PRs or carry security/identity hazards.
 
 > ✅ resolved (9): 14.1, 14.2, 14.3, 14.4, 14.7, 14.9, 14.11, 14.13, 14.14 — evidence in [archive](archive/maintenance-backlog-archive.md)
-> 🚫 declined (1): 14.16 — evidence in [archive](archive/maintenance-backlog-archive.md)
+> 🚫 declined (2): 14.15, 14.16 — evidence in [archive](archive/maintenance-backlog-archive.md)
 
 | # | Status | Automouse | Evidence / note |
 |---|--------|-----------|-----------------|
@@ -785,7 +759,6 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 | 14.8 | ⬜ Open | 🟩 | Introduce `HttpRequest` VO wrapping superglobals; green-green abstraction. |
 | 14.10 | ◑ Partial | 🟨 | Container accessor registered (PR1); side-effect removal deferred to PR3 (boosted-HTMX cookie-population hazard) → careful sequencing. |
 | 14.12 | ◑ Partial | 🟩 | Wholesale `$_REQUEST`→`$GLOBALS` gone; modules still read `$op/$pid` from `$_REQUEST` → Request object is the residual (folds into 14.8). |
-| 14.15 | ◑ Partial | 🚫 | ScheduleUpdater basePath injected; PageLayout remainder **declined** (user 2026-06-13 — disproportionate). |
 
 ### 14.5 Module `index.php` Files Are the Real Composition Root (42 of 47)
 **Location:** `ibl5/modules/*/index.php`
@@ -809,13 +782,6 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 **Est. effort:** M
 **Risk if untouched:** PRG/HTMX redirect logic untestable; superglobals must be polluted in tests.
 
-### 14.9 `$cookie[1]` Username Ritual — 21 Occurrences Across 11 Files
-**Location:** `modules/Trading/index.php` lines 74, 91, 111; `modules/FreeAgency/index.php`; `modules/Player/index.php` etc. (21 occurrences across 11 files, verified 2026-07-24)
-**Problem:** Controllers call `cookiedecode($user)` to populate `global $cookie`, then read `$cookie[1]` — despite `AuthService::getUsername()` existing at `classes/Auth/AuthService.php:111`. The original audit listed 17 sites; a 2026-07-24 rescan found 21 occurrences across 11 files.
-**Suggested direction:** Replace with `$authService->getUsername()` injected from container; `AuthService` already exists and is already injected in some controllers.
-**Est. effort:** M
-**Risk if untouched:** Every new controller replicates the ritual; ordering bug in 14.10 spreads.
-
 ### 14.10 `PageLayout::header()` Has Side Effect Controllers Depend On
 **Location:** `PageLayout/PageLayout.php:16` (`cookiedecode($user)`); `FreeAgency/FreeAgencyController.php:55` comment "Must come first"
 **Problem:** Header internally calls `cookiedecode($user)` setting `global $cookie`. Controllers reading `$cookie[1]` after header depend on the side effect; skip header → null identity.
@@ -831,14 +797,6 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 **Est. effort:** L
 **Risk if untouched:** Name collisions silently overwrite globals; PHPStan needs per-site `@var` annotations.
 **Status:** Partially completed (verified 2026-05-29 audit) — the wholesale `$_REQUEST`→`$GLOBALS` copy is gone; `ConfigBootstrap` now allowlists only `newlang`/`redirect` (see [[3.6]]). Modules still read `$op`/`$pid`/`$action` directly from `$_REQUEST` — a `Request` object remains the longer-term fix.
-
-### 14.15 `AppPaths::root()` Stateful Static Singleton
-**Location:** `Bootstrap/AppPaths.php`; actual consumers (repo-wide sweep 2026-06-09): `Updater/ScheduleUpdater.php:149,234`, `PageLayout/PageLayout.php:78,111`. The previously listed consumers (`Cache/PageCache.php`, `Mail/MailService.php`, `Logging/LoggerFactory.php`, `Auth/DevAutoLogin.php`) use raw `dirname(__DIR__, 2)` / `__DIR__` — not `AppPaths::root()`.
-**Problem:** Global mutable state for path resolution; not injectable.
-**Suggested direction:** Constructor-injected `string $basePath` from container.
-**Est. effort:** S
-**Risk if untouched:** Path-dependent classes untestable without filesystem coupling.
-**Status:** Partial + remainder Declined. `ScheduleUpdater` now takes `?string $basePath = null` (fallback `AppPaths::root()`, 2026-06-09). PageLayout remainder — **Declined (user call 2026-06-13):** `PageLayout`'s `AppPaths::root()` access stays intentional-static. Converting `PageLayout` to an instance class is disproportionate (155 static call sites, no DI seam) and a trailing `?string $basePath` param seam was rejected as test-only ceremony that wouldn't even eliminate the `AppPaths::root()` singleton (the fallback remains). The `DevAutoLogin` half was completed separately (static→instance, merged #1095).
 
 ---
 

--- a/ibl5/docs/backlog/token-spend-backlog.md
+++ b/ibl5/docs/backlog/token-spend-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Token-spend reduction backlog — resident-context diet, caching economics, output-spend guards, and LSP-first navigation for the Claude Code harness, with per-entry status.
-last_verified: 2026-08-05
+last_verified: 2026-08-08
 ---
 
 # Token-Spend Reduction Backlog
@@ -29,7 +29,7 @@ last_verified: 2026-08-05
 
 ## Entries
 
-First-wave entries (T1–T13) are ✅ Implemented — see the dated pointers below and [token-spend-backlog-archive.md](archive/token-spend-backlog-archive.md). T14–T16 are the second wave, from the 2026-07-16 re-measure.
+All entries (T1–T16) are ✅ Implemented — fully burned down as of 2026-07-17. T14–T16 were the second wave, from the 2026-07-16 re-measure. See the dated pointers below and [token-spend-backlog-archive.md](archive/token-spend-backlog-archive.md).
 
 **T14** ✅ Implemented 2026-07-16 — archived in [token-spend-backlog-archive.md](archive/token-spend-backlog-archive.md).
 
@@ -59,7 +59,7 @@ First-wave entries (T1–T13) are ✅ Implemented — see the dated pointers bel
 **Token-relevant entries tracked elsewhere:**
 - L18 (tier-default correction — `impl_model:` fails open to Opus) — [loop-engineering-backlog.md](loop-engineering-backlog.md). ✅ Implemented (2026-07-16). Supersedes the former L2 token-budget-breaker residual, closed 2026-07-15 as empirically refuted (PR #1477 closed unmerged): impl spend doesn't predict postplan spend, and the measured waste is tier misallocation (~82% of impl spend is Opus; ~$27/week routed to Opus purely by a missing `impl_model:` field), not plan length.
 - L15 (Sonnet-recipe completeness lint) — [loop-engineering-backlog.md](loop-engineering-backlog.md). ✅ Implemented (2026-07-15).
-- L16 (context-budget gate v2) — [loop-engineering-backlog.md](loop-engineering-backlog.md). 📋 Planned.
+- L16 (context-budget gate v2) — [loop-engineering-backlog.md](loop-engineering-backlog.md). ✅ Implemented (2026-07-15).
 - E8 (memory-lines→gates umbrella, pairs with T7) — [dev-efficiency-backlog.md](dev-efficiency-backlog.md). ◑ Partial as of 2026-07-14; one item remains (free-agents teamid write guard).
 - E6 (diff-scoped PHPStan wrapper) — [dev-efficiency-backlog.md](dev-efficiency-backlog.md): every agent verify iteration (local + automouse) drops from O(project) to O(diff) analysis — fewer polling turns and less output per loop. (Cross-referenced 2026-07-14, token-spend sweep.) ✅ Implemented (2026-07-14) — shipped in PR #1362.
 - E3 (PHPStan result-cache in CI) — [dev-efficiency-backlog.md](dev-efficiency-backlog.md). ✅ Implemented (2026-07-03). shorter CI runs → fewer CI-watch polling turns per PR. (Cross-referenced 2026-07-14, token-spend sweep.)


### PR DESCRIPTION
## Summary
- Updated `last_verified` dates to 2026-08-08 across all backlog tracking files (a11y, CI, dev-efficiency, loop-engineering, maintenance, token-spend)
- Moved completed items to archive files with status updates and PR references
- Marked items implemented: a11y (PRs #1175, #1180, #1169), CI (#1759), loop-engineering (L7, L10, L16), dev-efficiency (E9, E11)
- Updated maintenance-backlog status counts: resolved 19→20, declined 4→6
- Consolidated token-spend backlog as fully burned down (T1–T16 all ✅ Implemented)

## Manual Testing

No manual testing needed — verified by automated tests.
