### PR TITLE
refactor: extract StandingsUpdaterRepository from StandingsRepository (1.32)

### DIFF
--- a/ibl5/classes/Standings/README.md
+++ b/ibl5/classes/Standings/README.md
@@ -14,10 +14,14 @@ This module follows the interface-driven architecture pattern with separation of
 ```
 Standings/
 ├── Contracts/
-│   ├── StandingsRepositoryInterface.php  # Data access contract
-│   └── StandingsViewInterface.php        # View rendering contract
-├── StandingsRepository.php               # Data access implementation
-├── StandingsView.php                     # HTML rendering
+│   ├── StandingsRepositoryInterface.php  # Data access contract (unchanged)
+│   └── StandingsViewInterface.php        # View rendering contract (unchanged)
+├── StandingsRepository.php               # Read queries + thin delegator for writes
+├── StandingsUpdaterRepository.php        # Update/upsert/award writes (— NEW, Phase 2)
+├── StandingsView.php                     # Table orchestration: group, sort, header, rows
+├── AggregateTiebreaker.php               # Pure aggregate H2H win-pct helper
+├── PythagoreanCalculator.php             # Pythagorean expectation helper (7.14)
+├── OlympicsStandingsView.php             # Separate Olympics standings renderer
 └── README.md                             # This file
 ```
 
@@ -30,7 +34,7 @@ Standings/
 global $db;
 
 $repository = new Standings\StandingsRepository($db);
-$view = new Standings\StandingsView($repository);
+$view = new Standings\StandingsView($repository, $season->endingYear, $seriesRecordsService);
 
 echo $view->render();
 ```
@@ -39,7 +43,7 @@ echo $view->render();
 
 ```php
 $repository = new Standings\StandingsRepository($db);
-$view = new Standings\StandingsView($repository);
+$view = new Standings\StandingsView($repository, $season->endingYear, $seriesRecordsService);
 
 // Render only Eastern Conference
 echo $view->renderRegion('Eastern');

--- a/ibl5/classes/Standings/README.md
+++ b/ibl5/classes/Standings/README.md
@@ -1,6 +1,6 @@
 ---
 description: Conference and division standings display with clinched-indicator badges (Z-, Y-, X-) and dynamic HTML generation.
-last_verified: 2026-07-24
+last_verified: 2026-08-08
 ---
 
 # Standings Module

--- a/ibl5/classes/Standings/StandingsRepository.php
+++ b/ibl5/classes/Standings/StandingsRepository.php
@@ -28,57 +28,15 @@ use Standings\Contracts\StandingsRepositoryInterface;
  */
 class StandingsRepository extends \BaseMysqliRepository implements StandingsRepositoryInterface
 {
-    private string $teamAwardsTable;
-
     private readonly PythagoreanCalculator $pythagoreanCalculator;
 
-    /**
-     * Closed allowlists for the column identifiers that callers may pass into the
-     * setters/filters below. A column name is a SQL **identifier**, never a
-     * bindable value, so it cannot be a `?` parameter — it is validated against a
-     * fixed set (mirrors {@see \CareerLeaderboards\CareerLeaderboardsRepository}'s
-     * VALID_TABLES allowlist) and rejected with InvalidArgumentException, then
-     * concatenated backticked into the query. This closes the injection shape
-     * BanSqlStringInterpolationRule flags. The accepted values match exactly what
-     * {@see \Updater\StandingsUpdater} / {@see \Updater\StandingsGrouper} emit.
-     *
-     * @var list<string>
-     */
-    private const VALID_GROUPING_COLUMNS = ['conference', 'division'];
-
-    /** @var list<string> */
-    private const VALID_MAGIC_NUMBER_COLUMNS = ['conf_magic_number', 'div_magic_number'];
-
-    /** @var list<string> */
-    private const VALID_CLINCHED_COLUMNS = [
-        'clinched_conference',
-        'clinched_division',
-        'clinched_playoffs',
-        'clinched_league',
-    ];
+    private readonly StandingsUpdaterRepository $updaterRepository;
 
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->teamAwardsTable = 'ibl_team_awards';
         $this->pythagoreanCalculator = new PythagoreanCalculator();
-    }
-
-    /**
-     * Validate a caller-supplied column identifier against a closed allowlist and
-     * return it backtick-quoted for safe concatenation into query text. Throws on
-     * any value outside the allowlist — identifiers are never bound, so this is the
-     * only safe way to splice them.
-     *
-     * @param list<string> $allowed
-     */
-    private static function backtickAllowedColumn(string $column, array $allowed, string $kind): string
-    {
-        if (!in_array($column, $allowed, true)) {
-            throw new \InvalidArgumentException("Invalid {$kind} column: {$column}");
-        }
-
-        return '`' . $column . '`';
+        $this->updaterRepository = new StandingsUpdaterRepository($db, $leagueContext);
     }
 
     /**
@@ -311,69 +269,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
      */
     public function upsertStandings(array $params): void
     {
-        $this->execute(
-            "INSERT INTO `ibl_standings` (
-                teamid, team_name, league_record, wins, losses, pct, games_unplayed,
-                conference, conf_gb, conf_record,
-                division, div_gb, div_record,
-                home_record, away_record,
-                conf_wins, conf_losses, div_wins, div_losses,
-                home_wins, home_losses, away_wins, away_losses
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON DUPLICATE KEY UPDATE
-                team_name = VALUES(team_name),
-                league_record = VALUES(league_record),
-                wins = VALUES(wins),
-                losses = VALUES(losses),
-                pct = VALUES(pct),
-                games_unplayed = VALUES(games_unplayed),
-                conference = VALUES(conference),
-                conf_gb = VALUES(conf_gb),
-                conf_record = VALUES(conf_record),
-                division = VALUES(division),
-                div_gb = VALUES(div_gb),
-                div_record = VALUES(div_record),
-                home_record = VALUES(home_record),
-                away_record = VALUES(away_record),
-                conf_wins = VALUES(conf_wins),
-                conf_losses = VALUES(conf_losses),
-                div_wins = VALUES(div_wins),
-                div_losses = VALUES(div_losses),
-                home_wins = VALUES(home_wins),
-                home_losses = VALUES(home_losses),
-                away_wins = VALUES(away_wins),
-                away_losses = VALUES(away_losses),
-                conf_magic_number = NULL,
-                div_magic_number = NULL,
-                clinched_conference = NULL,
-                clinched_division = NULL,
-                clinched_playoffs = NULL,
-                clinched_league = NULL",
-            "issiidisdssdsssiiiiiiii",
-            $params['teamid'],
-            $params['teamName'],
-            $params['leagueRecord'],
-            $params['wins'],
-            $params['losses'],
-            $params['pct'],
-            $params['gamesUnplayed'],
-            $params['conference'],
-            $params['confGb'],
-            $params['confRecord'],
-            $params['division'],
-            $params['divGb'],
-            $params['divRecord'],
-            $params['homeRecord'],
-            $params['awayRecord'],
-            $params['confWins'],
-            $params['confLosses'],
-            $params['divWins'],
-            $params['divLosses'],
-            $params['homeWins'],
-            $params['homeLosses'],
-            $params['awayWins'],
-            $params['awayLosses']
-        );
+        $this->updaterRepository->upsertStandings($params);
     }
 
     /**
@@ -381,17 +277,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
      */
     public function updateMagicNumber(int $teamid, int $magicNumber, string $magicNumberColumn): void
     {
-        $column = self::backtickAllowedColumn(
-            $magicNumberColumn,
-            self::VALID_MAGIC_NUMBER_COLUMNS,
-            'magic number'
-        );
-        $this->execute(
-            "UPDATE `ibl_standings` SET " . $column . " = ? WHERE teamid = ?",
-            "ii",
-            $magicNumber,
-            $teamid
-        );
+        $this->updaterRepository->updateMagicNumber($teamid, $magicNumber, $magicNumberColumn);
     }
 
     /**
@@ -399,16 +285,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
      */
     public function updateClinchedFlag(string $teamName, string $clinchedColumn): void
     {
-        $column = self::backtickAllowedColumn(
-            $clinchedColumn,
-            self::VALID_CLINCHED_COLUMNS,
-            'clinched'
-        );
-        $this->execute(
-            "UPDATE `ibl_standings` SET " . $column . " = 1 WHERE team_name = ?",
-            "s",
-            $teamName
-        );
+        $this->updaterRepository->updateClinchedFlag($teamName, $clinchedColumn);
     }
 
     /**
@@ -416,17 +293,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
      */
     public function upsertTeamAward(int $seasonYear, string $teamName, string $awardName): void
     {
-        // $teamAwardsTable is the fixed property 'ibl_team_awards' (constructor-set,
-        // never user input); concatenate it backticked instead of interpolating.
-        $this->execute(
-            "INSERT INTO `" . $this->teamAwardsTable . "` (year, name, award)
-             VALUES (?, ?, ?)
-             ON DUPLICATE KEY UPDATE name = VALUES(name)",
-            "iss",
-            $seasonYear,
-            $teamName,
-            $awardName
-        );
+        $this->updaterRepository->upsertTeamAward($seasonYear, $teamName, $awardName);
     }
 
     /**
@@ -436,16 +303,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
      */
     public function fetchTeamsByRegion(string $grouping, string $region): array
     {
-        $groupingColumn = self::backtickAllowedColumn($grouping, self::VALID_GROUPING_COLUMNS, 'grouping');
-        /** @var list<array{teamid: int, team_name: string, home_wins: int, home_losses: int, away_wins: int, away_losses: int}> */
-        return $this->fetchAll(
-            "SELECT teamid, team_name, home_wins, home_losses, away_wins, away_losses
-            FROM `ibl_standings`
-            WHERE " . $groupingColumn . " = ?
-            ORDER BY pct DESC",
-            "s",
-            $region
-        );
+        return $this->updaterRepository->fetchTeamsByRegion($grouping, $region);
     }
 
     /**
@@ -455,28 +313,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
      */
     public function fetchTopTeamsByWins(?string $grouping, ?string $region): array
     {
-        if ($grouping !== null && $region !== null) {
-            $groupingColumn = self::backtickAllowedColumn($grouping, self::VALID_GROUPING_COLUMNS, 'grouping');
-            /** @var list<array{teamid: int, team_name: string, wins: int}> */
-            return $this->fetchAll(
-                "SELECT teamid, team_name, home_wins + away_wins AS wins
-                FROM `ibl_standings`
-                WHERE " . $groupingColumn . " = ?
-                ORDER BY wins DESC
-                LIMIT 2",
-                "s",
-                $region
-            );
-        }
-
-        /** @var list<array{teamid: int, team_name: string, wins: int}> */
-        return $this->fetchAll(
-            "SELECT teamid, team_name, home_wins + away_wins AS wins
-            FROM `ibl_standings`
-            ORDER BY wins DESC
-            LIMIT 2",
-            ""
-        );
+        return $this->updaterRepository->fetchTopTeamsByWins($grouping, $region);
     }
 
     /**
@@ -486,32 +323,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
      */
     public function fetchLeastLosingTeam(string $excludeTeamName, ?string $grouping, ?string $region): ?array
     {
-        if ($grouping !== null && $region !== null) {
-            $groupingColumn = self::backtickAllowedColumn($grouping, self::VALID_GROUPING_COLUMNS, 'grouping');
-            /** @var array{losses: int}|null */
-            return $this->fetchOne(
-                "SELECT home_losses + away_losses AS losses
-                FROM `ibl_standings`
-                WHERE " . $groupingColumn . " = ?
-                    AND team_name <> ?
-                ORDER BY losses ASC
-                LIMIT 1",
-                "ss",
-                $region,
-                $excludeTeamName
-            );
-        }
-
-        /** @var array{losses: int}|null */
-        return $this->fetchOne(
-            "SELECT home_losses + away_losses AS losses
-            FROM `ibl_standings`
-            WHERE team_name <> ?
-            ORDER BY losses ASC
-            LIMIT 1",
-            "s",
-            $excludeTeamName
-        );
+        return $this->updaterRepository->fetchLeastLosingTeam($excludeTeamName, $grouping, $region);
     }
 
     /**
@@ -519,21 +331,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
      */
     public function isRegionSeasonOver(?string $grouping, ?string $region): bool
     {
-        if ($grouping !== null && $grouping !== '' && $region !== null && $region !== '') {
-            $groupingColumn = self::backtickAllowedColumn($grouping, self::VALID_GROUPING_COLUMNS, 'grouping');
-            $result = $this->fetchOne(
-                "SELECT MAX(games_unplayed) AS maxLeft FROM `ibl_standings` WHERE " . $groupingColumn . " = ?",
-                "s",
-                $region
-            );
-        } else {
-            $result = $this->fetchOne(
-                "SELECT MAX(games_unplayed) AS maxLeft FROM `ibl_standings`",
-                ""
-            );
-        }
-
-        return $result !== null && $result['maxLeft'] === 0;
+        return $this->updaterRepository->isRegionSeasonOver($grouping, $region);
     }
 
     /**
@@ -541,34 +339,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
      */
     public function getHeadToHeadWinner(int $tid1, int $tid2, string $startDate, string $endDate): int
     {
-        $result = $this->fetchOne(
-            "SELECT
-                COUNT(*) AS total_games,
-                SUM(CASE
-                    WHEN (visitor_teamid = ? AND visitor_score > home_score) OR (home_teamid = ? AND home_score > visitor_score) THEN 1
-                    ELSE 0
-                END) AS team1_wins
-            FROM `ibl_schedule`
-            WHERE visitor_score > 0 AND home_score > 0
-            AND game_date BETWEEN ? AND ?
-            AND ((visitor_teamid = ? AND home_teamid = ?) OR (visitor_teamid = ? AND home_teamid = ?))",
-            "iissiiii",
-            $tid1, $tid1,
-            $startDate, $endDate,
-            $tid1, $tid2, $tid2, $tid1
-        );
-
-        if ($result === null) {
-            return $tid1;
-        }
-
-        /** @var int $totalGames */
-        $totalGames = $result['total_games'];
-        /** @var int $team1Wins */
-        $team1Wins = $result['team1_wins'];
-        $team2Wins = $totalGames - $team1Wins;
-
-        return $team1Wins >= $team2Wins ? $tid1 : $tid2;
+        return $this->updaterRepository->getHeadToHeadWinner($tid1, $tid2, $startDate, $endDate);
     }
 
     /**
@@ -578,26 +349,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
      */
     public function fetchTeamMapForSeason(int $seasonEndingYear): array
     {
-        /** @var list<array{team_slot: int, team_name: string, conference: string, division: string}> $rows */
-        $rows = $this->fetchAll(
-            "SELECT team_slot, team_name, conference, division
-            FROM `ibl_league_config`
-            WHERE season_ending_year = ?",
-            "i",
-            $seasonEndingYear
-        );
-
-        /** @var array<int, TeamMapping> $map */
-        $map = [];
-        foreach ($rows as $row) {
-            $map[$row['team_slot']] = [
-                'conference' => $row['conference'],
-                'division' => $row['division'],
-                'teamName' => $row['team_name'],
-            ];
-        }
-
-        return $map;
+        return $this->updaterRepository->fetchTeamMapForSeason($seasonEndingYear);
     }
 
     /**
@@ -607,17 +359,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
      */
     public function fetchPlayedGamesForSeason(string $startDate, string $endDate): array
     {
-        /** @var list<array{visitor_teamid: int, visitor_score: int, home_teamid: int, home_score: int}> */
-        return $this->fetchAll(
-            "SELECT visitor_teamid, visitor_score, home_teamid, home_score
-            FROM `ibl_schedule`
-            WHERE visitor_score > 0 AND home_score > 0
-            AND game_date BETWEEN ? AND ?
-            ORDER BY game_date ASC",
-            "ss",
-            $startDate,
-            $endDate
-        );
+        return $this->updaterRepository->fetchPlayedGamesForSeason($startDate, $endDate);
     }
 
     /**
@@ -627,16 +369,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
      */
     public function fetchWinningestTeams(string $conference): array
     {
-        /** @var list<array{team_name: string, wins: int}> */
-        return $this->fetchAll(
-            "SELECT team_name, home_wins + away_wins AS wins
-            FROM `ibl_standings`
-            WHERE conference = ?
-            ORDER BY wins DESC
-            LIMIT 8",
-            "s",
-            $conference
-        );
+        return $this->updaterRepository->fetchWinningestTeams($conference);
     }
 
     /**
@@ -646,16 +379,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
      */
     public function fetchMostLosingTeams(string $conference): array
     {
-        /** @var list<array{losses: int}> */
-        return $this->fetchAll(
-            "SELECT home_losses + away_losses AS losses
-            FROM `ibl_standings`
-            WHERE conference = ?
-            ORDER BY losses DESC
-            LIMIT 6",
-            "s",
-            $conference
-        );
+        return $this->updaterRepository->fetchMostLosingTeams($conference);
     }
 
     /**
@@ -665,25 +389,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
      */
     public function fetchScheduledGameCountsPerTeam(string $startDate, string $endDate): array
     {
-        /** @var list<array{teamid: int, game_count: int}> $rows */
-        $rows = $this->fetchAll(
-            "SELECT teamid, COUNT(*) AS game_count FROM (
-                SELECT visitor_teamid AS teamid FROM `ibl_schedule`
-                WHERE game_date BETWEEN ? AND ?
-                UNION ALL
-                SELECT home_teamid AS teamid FROM `ibl_schedule`
-                WHERE game_date BETWEEN ? AND ?
-            ) AS all_games
-            GROUP BY teamid",
-            "ssss",
-            $startDate, $endDate, $startDate, $endDate
-        );
-
-        $result = [];
-        foreach ($rows as $row) {
-            $result[$row['teamid']] = $row['game_count'];
-        }
-        return $result;
+        return $this->updaterRepository->fetchScheduledGameCountsPerTeam($startDate, $endDate);
     }
 
     /**

--- a/ibl5/classes/Standings/StandingsUpdaterRepository.php
+++ b/ibl5/classes/Standings/StandingsUpdaterRepository.php
@@ -69,6 +69,7 @@ class StandingsUpdaterRepository extends \BaseMysqliRepository
     }
 
     /**
+     * @param UpsertStandingsParams $params
      * @see StandingsRepositoryInterface::upsertStandings()
      */
     public function upsertStandings(array $params): void

--- a/ibl5/classes/Standings/StandingsUpdaterRepository.php
+++ b/ibl5/classes/Standings/StandingsUpdaterRepository.php
@@ -1,0 +1,450 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Standings;
+
+use League\LeagueContext;
+use Standings\Contracts\StandingsRepositoryInterface;
+
+/**
+ * StandingsUpdaterRepository - Write-side and computation data access for team standings
+ *
+ * Handles standing upserts, magic-number/clinch-flag updates, award records,
+ * and computation queries used by the standings updater pipeline.
+ *
+ * @phpstan-import-type TeamMapping from StandingsRepositoryInterface
+ * @phpstan-import-type UpsertStandingsParams from StandingsRepositoryInterface
+ */
+class StandingsUpdaterRepository extends \BaseMysqliRepository
+{
+    private string $teamAwardsTable;
+
+    /**
+     * Closed allowlists for the column identifiers that callers may pass into the
+     * setters/filters below. A column name is a SQL **identifier**, never a
+     * bindable value, so it cannot be a `?` parameter — it is validated against a
+     * fixed set (mirrors {@see \CareerLeaderboards\CareerLeaderboardsRepository}'s
+     * VALID_TABLES allowlist) and rejected with InvalidArgumentException, then
+     * concatenated backticked into the query. This closes the injection shape
+     * BanSqlStringInterpolationRule flags. The accepted values match exactly what
+     * {@see \Updater\StandingsUpdater} / {@see \Updater\StandingsGrouper} emit.
+     *
+     * @var list<string>
+     */
+    private const VALID_GROUPING_COLUMNS = ['conference', 'division'];
+
+    /** @var list<string> */
+    private const VALID_MAGIC_NUMBER_COLUMNS = ['conf_magic_number', 'div_magic_number'];
+
+    /** @var list<string> */
+    private const VALID_CLINCHED_COLUMNS = [
+        'clinched_conference',
+        'clinched_division',
+        'clinched_playoffs',
+        'clinched_league',
+    ];
+
+    public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
+    {
+        parent::__construct($db, $leagueContext);
+        $this->teamAwardsTable = 'ibl_team_awards';
+    }
+
+    /**
+     * Validate a caller-supplied column identifier against a closed allowlist and
+     * return it backtick-quoted for safe concatenation into query text. Throws on
+     * any value outside the allowlist — identifiers are never bound, so this is the
+     * only safe way to splice them.
+     *
+     * @param list<string> $allowed
+     */
+    private static function backtickAllowedColumn(string $column, array $allowed, string $kind): string
+    {
+        if (!in_array($column, $allowed, true)) {
+            throw new \InvalidArgumentException("Invalid {$kind} column: {$column}");
+        }
+
+        return '`' . $column . '`';
+    }
+
+    /**
+     * @see StandingsRepositoryInterface::upsertStandings()
+     */
+    public function upsertStandings(array $params): void
+    {
+        $this->execute(
+            "INSERT INTO `ibl_standings` (
+                teamid, team_name, league_record, wins, losses, pct, games_unplayed,
+                conference, conf_gb, conf_record,
+                division, div_gb, div_record,
+                home_record, away_record,
+                conf_wins, conf_losses, div_wins, div_losses,
+                home_wins, home_losses, away_wins, away_losses
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                team_name = VALUES(team_name),
+                league_record = VALUES(league_record),
+                wins = VALUES(wins),
+                losses = VALUES(losses),
+                pct = VALUES(pct),
+                games_unplayed = VALUES(games_unplayed),
+                conference = VALUES(conference),
+                conf_gb = VALUES(conf_gb),
+                conf_record = VALUES(conf_record),
+                division = VALUES(division),
+                div_gb = VALUES(div_gb),
+                div_record = VALUES(div_record),
+                home_record = VALUES(home_record),
+                away_record = VALUES(away_record),
+                conf_wins = VALUES(conf_wins),
+                conf_losses = VALUES(conf_losses),
+                div_wins = VALUES(div_wins),
+                div_losses = VALUES(div_losses),
+                home_wins = VALUES(home_wins),
+                home_losses = VALUES(home_losses),
+                away_wins = VALUES(away_wins),
+                away_losses = VALUES(away_losses),
+                conf_magic_number = NULL,
+                div_magic_number = NULL,
+                clinched_conference = NULL,
+                clinched_division = NULL,
+                clinched_playoffs = NULL,
+                clinched_league = NULL",
+            "issiidisdssdsssiiiiiiii",
+            $params['teamid'],
+            $params['teamName'],
+            $params['leagueRecord'],
+            $params['wins'],
+            $params['losses'],
+            $params['pct'],
+            $params['gamesUnplayed'],
+            $params['conference'],
+            $params['confGb'],
+            $params['confRecord'],
+            $params['division'],
+            $params['divGb'],
+            $params['divRecord'],
+            $params['homeRecord'],
+            $params['awayRecord'],
+            $params['confWins'],
+            $params['confLosses'],
+            $params['divWins'],
+            $params['divLosses'],
+            $params['homeWins'],
+            $params['homeLosses'],
+            $params['awayWins'],
+            $params['awayLosses']
+        );
+    }
+
+    /**
+     * @see StandingsRepositoryInterface::updateMagicNumber()
+     */
+    public function updateMagicNumber(int $teamid, int $magicNumber, string $magicNumberColumn): void
+    {
+        $column = self::backtickAllowedColumn(
+            $magicNumberColumn,
+            self::VALID_MAGIC_NUMBER_COLUMNS,
+            'magic number'
+        );
+        $this->execute(
+            "UPDATE `ibl_standings` SET " . $column . " = ? WHERE teamid = ?",
+            "ii",
+            $magicNumber,
+            $teamid
+        );
+    }
+
+    /**
+     * @see StandingsRepositoryInterface::updateClinchedFlag()
+     */
+    public function updateClinchedFlag(string $teamName, string $clinchedColumn): void
+    {
+        $column = self::backtickAllowedColumn(
+            $clinchedColumn,
+            self::VALID_CLINCHED_COLUMNS,
+            'clinched'
+        );
+        $this->execute(
+            "UPDATE `ibl_standings` SET " . $column . " = 1 WHERE team_name = ?",
+            "s",
+            $teamName
+        );
+    }
+
+    /**
+     * @see StandingsRepositoryInterface::upsertTeamAward()
+     */
+    public function upsertTeamAward(int $seasonYear, string $teamName, string $awardName): void
+    {
+        // $teamAwardsTable is the fixed property 'ibl_team_awards' (constructor-set,
+        // never user input); concatenate it backticked instead of interpolating.
+        $this->execute(
+            "INSERT INTO `" . $this->teamAwardsTable . "` (year, name, award)
+             VALUES (?, ?, ?)
+             ON DUPLICATE KEY UPDATE name = VALUES(name)",
+            "iss",
+            $seasonYear,
+            $teamName,
+            $awardName
+        );
+    }
+
+    /**
+     * @see StandingsRepositoryInterface::fetchTeamsByRegion()
+     *
+     * @return list<array{teamid: int, team_name: string, home_wins: int, home_losses: int, away_wins: int, away_losses: int}>
+     */
+    public function fetchTeamsByRegion(string $grouping, string $region): array
+    {
+        $groupingColumn = self::backtickAllowedColumn($grouping, self::VALID_GROUPING_COLUMNS, 'grouping');
+        /** @var list<array{teamid: int, team_name: string, home_wins: int, home_losses: int, away_wins: int, away_losses: int}> */
+        return $this->fetchAll(
+            "SELECT teamid, team_name, home_wins, home_losses, away_wins, away_losses
+            FROM `ibl_standings`
+            WHERE " . $groupingColumn . " = ?
+            ORDER BY pct DESC",
+            "s",
+            $region
+        );
+    }
+
+    /**
+     * @see StandingsRepositoryInterface::fetchTopTeamsByWins()
+     *
+     * @return list<array{teamid: int, team_name: string, wins: int}>
+     */
+    public function fetchTopTeamsByWins(?string $grouping, ?string $region): array
+    {
+        if ($grouping !== null && $region !== null) {
+            $groupingColumn = self::backtickAllowedColumn($grouping, self::VALID_GROUPING_COLUMNS, 'grouping');
+            /** @var list<array{teamid: int, team_name: string, wins: int}> */
+            return $this->fetchAll(
+                "SELECT teamid, team_name, home_wins + away_wins AS wins
+                FROM `ibl_standings`
+                WHERE " . $groupingColumn . " = ?
+                ORDER BY wins DESC
+                LIMIT 2",
+                "s",
+                $region
+            );
+        }
+
+        /** @var list<array{teamid: int, team_name: string, wins: int}> */
+        return $this->fetchAll(
+            "SELECT teamid, team_name, home_wins + away_wins AS wins
+            FROM `ibl_standings`
+            ORDER BY wins DESC
+            LIMIT 2",
+            ""
+        );
+    }
+
+    /**
+     * @see StandingsRepositoryInterface::fetchLeastLosingTeam()
+     *
+     * @return array{losses: int}|null
+     */
+    public function fetchLeastLosingTeam(string $excludeTeamName, ?string $grouping, ?string $region): ?array
+    {
+        if ($grouping !== null && $region !== null) {
+            $groupingColumn = self::backtickAllowedColumn($grouping, self::VALID_GROUPING_COLUMNS, 'grouping');
+            /** @var array{losses: int}|null */
+            return $this->fetchOne(
+                "SELECT home_losses + away_losses AS losses
+                FROM `ibl_standings`
+                WHERE " . $groupingColumn . " = ?
+                    AND team_name <> ?
+                ORDER BY losses ASC
+                LIMIT 1",
+                "ss",
+                $region,
+                $excludeTeamName
+            );
+        }
+
+        /** @var array{losses: int}|null */
+        return $this->fetchOne(
+            "SELECT home_losses + away_losses AS losses
+            FROM `ibl_standings`
+            WHERE team_name <> ?
+            ORDER BY losses ASC
+            LIMIT 1",
+            "s",
+            $excludeTeamName
+        );
+    }
+
+    /**
+     * @see StandingsRepositoryInterface::isRegionSeasonOver()
+     */
+    public function isRegionSeasonOver(?string $grouping, ?string $region): bool
+    {
+        if ($grouping !== null && $grouping !== '' && $region !== null && $region !== '') {
+            $groupingColumn = self::backtickAllowedColumn($grouping, self::VALID_GROUPING_COLUMNS, 'grouping');
+            $result = $this->fetchOne(
+                "SELECT MAX(games_unplayed) AS maxLeft FROM `ibl_standings` WHERE " . $groupingColumn . " = ?",
+                "s",
+                $region
+            );
+        } else {
+            $result = $this->fetchOne(
+                "SELECT MAX(games_unplayed) AS maxLeft FROM `ibl_standings`",
+                ""
+            );
+        }
+
+        return $result !== null && $result['maxLeft'] === 0;
+    }
+
+    /**
+     * @see StandingsRepositoryInterface::getHeadToHeadWinner()
+     */
+    public function getHeadToHeadWinner(int $tid1, int $tid2, string $startDate, string $endDate): int
+    {
+        $result = $this->fetchOne(
+            "SELECT
+                COUNT(*) AS total_games,
+                SUM(CASE
+                    WHEN (visitor_teamid = ? AND visitor_score > home_score) OR (home_teamid = ? AND home_score > visitor_score) THEN 1
+                    ELSE 0
+                END) AS team1_wins
+            FROM `ibl_schedule`
+            WHERE visitor_score > 0 AND home_score > 0
+            AND game_date BETWEEN ? AND ?
+            AND ((visitor_teamid = ? AND home_teamid = ?) OR (visitor_teamid = ? AND home_teamid = ?))",
+            "iissiiii",
+            $tid1, $tid1,
+            $startDate, $endDate,
+            $tid1, $tid2, $tid2, $tid1
+        );
+
+        if ($result === null) {
+            return $tid1;
+        }
+
+        /** @var int $totalGames */
+        $totalGames = $result['total_games'];
+        /** @var int $team1Wins */
+        $team1Wins = $result['team1_wins'];
+        $team2Wins = $totalGames - $team1Wins;
+
+        return $team1Wins >= $team2Wins ? $tid1 : $tid2;
+    }
+
+    /**
+     * @see StandingsRepositoryInterface::fetchTeamMapForSeason()
+     *
+     * @return array<int, TeamMapping>
+     */
+    public function fetchTeamMapForSeason(int $seasonEndingYear): array
+    {
+        /** @var list<array{team_slot: int, team_name: string, conference: string, division: string}> $rows */
+        $rows = $this->fetchAll(
+            "SELECT team_slot, team_name, conference, division
+            FROM `ibl_league_config`
+            WHERE season_ending_year = ?",
+            "i",
+            $seasonEndingYear
+        );
+
+        /** @var array<int, TeamMapping> $map */
+        $map = [];
+        foreach ($rows as $row) {
+            $map[$row['team_slot']] = [
+                'conference' => $row['conference'],
+                'division' => $row['division'],
+                'teamName' => $row['team_name'],
+            ];
+        }
+
+        return $map;
+    }
+
+    /**
+     * @see StandingsRepositoryInterface::fetchPlayedGamesForSeason()
+     *
+     * @return list<array{visitor_teamid: int, visitor_score: int, home_teamid: int, home_score: int}>
+     */
+    public function fetchPlayedGamesForSeason(string $startDate, string $endDate): array
+    {
+        /** @var list<array{visitor_teamid: int, visitor_score: int, home_teamid: int, home_score: int}> */
+        return $this->fetchAll(
+            "SELECT visitor_teamid, visitor_score, home_teamid, home_score
+            FROM `ibl_schedule`
+            WHERE visitor_score > 0 AND home_score > 0
+            AND game_date BETWEEN ? AND ?
+            ORDER BY game_date ASC",
+            "ss",
+            $startDate,
+            $endDate
+        );
+    }
+
+    /**
+     * @see StandingsRepositoryInterface::fetchWinningestTeams()
+     *
+     * @return list<array{team_name: string, wins: int}>
+     */
+    public function fetchWinningestTeams(string $conference): array
+    {
+        /** @var list<array{team_name: string, wins: int}> */
+        return $this->fetchAll(
+            "SELECT team_name, home_wins + away_wins AS wins
+            FROM `ibl_standings`
+            WHERE conference = ?
+            ORDER BY wins DESC
+            LIMIT 8",
+            "s",
+            $conference
+        );
+    }
+
+    /**
+     * @see StandingsRepositoryInterface::fetchMostLosingTeams()
+     *
+     * @return list<array{losses: int}>
+     */
+    public function fetchMostLosingTeams(string $conference): array
+    {
+        /** @var list<array{losses: int}> */
+        return $this->fetchAll(
+            "SELECT home_losses + away_losses AS losses
+            FROM `ibl_standings`
+            WHERE conference = ?
+            ORDER BY losses DESC
+            LIMIT 6",
+            "s",
+            $conference
+        );
+    }
+
+    /**
+     * @see StandingsRepositoryInterface::fetchScheduledGameCountsPerTeam()
+     *
+     * @return array<int, int>
+     */
+    public function fetchScheduledGameCountsPerTeam(string $startDate, string $endDate): array
+    {
+        /** @var list<array{teamid: int, game_count: int}> $rows */
+        $rows = $this->fetchAll(
+            "SELECT teamid, COUNT(*) AS game_count FROM (
+                SELECT visitor_teamid AS teamid FROM `ibl_schedule`
+                WHERE game_date BETWEEN ? AND ?
+                UNION ALL
+                SELECT home_teamid AS teamid FROM `ibl_schedule`
+                WHERE game_date BETWEEN ? AND ?
+            ) AS all_games
+            GROUP BY teamid",
+            "ssss",
+            $startDate, $endDate, $startDate, $endDate
+        );
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row['teamid']] = $row['game_count'];
+        }
+        return $result;
+    }
+}

--- a/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
@@ -253,6 +253,17 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 
 **Table evidence (2026-07-27):** TradeRosterPreviewApiHandler 508 LOC — API handler mixing param validation + cash-row building + table render. Extract validation and cash-row collaborators; endpoint (request-handling) → add an E2E/characterization pin.
 
+### 1.32 StandingsRepository — Per-Category Query Accumulation (726 LOC)
+**Location:** `ibl5/classes/Standings/StandingsRepository.php` (726 lines)
+**Problem:** Multiple per-category standings-query methods accumulated in one repository (division standings, tiebreaker, playoff seeding, historical standings, etc.).
+**Suggested direction:** Extract per-category query collaborators behind `StandingsRepositoryInterface`; keep the repo as a thin aggregator. Plan together with 1.35 (StandingsView shares the same `classes/Standings/` module).
+**Est. effort:** M
+**Risk if untouched:** Largest repository in Standings module; every new standings category inflates it further.
+**Provenance:** Seeded 2026-07-24 — ground-truth audit hot-file scan.
+**Status:** Implemented — StandingsUpdaterRepository extracted from StandingsRepository (2026-08-08, PR TBD).
+
+**Table evidence (2026-08-08):** StandingsRepository 726 LOC — per-category standings query methods. Extract per-category query collaborators; green-green DB pin. Shares `classes/Standings/` with 1.35 — plan as ONE chunk.
+
 ### 1.34 SavedDepthChartService — Data Assembly + Slot-Conflict Resolution (626 LOC)
 **Location:** `ibl5/classes/SavedDepthChart/SavedDepthChartService.php` (626 lines)
 **Problem:** One service assembles depth-chart page data and resolves slot conflicts, mixing orchestration with conflict-resolution logic.

--- a/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
@@ -260,7 +260,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Est. effort:** M
 **Risk if untouched:** Largest repository in Standings module; every new standings category inflates it further.
 **Provenance:** Seeded 2026-07-24 — ground-truth audit hot-file scan.
-**Status:** Implemented — StandingsUpdaterRepository extracted from StandingsRepository (2026-08-08, PR TBD).
+**Status:** Implemented — StandingsUpdaterRepository extracted from StandingsRepository (2026-08-08, PR #1794).
 
 **Table evidence (2026-08-08):** StandingsRepository 726 LOC — per-category standings query methods. Extract per-category query collaborators; green-green DB pin. Shares `classes/Standings/` with 1.35 — plan as ONE chunk.
 

--- a/ibl5/docs/backlog/maintenance-backlog.md
+++ b/ibl5/docs/backlog/maintenance-backlog.md
@@ -53,7 +53,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 | 🟨 Conditional | needs one mechanical-scope add, one upfront decision, or a collision-PR to merge first |
 | 🟥 Not automouse-safe | 12.11 — `git filter-repo` history rewrite (irreversible, coordinated) |
 
-**Highest-leverage 🟩 auto-mergeable clusters** (no human needed): the open god-class extractions (1.3/1.9/1.11/1.13/1.17/1.18/1.20, 7.14/7.15, 1.32–1.36), the entire Axis-6 coverage backlog (bar 6.21, now 🟨), the Axis-9 docs items, and the PHPStan-baseline burndowns (10.12/10.13/10.19/10.21).
+**Highest-leverage 🟩 auto-mergeable clusters** (no human needed): the open god-class extractions (1.3/1.9/1.11/1.13/1.17/1.18/1.20, 7.14/7.15, 1.33–1.36), the entire Axis-6 coverage backlog (bar 6.21, now 🟨), the Axis-9 docs items, and the PHPStan-baseline burndowns (10.12/10.13/10.19/10.21).
 
 ---
 
@@ -71,7 +71,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 | 1.26 | ⬜ Open | 🟩 | BugReportRepository 546 LOC — 24 methods spanning claim/lease/transition state-machine + reporter-profile + queue queries. Split by query group; green-green with DB-integration pins. |
 | 1.30 | ⬜ Open | 🟩 | TradingService 516 LOC — page-data orchestration + offer-grouping + future-salary calc. Extract offer-grouping and salary collaborators; green-green. |
 | 1.33 | ⬜ Open | 🟩 | Player 671 LOC — typed-getter accumulation. Extract per-domain typed-getter groups (contract, stats, identity); green-green. |
-| 1.35 | ⬜ Open | 🟩 | StandingsView 610 LOC — per-division block renderers. Extract per-division renderer collaborators; golden-master pin. Shares `classes/Standings/` with 1.32 — plan as ONE chunk. |
+| 1.35 | ⬜ Open | 🟩 | StandingsView 610 LOC — per-division block renderers. Extract per-division renderer collaborators; golden-master pin. (1.32 resolved — can now plan independently.) |
 
 > **Note:** `BaseMysqliRepository.php` (602 LOC) is the 18th hot file but is tracked under **2.29** (global-namespace elimination sweep) and is not seeded as a standalone god-class item here.
 
@@ -133,7 +133,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 ### 1.35 StandingsView — Per-Division Block Renderer (610 LOC)
 **Location:** `ibl5/classes/Standings/StandingsView.php` (610 lines)
 **Problem:** One view renders per-division standings blocks, tiebreaker panels, and playoff-seeding tables for multiple page variants.
-**Suggested direction:** Extract per-division renderer collaborators; golden-master pin. Plan together with 1.32 (StandingsRepository shares the same `classes/Standings/` module).
+**Suggested direction:** Extract per-division renderer collaborators; golden-master pin. (1.32 resolved 2026-08-08 — can plan independently; no longer a "same chunk" coupling.)
 **Est. effort:** M
 **Risk if untouched:** Every new standings display variant inflates the view.
 **Provenance:** Seeded 2026-07-24 — ground-truth audit hot-file scan.

--- a/ibl5/docs/backlog/maintenance-backlog.md
+++ b/ibl5/docs/backlog/maintenance-backlog.md
@@ -61,7 +61,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 
 **Automouse audit (verified 2026-06-20):**
 
-> ✅ resolved (28): 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.19, 1.20, 1.21, 1.23, 1.24, 1.27, 1.28, 1.29, 1.31, 1.34, 1.36 — evidence in [archive](archive/maintenance-backlog-archive.md)
+> ✅ resolved (29): 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.19, 1.20, 1.21, 1.23, 1.24, 1.27, 1.28, 1.29, 1.31, 1.32, 1.34, 1.36 — evidence in [archive](archive/maintenance-backlog-archive.md)
 
 | # | Status | Automouse | Evidence / note |
 |---|--------|-----------|-----------------|
@@ -70,7 +70,6 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 | 1.25 | ⬜ Open | 🟨 | BoxscoreProcessor 559 LOC — mutating .sco import pipeline; regular/all-star/rising-stars game processors in one class. Extract per-game-type processors; import-fidelity-critical → characterization pins first. Size finding only; the Processor→Service *rename* is separately declined at 2.5. |
 | 1.26 | ⬜ Open | 🟩 | BugReportRepository 546 LOC — 24 methods spanning claim/lease/transition state-machine + reporter-profile + queue queries. Split by query group; green-green with DB-integration pins. |
 | 1.30 | ⬜ Open | 🟩 | TradingService 516 LOC — page-data orchestration + offer-grouping + future-salary calc. Extract offer-grouping and salary collaborators; green-green. |
-| 1.32 | ⬜ Open | 🟩 | StandingsRepository 726 LOC — per-category standings query methods. Extract per-category query collaborators; green-green DB pin. Shares `classes/Standings/` with 1.35 — plan as ONE chunk. |
 | 1.33 | ⬜ Open | 🟩 | Player 671 LOC — typed-getter accumulation. Extract per-domain typed-getter groups (contract, stats, identity); green-green. |
 | 1.35 | ⬜ Open | 🟩 | StandingsView 610 LOC — per-division block renderers. Extract per-division renderer collaborators; golden-master pin. Shares `classes/Standings/` with 1.32 — plan as ONE chunk. |
 
@@ -122,14 +121,6 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 **Est. effort:** M
 **Risk if untouched:** Trade page-data logic concentrated in one service; green-green.
 **Provenance:** Seeded 2026-07-24 — hot-files comment→backlog migration.
-
-### 1.32 StandingsRepository — Per-Category Query Accumulation (726 LOC)
-**Location:** `ibl5/classes/Standings/StandingsRepository.php` (726 lines)
-**Problem:** Multiple per-category standings-query methods accumulated in one repository (division standings, tiebreaker, playoff seeding, historical standings, etc.).
-**Suggested direction:** Extract per-category query collaborators behind `StandingsRepositoryInterface`; keep the repo as a thin aggregator. Plan together with 1.35 (StandingsView shares the same `classes/Standings/` module).
-**Est. effort:** M
-**Risk if untouched:** Largest repository in Standings module; every new standings category inflates it further.
-**Provenance:** Seeded 2026-07-24 — ground-truth audit hot-file scan.
 
 ### 1.33 Player — Typed-Getter Accumulation (671 LOC)
 **Location:** `ibl5/classes/Player/Player.php` (671 lines)

--- a/ibl5/phpstan-baseline-counts.json
+++ b/ibl5/phpstan-baseline-counts.json
@@ -14,7 +14,7 @@
         "ibl.directTime": 13,
         "ibl.hardcodedEnvString": 8,
         "ibl.orderByMissingTiebreaker": 84,
-        "ibl.sqlStringConcatenation": 32,
+        "ibl.sqlStringConcatenation": 33,
         "ibl.trustedVariable": 16,
         "identical.alwaysFalse": 1,
         "if.condNotBoolean": 1,

--- a/ibl5/phpstan-baseline.neon
+++ b/ibl5/phpstan-baseline.neon
@@ -697,34 +697,40 @@ parameters:
 			path: classes/Standings/StandingsRepository.php
 
 		-
+			rawMessage: 'SQL string concatenates a non-constant value. Concatenating a runtime value into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringConcatenation
+			count: 10
+			path: classes/Standings/StandingsRepository.php
+
+		-
 			rawMessage: 'ORDER BY on rendered/LIMIT-cut output must end in a unique tiebreaker column (e.g. append ", pid ASC"); final sort term "game_date" is not a recognized-unique column. See ADR-0083. Acknowledge a genuine exception with // @phpstan-ignore ibl.orderByMissingTiebreaker.'
 			identifier: ibl.orderByMissingTiebreaker
 			count: 1
-			path: classes/Standings/StandingsRepository.php
+			path: classes/Standings/StandingsUpdaterRepository.php
 
 		-
 			rawMessage: 'ORDER BY on rendered/LIMIT-cut output must end in a unique tiebreaker column (e.g. append ", pid ASC"); final sort term "losses" is not a recognized-unique column. See ADR-0083. Acknowledge a genuine exception with // @phpstan-ignore ibl.orderByMissingTiebreaker.'
 			identifier: ibl.orderByMissingTiebreaker
 			count: 1
-			path: classes/Standings/StandingsRepository.php
+			path: classes/Standings/StandingsUpdaterRepository.php
 
 		-
 			rawMessage: 'ORDER BY on rendered/LIMIT-cut output must end in a unique tiebreaker column (e.g. append ", pid ASC"); final sort term "pct" is not a recognized-unique column. See ADR-0083. Acknowledge a genuine exception with // @phpstan-ignore ibl.orderByMissingTiebreaker.'
 			identifier: ibl.orderByMissingTiebreaker
 			count: 1
-			path: classes/Standings/StandingsRepository.php
+			path: classes/Standings/StandingsUpdaterRepository.php
 
 		-
 			rawMessage: 'ORDER BY on rendered/LIMIT-cut output must end in a unique tiebreaker column (e.g. append ", pid ASC"); final sort term "wins" is not a recognized-unique column. See ADR-0083. Acknowledge a genuine exception with // @phpstan-ignore ibl.orderByMissingTiebreaker.'
 			identifier: ibl.orderByMissingTiebreaker
 			count: 3
-			path: classes/Standings/StandingsRepository.php
+			path: classes/Standings/StandingsUpdaterRepository.php
 
 		-
 			rawMessage: 'SQL string concatenates a non-constant value. Concatenating a runtime value into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
 			identifier: ibl.sqlStringConcatenation
-			count: 17
-			path: classes/Standings/StandingsRepository.php
+			count: 7
+			path: classes/Standings/StandingsUpdaterRepository.php
 
 		-
 			rawMessage: 'SQL string concatenates a non-constant value. Concatenating a runtime value into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'

--- a/ibl5/tests/DatabaseIntegration/StandingsRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/StandingsRepositoryTest.php
@@ -240,8 +240,8 @@ class StandingsRepositoryTest extends DatabaseTestCase
         $result = $this->repo->fetchTopTeamsByWins('conference', 'Eastern');
 
         self::assertCount(2, $result);
-        self::assertEquals(30, $result[0]['wins']);
-        self::assertEquals(20, $result[1]['wins']);
+        self::assertSame(30, $result[0]['wins']);
+        self::assertSame(20, $result[1]['wins']);
     }
 
     public function testFetchTopTeamsByWinsWithNullGroupingScansWholeLeague(): void
@@ -255,8 +255,8 @@ class StandingsRepositoryTest extends DatabaseTestCase
         $result = $this->repo->fetchTopTeamsByWins(null, null);
 
         self::assertCount(2, $result);
-        self::assertEquals(40, $result[0]['wins']);
-        self::assertEquals(35, $result[1]['wins']);
+        self::assertSame(40, $result[0]['wins']);
+        self::assertSame(35, $result[1]['wins']);
         self::assertSame(1, $result[0]['teamid']);
         self::assertSame(2, $result[1]['teamid']);
     }
@@ -277,7 +277,7 @@ class StandingsRepositoryTest extends DatabaseTestCase
         $result = $this->repo->fetchLeastLosingTeam('Spurs', 'conference', 'TestConf3');
 
         self::assertNotNull($result);
-        self::assertEquals(6, $result['losses']);
+        self::assertSame(6, $result['losses']);
     }
 
     public function testFetchLeastLosingTeamReturnsNullWhenOnlyCandidateIsExcluded(): void
@@ -391,7 +391,7 @@ class StandingsRepositoryTest extends DatabaseTestCase
         $scored = $this->repo->fetchPlayedGamesForSeason('2099-01-01', '2099-12-31');
 
         self::assertCount(1, $scored);
-        self::assertEquals(100, $scored[0]['visitor_score']);
+        self::assertSame(100, $scored[0]['visitor_score']);
 
         $empty = $this->repo->fetchPlayedGamesForSeason('2090-01-01', '2090-12-31');
         self::assertSame([], $empty);
@@ -482,7 +482,7 @@ class StandingsRepositoryTest extends DatabaseTestCase
         self::assertNotFalse($row);
         $data = $row->fetch_assoc();
         self::assertIsArray($data);
-        self::assertEquals(60, $data['wins']);
+        self::assertSame(60, $data['wins']);
         self::assertNull($data['conf_magic_number']);
         self::assertNull($data['div_magic_number']);
         self::assertNull($data['clinched_conference']);
@@ -501,7 +501,7 @@ class StandingsRepositoryTest extends DatabaseTestCase
         self::assertNotFalse($result);
         $row = $result->fetch_assoc();
         self::assertIsArray($row);
-        self::assertEquals(1, $row['clinched_playoffs']);
+        self::assertSame(1, $row['clinched_playoffs']);
     }
 
     public function testUpsertTeamAwardIsIdempotent(): void
@@ -515,6 +515,6 @@ class StandingsRepositoryTest extends DatabaseTestCase
         self::assertNotFalse($result);
         $row = $result->fetch_assoc();
         self::assertIsArray($row);
-        self::assertEquals(1, $row['cnt']);
+        self::assertSame(1, $row['cnt']);
     }
 }

--- a/ibl5/tests/DatabaseIntegration/StandingsRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/StandingsRepositoryTest.php
@@ -227,4 +227,294 @@ class StandingsRepositoryTest extends DatabaseTestCase
         self::assertNotEmpty($result);
         self::assertArrayHasKey('teamid', $result[0]);
     }
+
+    // ── Group C: computation queries ──────────────────────────────────────────
+
+    public function testFetchTopTeamsByWinsReturnsTwoOrderedByWins(): void
+    {
+        $updateA = $this->db->query('UPDATE `ibl_standings` SET home_wins = 20, away_wins = 10 WHERE teamid = 1');
+        self::assertNotFalse($updateA);
+        $updateB = $this->db->query('UPDATE `ibl_standings` SET home_wins = 15, away_wins = 5 WHERE teamid = 3');
+        self::assertNotFalse($updateB);
+
+        $result = $this->repo->fetchTopTeamsByWins('conference', 'Eastern');
+
+        self::assertCount(2, $result);
+        self::assertEquals(30, $result[0]['wins']);
+        self::assertEquals(20, $result[1]['wins']);
+    }
+
+    public function testFetchTopTeamsByWinsWithNullGroupingScansWholeLeague(): void
+    {
+        // Only set two teams; remaining 26 have NULL home_wins → NULL wins → sort last under DESC
+        $updateA = $this->db->query('UPDATE `ibl_standings` SET home_wins = 30, away_wins = 10 WHERE teamid = 1');
+        self::assertNotFalse($updateA);
+        $updateB = $this->db->query('UPDATE `ibl_standings` SET home_wins = 20, away_wins = 15 WHERE teamid = 2');
+        self::assertNotFalse($updateB);
+
+        $result = $this->repo->fetchTopTeamsByWins(null, null);
+
+        self::assertCount(2, $result);
+        self::assertEquals(40, $result[0]['wins']);
+        self::assertEquals(35, $result[1]['wins']);
+        self::assertSame(1, $result[0]['teamid']);
+        self::assertSame(2, $result[1]['teamid']);
+    }
+
+    public function testFetchLeastLosingTeamExcludesNamedTeam(): void
+    {
+        // Private conference avoids seed NULLs sorting first under ASC; only these two teams are in scope
+        $updateA = $this->db->query(
+            "UPDATE `ibl_standings` SET conference = 'TestConf3', home_losses = 1, away_losses = 1 WHERE teamid = 10"
+        );
+        self::assertNotFalse($updateA);
+        $updateB = $this->db->query(
+            "UPDATE `ibl_standings` SET conference = 'TestConf3', home_losses = 3, away_losses = 3 WHERE teamid = 11"
+        );
+        self::assertNotFalse($updateB);
+        // Spurs (tid=10): losses=2 (fewest, excluded); Pioneers (tid=11): losses=6 (expected result)
+
+        $result = $this->repo->fetchLeastLosingTeam('Spurs', 'conference', 'TestConf3');
+
+        self::assertNotNull($result);
+        self::assertEquals(6, $result['losses']);
+    }
+
+    public function testFetchLeastLosingTeamReturnsNullWhenOnlyCandidateIsExcluded(): void
+    {
+        $update = $this->db->query(
+            "UPDATE `ibl_standings` SET conference = 'TestConf4', home_losses = 5, away_losses = 5 WHERE teamid = 13"
+        );
+        self::assertNotFalse($update);
+
+        $result = $this->repo->fetchLeastLosingTeam('Apollos', 'conference', 'TestConf4');
+
+        self::assertNull($result);
+    }
+
+    public function testIsRegionSeasonOverTrueWhenNoGamesUnplayed(): void
+    {
+        $update = $this->db->query("UPDATE `ibl_standings` SET games_unplayed = 0 WHERE conference = 'Eastern'");
+        self::assertNotFalse($update);
+
+        $result = $this->repo->isRegionSeasonOver('conference', 'Eastern');
+
+        self::assertTrue($result);
+    }
+
+    public function testIsRegionSeasonOverFalseWhenAnyGameUnplayed(): void
+    {
+        $updateAll = $this->db->query("UPDATE `ibl_standings` SET games_unplayed = 0 WHERE conference = 'Eastern'");
+        self::assertNotFalse($updateAll);
+        $updateOne = $this->db->query('UPDATE `ibl_standings` SET games_unplayed = 1 WHERE teamid = 1');
+        self::assertNotFalse($updateOne);
+
+        $result = $this->repo->isRegionSeasonOver('conference', 'Eastern');
+
+        self::assertFalse($result);
+    }
+
+    public function testGetHeadToHeadWinnerReturnsActualWinner(): void
+    {
+        // Isolated 2099 window: visitor=1 (Metros, 100) beats home=2 (Stars, 90)
+        $this->insertScheduleRow(2099, '2099-06-15', 1, 100, 2, 90);
+
+        $winner12 = $this->repo->getHeadToHeadWinner(1, 2, '2099-01-01', '2099-12-31');
+        $winner21 = $this->repo->getHeadToHeadWinner(2, 1, '2099-01-01', '2099-12-31');
+
+        self::assertSame(1, $winner12);
+        self::assertSame(1, $winner21);
+    }
+
+    public function testGetHeadToHeadWinnerFallsBackToFirstTeamWithNoGames(): void
+    {
+        $tid1 = 1;
+        $tid2 = 2;
+
+        $result = $this->repo->getHeadToHeadWinner($tid1, $tid2, '2090-01-01', '2090-12-31');
+
+        self::assertSame($tid1, $result);
+    }
+
+    public function testFetchTeamMapForSeasonKeysBySlot(): void
+    {
+        $this->insertRow('ibl_league_config', [
+            'season_ending_year' => 2099,
+            'team_slot' => 1,
+            'team_name' => 'Metros',
+            'conference' => 'Eastern',
+            'division' => 'Atlantic',
+            'playoff_qualifiers_per_conf' => 4,
+            'playoff_round1_format' => 'bo7',
+            'playoff_round2_format' => 'bo7',
+            'playoff_round3_format' => 'bo7',
+            'playoff_round4_format' => 'bo7',
+            'team_count' => 28,
+        ]);
+        $this->insertRow('ibl_league_config', [
+            'season_ending_year' => 2099,
+            'team_slot' => 2,
+            'team_name' => 'Stars',
+            'conference' => 'Western',
+            'division' => 'Pacific',
+            'playoff_qualifiers_per_conf' => 4,
+            'playoff_round1_format' => 'bo7',
+            'playoff_round2_format' => 'bo7',
+            'playoff_round3_format' => 'bo7',
+            'playoff_round4_format' => 'bo7',
+            'team_count' => 28,
+        ]);
+
+        $result = $this->repo->fetchTeamMapForSeason(2099);
+
+        self::assertCount(2, $result);
+        self::assertArrayHasKey(1, $result);
+        self::assertArrayHasKey(2, $result);
+        self::assertSame('Eastern', $result[1]['conference']);
+        self::assertSame('Atlantic', $result[1]['division']);
+        self::assertSame('Metros', $result[1]['teamName']);
+        self::assertSame('Western', $result[2]['conference']);
+    }
+
+    public function testFetchTeamMapForSeasonReturnsEmptyForUnseededYear(): void
+    {
+        $result = $this->repo->fetchTeamMapForSeason(9999);
+
+        self::assertSame([], $result);
+    }
+
+    public function testFetchPlayedGamesForSeasonReturnsScoredGamesOnly(): void
+    {
+        $this->insertScheduleRow(2099, '2099-06-01', 1, 0, 2, 0);
+        $this->insertScheduleRow(2099, '2099-06-02', 1, 100, 2, 90);
+
+        $scored = $this->repo->fetchPlayedGamesForSeason('2099-01-01', '2099-12-31');
+
+        self::assertCount(1, $scored);
+        self::assertEquals(100, $scored[0]['visitor_score']);
+
+        $empty = $this->repo->fetchPlayedGamesForSeason('2090-01-01', '2090-12-31');
+        self::assertSame([], $empty);
+    }
+
+    public function testFetchWinningestTeamsCapsAtEightPerConference(): void
+    {
+        // Eastern has 15 teams; setting home_wins = teamid gives unique values ≤ 41
+        $update = $this->db->query(
+            "UPDATE `ibl_standings` SET home_wins = teamid, away_wins = 0 WHERE conference = 'Eastern'"
+        );
+        self::assertNotFalse($update);
+
+        $result = $this->repo->fetchWinningestTeams('Eastern');
+
+        self::assertCount(8, $result);
+        $prevWins = PHP_INT_MAX;
+        foreach ($result as $row) {
+            self::assertLessThanOrEqual($prevWins, $row['wins']);
+            $prevWins = $row['wins'];
+        }
+    }
+
+    public function testFetchMostLosingTeamsCapsAtSixPerConference(): void
+    {
+        // Eastern has 15 teams; setting home_losses = teamid gives unique values ≤ 41
+        $update = $this->db->query(
+            "UPDATE `ibl_standings` SET home_losses = teamid, away_losses = 0 WHERE conference = 'Eastern'"
+        );
+        self::assertNotFalse($update);
+
+        $result = $this->repo->fetchMostLosingTeams('Eastern');
+
+        self::assertCount(6, $result);
+        $prevLosses = PHP_INT_MAX;
+        foreach ($result as $row) {
+            self::assertLessThanOrEqual($prevLosses, $row['losses']);
+            $prevLosses = $row['losses'];
+        }
+    }
+
+    public function testFetchScheduledGameCountsPerTeamCountsBothSides(): void
+    {
+        // Seeded game: 2025-01-15, visitor=2, home=1; UNION ALL counts each team once per role
+        $result = $this->repo->fetchScheduledGameCountsPerTeam('2025-01-01', '2025-12-31');
+
+        self::assertArrayHasKey(1, $result);
+        self::assertArrayHasKey(2, $result);
+        self::assertGreaterThanOrEqual(1, $result[1]);
+        self::assertGreaterThanOrEqual(1, $result[2]);
+    }
+
+    // ── Group B: write operations ─────────────────────────────────────────────
+
+    public function testUpsertStandingsInsertsThenUpdatesSameTeam(): void
+    {
+        // Remove seeded row so the first upsert is a real INSERT, not ON DUPLICATE KEY UPDATE
+        $del = $this->db->query('DELETE FROM `ibl_standings` WHERE teamid = 1');
+        self::assertNotFalse($del);
+
+        $baseParams = [
+            'teamid' => 1, 'teamName' => 'Metros', 'leagueRecord' => '40-20',
+            'wins' => 40, 'losses' => 20, 'pct' => 0.667, 'gamesUnplayed' => 0,
+            'conference' => 'Eastern', 'confGb' => 0.0, 'confRecord' => '20-10',
+            'division' => 'Atlantic', 'divGb' => 0.0, 'divRecord' => '10-5',
+            'homeRecord' => '22-8', 'awayRecord' => '18-12',
+            'confWins' => 20, 'confLosses' => 10, 'divWins' => 10, 'divLosses' => 5,
+            'homeWins' => 22, 'homeLosses' => 8, 'awayWins' => 18, 'awayLosses' => 12,
+        ];
+
+        // First call: true INSERT
+        $this->repo->upsertStandings($baseParams);
+
+        // Arrange values that ON DUPLICATE KEY UPDATE should reset to NULL
+        $this->repo->updateMagicNumber(1, 5, 'conf_magic_number');
+        $this->repo->updateClinchedFlag('Metros', 'clinched_playoffs');
+
+        // Second call: ON DUPLICATE KEY UPDATE — resets all 6 magic/clinched columns to NULL
+        $this->repo->upsertStandings(array_merge($baseParams, [
+            'wins' => 60, 'losses' => 10, 'leagueRecord' => '60-10', 'pct' => 0.857,
+        ]));
+
+        $row = $this->db->query(
+            'SELECT wins, conf_magic_number, div_magic_number, clinched_conference,
+                    clinched_division, clinched_playoffs, clinched_league
+             FROM `ibl_standings` WHERE teamid = 1'
+        );
+        self::assertNotFalse($row);
+        $data = $row->fetch_assoc();
+        self::assertIsArray($data);
+        self::assertEquals(60, $data['wins']);
+        self::assertNull($data['conf_magic_number']);
+        self::assertNull($data['div_magic_number']);
+        self::assertNull($data['clinched_conference']);
+        self::assertNull($data['clinched_division']);
+        self::assertNull($data['clinched_playoffs']);
+        self::assertNull($data['clinched_league']);
+    }
+
+    public function testUpdateClinchedFlagSetsAllowlistedColumn(): void
+    {
+        $this->repo->updateClinchedFlag('Metros', 'clinched_playoffs');
+
+        $result = $this->db->query(
+            "SELECT `clinched_playoffs` FROM `ibl_standings` WHERE team_name = 'Metros'"
+        );
+        self::assertNotFalse($result);
+        $row = $result->fetch_assoc();
+        self::assertIsArray($row);
+        self::assertEquals(1, $row['clinched_playoffs']);
+    }
+
+    public function testUpsertTeamAwardIsIdempotent(): void
+    {
+        $this->repo->upsertTeamAward(2099, 'Metros', 'TestDivisionAward');
+        $this->repo->upsertTeamAward(2099, 'Metros', 'TestDivisionAward');
+
+        $result = $this->db->query(
+            "SELECT COUNT(*) AS cnt FROM `ibl_team_awards` WHERE year = 2099 AND award = 'TestDivisionAward'"
+        );
+        self::assertNotFalse($result);
+        $row = $result->fetch_assoc();
+        self::assertIsArray($row);
+        self::assertEquals(1, $row['cnt']);
+    }
 }


### PR DESCRIPTION
## Summary

Extracts 14 group B+C methods (update/upsert/award writes and computation queries) from `StandingsRepository` (726 LOC) into a new `StandingsUpdaterRepository` collaborator, leaving `StandingsRepository` as a thin read-query aggregator that delegates.

- **Phase 1:** 17 characterization pins for group B+C methods in `StandingsRepositoryTest` (green-green proof)
- **Phase 2:** New `StandingsUpdaterRepository` with verbatim method bodies; `StandingsRepository` collapses each to a one-line delegation
- **Phase 3:** `Standings/README.md` architecture tree and constructor arity fixes
- **Phase 4:** Backlog item 1.32 flipped to Implemented, archived, roll-up recounted

No caller changes — `StandingsRepositoryInterface` stays on the aggregator.

Closes backlog item 1.32.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
