### PR TITLE
refactor: extract StandingsRowView + StandingsTiebreakerResolver from StandingsView (1.35)

### DIFF
--- a/ibl5/classes/Standings/README.md
+++ b/ibl5/classes/Standings/README.md
@@ -19,6 +19,8 @@ Standings/
 ├── StandingsRepository.php               # Read queries + thin delegator for writes
 ├── StandingsUpdaterRepository.php        # Update/upsert/award writes (— NEW, Phase 2)
 ├── StandingsView.php                     # Table orchestration: group, sort, header, rows
+├── StandingsRowView.php                  # Single-row HTML + clinch tier/prefix (— NEW, Phase 2)
+├── StandingsTiebreakerResolver.php       # H2H tie-break ordering within tied groups (— NEW, Phase 3)
 ├── AggregateTiebreaker.php               # Pure aggregate H2H win-pct helper
 ├── PythagoreanCalculator.php             # Pythagorean expectation helper (7.14)
 ├── OlympicsStandingsView.php             # Separate Olympics standings renderer

--- a/ibl5/classes/Standings/README.md
+++ b/ibl5/classes/Standings/README.md
@@ -1,5 +1,5 @@
 ---
-description: Conference and division standings display with clinched-indicator badges (Z-, Y-, X-) and dynamic HTML generation.
+description: Conference and division standings display with clinched-indicator badges (W-, Z-, Y-, X-) and dynamic HTML generation.
 last_verified: 2026-08-08
 ---
 
@@ -74,6 +74,7 @@ $streakData = $repository->getTeamStreakData($teamId);
 ## Clinched Indicators
 
 Teams that have clinched playoff positions display prefixes:
+- **W-** Clinched league/championship
 - **Z-** Clinched conference
 - **Y-** Clinched division
 - **X-** Clinched playoffs

--- a/ibl5/classes/Standings/StandingsRowView.php
+++ b/ibl5/classes/Standings/StandingsRowView.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Standings;
+
+use Standings\Contracts\StandingsRepositoryInterface;
+use UI\TeamCellHelper;
+
+/**
+ * StandingsRowView - HTML rendering for a single standings table row
+ *
+ * Renders individual team rows, team name formatting, and clinch-tier helpers.
+ *
+ * @phpstan-import-type StandingsRow from StandingsRepositoryInterface
+ * @phpstan-import-type StreakRow from StandingsRepositoryInterface
+ * @phpstan-import-type PythagoreanStats from StandingsRepositoryInterface
+ */
+final class StandingsRowView
+{
+    /**
+     * Render a single team row
+     *
+     * @param StandingsRow $team Team standings data
+     * @param bool $isBottomLocked Whether this team is mathematically locked at the bottom
+     * @param StreakRow|null $streakData Pre-loaded streak data for this team
+     * @param PythagoreanStats|null $pythagoreanStats Pre-loaded Pythagorean stats for this team
+     * @return string HTML for team row
+     */
+    public function renderTeamRow(array $team, bool $isBottomLocked, ?array $streakData, ?array $pythagoreanStats): string
+    {
+        $teamId = $team['teamid'];
+        $teamName = $this->formatTeamName($team);
+
+        $lastWin = $streakData['last_win'] ?? 0;
+        $lastLoss = $streakData['last_loss'] ?? 0;
+        $streak = $streakData['streak'] ?? 0;
+        $streakSortKey = ($streakData['streak_type'] ?? '') === 'W' ? $streak : -$streak;
+        $rating = $streakData['ranking'] ?? 0;
+        $sos = $streakData['sos'] ?? 0;
+        $remainingSos = $streakData['remaining_sos'] ?? 0;
+
+        // Get Pythagorean win percentage from pre-loaded data
+        $pythagoreanPct = '0.000';
+        if ($pythagoreanStats !== null) {
+            $pythagoreanPct = \BasketballStats\StatsFormatter::calculatePythagoreanWinPercentage(
+                $pythagoreanStats['pointsScored'],
+                $pythagoreanStats['pointsAllowed']
+            );
+        }
+
+        $leagueRecord = $team['league_record'];
+        $pct = $team['pct'];
+        $gamesBack = $team['gamesBack'];
+        $magicNumber = $team['magicNumber'];
+        $gamesUnplayed = $team['games_unplayed'];
+        $confRecord = $team['conf_record'];
+        $divRecord = $team['div_record'];
+        $homeRecord = $team['home_record'];
+        $awayRecord = $team['away_record'];
+        $homeGames = $team['homeGames'];
+        $awayGames = $team['awayGames'];
+
+        // Build CSS class for row highlighting
+        $rowClass = '';
+        if ($isBottomLocked) {
+            $rowClass = 'bottom-locked';
+        } else {
+            $rowClass = self::getClinchTierClass($team);
+        }
+
+        ob_start();
+        ?>
+        <tr data-team-id="<?= \Security\HtmlSanitizer::e($teamId); ?>"<?= $rowClass !== '' ? ' class="' . \Security\HtmlSanitizer::e($rowClass) . '"' : ''; ?>>
+            <?= TeamCellHelper::renderTeamCell($teamId, $team['team_name'], $team['color1'], $team['color2'], 'sticky-col', '', $teamName) ?>
+            <td><?= \Security\HtmlSanitizer::e($leagueRecord); ?></td>
+            <td><?= \BasketballStats\StatsFormatter::formatWithDecimals((float)$pct, 3); ?></td>
+            <td><?= \Security\HtmlSanitizer::e($pythagoreanPct); ?></td>
+            <td><?= \Security\HtmlSanitizer::e($gamesBack); ?></td>
+            <td><?= \Security\HtmlSanitizer::e($magicNumber); ?></td>
+            <td><?= \Security\HtmlSanitizer::e($gamesUnplayed); ?></td>
+            <td><?= \Security\HtmlSanitizer::e($confRecord); ?></td>
+            <td><?= \Security\HtmlSanitizer::e($divRecord); ?></td>
+            <td><?= \Security\HtmlSanitizer::e($homeRecord); ?></td>
+            <td><?= \Security\HtmlSanitizer::e($awayRecord); ?></td>
+            <td><?= \Security\HtmlSanitizer::e($homeGames); ?></td>
+            <td><?= \Security\HtmlSanitizer::e($awayGames); ?></td>
+            <td><?= \Security\HtmlSanitizer::e($lastWin); ?>-<?= \Security\HtmlSanitizer::e($lastLoss); ?></td>
+            <td sorttable_customkey="<?= \Security\HtmlSanitizer::e($streakSortKey); ?>"><?= \Security\HtmlSanitizer::e($streakData['streak_type'] ?? ''); ?> <?= \Security\HtmlSanitizer::e($streak); ?></td>
+            <td><span class="ibl-stat-highlight"><?= \Security\HtmlSanitizer::e($rating); ?></span></td>
+            <td><?= \BasketballStats\StatsFormatter::formatWithDecimals((float)$sos, 3); ?></td>
+            <td><?= \BasketballStats\StatsFormatter::formatWithDecimals((float)$remainingSos, 3); ?></td>
+        </tr>
+        <?php
+        return (string) ob_get_clean();
+    }
+
+    /**
+     * Format team name with clinched indicator
+     *
+     * Priority: W (league) > Z (conference) > Y (division) > X (playoffs)
+     *
+     * @param StandingsRow $team Team standings data
+     * @return string Formatted team name with clinched prefix if applicable
+     */
+    public function formatTeamName(array $team): string
+    {
+        $teamName = \Security\HtmlSanitizer::safeHtmlOutput($team['team_name']);
+
+        if ($team['clinched_league'] === 1) {
+            return '<span class="ibl-clinched-indicator">W</span>-' . $teamName;
+        }
+
+        if ($team['clinched_conference'] === 1) {
+            return '<span class="ibl-clinched-indicator">Z</span>-' . $teamName;
+        }
+
+        if ($team['clinched_division'] === 1) {
+            return '<span class="ibl-clinched-indicator">Y</span>-' . $teamName;
+        }
+
+        if ($team['clinched_playoffs'] === 1) {
+            return '<span class="ibl-clinched-indicator">X</span>-' . $teamName;
+        }
+
+        return $teamName;
+    }
+
+    /**
+     * Determine which teams are eliminated (bottom-locked) in standings
+     *
+     * When the season is over (all gamesUnplayed = 0), any team without a clinch
+     * flag is eliminated. During the season, cascades from the bottom: a team is
+     * locked if even winning all remaining games can't catch the team above.
+     * The cascade stops at clinched teams or when a team can catch the one above.
+     *
+     * @param list<StandingsRow> $standings Standings data sorted by games back ASC
+     * @return array<int, true> Map of array indexes that are bottom-locked
+     */
+    public function getBottomLockedIndexes(array $standings): array
+    {
+        $count = count($standings);
+        /** @var array<int, true> $locked */
+        $locked = [];
+
+        if ($this->isSeasonOver($standings)) {
+            foreach ($standings as $index => $team) {
+                if (!self::hasClinchStatus($team)) {
+                    $locked[$index] = true;
+                }
+            }
+
+            return $locked;
+        }
+
+        // During season: cascade from bottom, stop at clinched teams
+        for ($i = $count - 1; $i >= 1; $i--) {
+            if (self::hasClinchStatus($standings[$i])) {
+                break;
+            }
+
+            $maxPossibleWins = $standings[$i]['wins'] + $standings[$i]['games_unplayed'];
+            if ($maxPossibleWins < $standings[$i - 1]['wins']) {
+                $locked[$i] = true;
+            } else {
+                break;
+            }
+        }
+
+        return $locked;
+    }
+
+    /**
+     * Check if the season is over (all teams have 0 games remaining)
+     *
+     * @param list<StandingsRow> $standings Standings data
+     */
+    private function isSeasonOver(array $standings): bool
+    {
+        foreach ($standings as $team) {
+            if ($team['games_unplayed'] > 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if a team has any clinch status (playoffs, division, conference, or league)
+     *
+     * @param StandingsRow $team Team standings data
+     */
+    public static function hasClinchStatus(array $team): bool
+    {
+        return $team['clinched_league'] === 1
+            || $team['clinched_conference'] === 1
+            || $team['clinched_division'] === 1
+            || $team['clinched_playoffs'] === 1;
+    }
+
+    /**
+     * Get the CSS class for a team's clinch tier
+     *
+     * @param StandingsRow $team Team standings data
+     * @return string CSS class name, or empty string if not clinched
+     */
+    public static function getClinchTierClass(array $team): string
+    {
+        if ($team['clinched_league'] === 1) {
+            return 'clinch-league';
+        }
+
+        if ($team['clinched_conference'] === 1) {
+            return 'clinch-conference';
+        }
+
+        if ($team['clinched_division'] === 1) {
+            return 'clinch-division';
+        }
+
+        if ($team['clinched_playoffs'] === 1) {
+            return 'clinch-playoffs';
+        }
+
+        return '';
+    }
+
+    /**
+     * Compute clinch tier score for a team (higher = better clinch status)
+     *
+     * @param array{clinched_league: int, clinched_conference: int, clinched_division: int, clinched_playoffs: int, ...} $team
+     */
+    public static function getClinchTierScore(array $team): int
+    {
+        return $team['clinched_league'] * 4
+            + $team['clinched_conference'] * 3
+            + $team['clinched_division'] * 2
+            + $team['clinched_playoffs'];
+    }
+}

--- a/ibl5/classes/Standings/StandingsTiebreakerResolver.php
+++ b/ibl5/classes/Standings/StandingsTiebreakerResolver.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Standings;
+
+/**
+ * StandingsTiebreakerResolver - H2H tiebreaker logic for standings groups
+ *
+ * Resolves groups of teams tied on GB, clinch tier, and wins by sorting each
+ * group by aggregate head-to-head win percentage.
+ *
+ * @phpstan-import-type StandingsRow from \Standings\Contracts\StandingsRepositoryInterface
+ */
+final class StandingsTiebreakerResolver
+{
+    /**
+     * Resolve H2H tie-breaking for groups of teams tied on GB, clinch tier, and wins
+     *
+     * Walks the sorted standings list, identifies groups of teams with the same
+     * games-back, clinch tier, and wins, then sorts each group by aggregate H2H
+     * win percentage (best H2H first for standings).
+     *
+     * @param list<StandingsRow> $teams Standings sorted by SQL (GB, clinch, wins)
+     * @param array<int, array<int, array{wins: int, losses: int}>>|null $seriesMatrix Pre-loaded H2H series matrix
+     * @return list<StandingsRow> Re-sorted standings with H2H tie-breaking applied
+     */
+    public function resolveH2HTiedGroups(array $teams, ?array $seriesMatrix): array
+    {
+        if (count($teams) <= 1 || $seriesMatrix === null || $seriesMatrix === []) {
+            return $teams;
+        }
+
+        /** @var list<StandingsRow> $result */
+        $result = [];
+        $count = count($teams);
+        $groupStart = 0;
+
+        for ($i = 1; $i <= $count; $i++) {
+            if ($i < $count
+                && $teams[$i]['gamesBack'] === $teams[$groupStart]['gamesBack']
+                && StandingsRowView::getClinchTierScore($teams[$i]) === StandingsRowView::getClinchTierScore($teams[$groupStart])
+                && $teams[$i]['wins'] === $teams[$groupStart]['wins']
+            ) {
+                continue;
+            }
+
+            $group = array_slice($teams, $groupStart, $i - $groupStart);
+
+            if (count($group) > 1) {
+                $group = $this->sortTiedGroup($group, $seriesMatrix);
+            }
+
+            array_push($result, ...$group);
+            $groupStart = $i;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Sort a tied group by aggregate H2H win percentage (best first for standings)
+     *
+     * For each team, computes aggregate H2H record against all other teams in the
+     * group, then sorts descending by H2H win pct.
+     *
+     * @param list<StandingsRow> $group Teams tied on GB/clinch/wins
+     * @param array<int, array<int, array{wins: int, losses: int}>> $seriesMatrix Pre-loaded H2H series matrix
+     * @return list<StandingsRow> Sorted group (best H2H first)
+     */
+    private function sortTiedGroup(array $group, array $seriesMatrix): array
+    {
+        $tids = array_map(static fn (array $t): int => $t['teamid'], $group);
+        $matrix = $seriesMatrix;
+
+        $aggregateH2HPct = AggregateTiebreaker::computeAggregateH2HPcts(
+            $tids,
+            /** @return array{wins: int, losses: int} */
+            static fn (int $tid, int $oppTid): array => [
+                'wins' => $matrix[$tid][$oppTid]['wins'] ?? 0,
+                'losses' => $matrix[$tid][$oppTid]['losses'] ?? 0,
+            ],
+        );
+
+        usort($group, static function (array $a, array $b) use ($aggregateH2HPct): int {
+            return $aggregateH2HPct[$b['teamid']] <=> $aggregateH2HPct[$a['teamid']];
+        });
+
+        return $group;
+    }
+}

--- a/ibl5/classes/Standings/StandingsView.php
+++ b/ibl5/classes/Standings/StandingsView.php
@@ -8,7 +8,6 @@ use League\League;
 use SeriesRecords\Contracts\SeriesRecordsServiceInterface;
 use Standings\Contracts\StandingsRepositoryInterface;
 use Standings\Contracts\StandingsViewInterface;
-use UI\TeamCellHelper;
 
 /**
  * StandingsView - HTML rendering for team standings
@@ -39,6 +38,8 @@ class StandingsView implements StandingsViewInterface
     /** @var array<int, array<int, array{wins: int, losses: int}>>|null Pre-loaded H2H series matrix */
     private ?array $seriesMatrix = null;
 
+    private readonly StandingsRowView $rowView;
+
     /**
      * Constructor
      *
@@ -54,6 +55,7 @@ class StandingsView implements StandingsViewInterface
         $this->repository = $repository;
         $this->seasonYear = $seasonYear;
         $this->seriesRecordsService = $seriesRecordsService;
+        $this->rowView = new StandingsRowView();
     }
 
     /**
@@ -183,7 +185,7 @@ class StandingsView implements StandingsViewInterface
             }
 
             // 2. Clinch priority DESC
-            $clinchCmp = $this->getClinchTierScore($b) <=> $this->getClinchTierScore($a);
+            $clinchCmp = StandingsRowView::getClinchTierScore($b) <=> StandingsRowView::getClinchTierScore($a);
             if ($clinchCmp !== 0) {
                 return $clinchCmp;
             }
@@ -304,222 +306,15 @@ class StandingsView implements StandingsViewInterface
     private function renderRows(array $standings): string
     {
         $html = '';
-        $bottomLocked = $this->getBottomLockedIndexes($standings);
+        $bottomLocked = $this->rowView->getBottomLockedIndexes($standings);
 
         foreach ($standings as $index => $team) {
             $isBottomLocked = isset($bottomLocked[$index]);
-            $html .= $this->renderTeamRow($team, $isBottomLocked);
+            $teamId = $team['teamid'];
+            $html .= $this->rowView->renderTeamRow($team, $isBottomLocked, $this->allStreakData[$teamId] ?? null, $this->allPythagoreanStats[$teamId] ?? null);
         }
 
         return $html;
-    }
-
-    /**
-     * Render a single team row
-     *
-     * @param StandingsRow $team Team standings data
-     * @param bool $isBottomLocked Whether this team is mathematically locked at the bottom
-     * @return string HTML for team row
-     */
-    private function renderTeamRow(array $team, bool $isBottomLocked = false): string
-    {
-        $teamId = $team['teamid'];
-        $teamName = $this->formatTeamName($team);
-        $streakData = $this->allStreakData[$teamId] ?? null;
-
-        $lastWin = $streakData['last_win'] ?? 0;
-        $lastLoss = $streakData['last_loss'] ?? 0;
-        $streak = $streakData['streak'] ?? 0;
-        $streakSortKey = ($streakData['streak_type'] ?? '') === 'W' ? $streak : -$streak;
-        $rating = $streakData['ranking'] ?? 0;
-        $sos = $streakData['sos'] ?? 0;
-        $remainingSos = $streakData['remaining_sos'] ?? 0;
-
-        // Get Pythagorean win percentage from pre-loaded data
-        $pythagoreanStats = $this->allPythagoreanStats[$teamId] ?? null;
-        $pythagoreanPct = '0.000';
-        if ($pythagoreanStats !== null) {
-            $pythagoreanPct = \BasketballStats\StatsFormatter::calculatePythagoreanWinPercentage(
-                $pythagoreanStats['pointsScored'],
-                $pythagoreanStats['pointsAllowed']
-            );
-        }
-
-        $leagueRecord = $team['league_record'];
-        $pct = $team['pct'];
-        $gamesBack = $team['gamesBack'];
-        $magicNumber = $team['magicNumber'];
-        $gamesUnplayed = $team['games_unplayed'];
-        $confRecord = $team['conf_record'];
-        $divRecord = $team['div_record'];
-        $homeRecord = $team['home_record'];
-        $awayRecord = $team['away_record'];
-        $homeGames = $team['homeGames'];
-        $awayGames = $team['awayGames'];
-
-        // Build CSS class for row highlighting
-        $rowClass = '';
-        if ($isBottomLocked) {
-            $rowClass = 'bottom-locked';
-        } else {
-            $rowClass = $this->getClinchTierClass($team);
-        }
-
-        ob_start();
-        ?>
-        <tr data-team-id="<?= \Security\HtmlSanitizer::e($teamId); ?>"<?= $rowClass !== '' ? ' class="' . \Security\HtmlSanitizer::e($rowClass) . '"' : ''; ?>>
-            <?= TeamCellHelper::renderTeamCell($teamId, $team['team_name'], $team['color1'], $team['color2'], 'sticky-col', '', $teamName) ?>
-            <td><?= \Security\HtmlSanitizer::e($leagueRecord); ?></td>
-            <td><?= \BasketballStats\StatsFormatter::formatWithDecimals((float)$pct, 3); ?></td>
-            <td><?= \Security\HtmlSanitizer::e($pythagoreanPct); ?></td>
-            <td><?= \Security\HtmlSanitizer::e($gamesBack); ?></td>
-            <td><?= \Security\HtmlSanitizer::e($magicNumber); ?></td>
-            <td><?= \Security\HtmlSanitizer::e($gamesUnplayed); ?></td>
-            <td><?= \Security\HtmlSanitizer::e($confRecord); ?></td>
-            <td><?= \Security\HtmlSanitizer::e($divRecord); ?></td>
-            <td><?= \Security\HtmlSanitizer::e($homeRecord); ?></td>
-            <td><?= \Security\HtmlSanitizer::e($awayRecord); ?></td>
-            <td><?= \Security\HtmlSanitizer::e($homeGames); ?></td>
-            <td><?= \Security\HtmlSanitizer::e($awayGames); ?></td>
-            <td><?= \Security\HtmlSanitizer::e($lastWin); ?>-<?= \Security\HtmlSanitizer::e($lastLoss); ?></td>
-            <td sorttable_customkey="<?= \Security\HtmlSanitizer::e($streakSortKey); ?>"><?= \Security\HtmlSanitizer::e($streakData['streak_type'] ?? ''); ?> <?= \Security\HtmlSanitizer::e($streak); ?></td>
-            <td><span class="ibl-stat-highlight"><?= \Security\HtmlSanitizer::e($rating); ?></span></td>
-            <td><?= \BasketballStats\StatsFormatter::formatWithDecimals((float)$sos, 3); ?></td>
-            <td><?= \BasketballStats\StatsFormatter::formatWithDecimals((float)$remainingSos, 3); ?></td>
-        </tr>
-        <?php
-        return (string) ob_get_clean();
-    }
-
-    /**
-     * Format team name with clinched indicator
-     *
-     * Priority: W (league) > Z (conference) > Y (division) > X (playoffs)
-     *
-     * @param StandingsRow $team Team standings data
-     * @return string Formatted team name with clinched prefix if applicable
-     */
-    private function formatTeamName(array $team): string
-    {
-        $teamName = \Security\HtmlSanitizer::safeHtmlOutput($team['team_name']);
-
-        if ($team['clinched_league'] === 1) {
-            return '<span class="ibl-clinched-indicator">W</span>-' . $teamName;
-        }
-
-        if ($team['clinched_conference'] === 1) {
-            return '<span class="ibl-clinched-indicator">Z</span>-' . $teamName;
-        }
-
-        if ($team['clinched_division'] === 1) {
-            return '<span class="ibl-clinched-indicator">Y</span>-' . $teamName;
-        }
-
-        if ($team['clinched_playoffs'] === 1) {
-            return '<span class="ibl-clinched-indicator">X</span>-' . $teamName;
-        }
-
-        return $teamName;
-    }
-
-    /**
-     * Get the CSS class for a team's clinch tier
-     *
-     * @param StandingsRow $team Team standings data
-     * @return string CSS class name, or empty string if not clinched
-     */
-    private function getClinchTierClass(array $team): string
-    {
-        if ($team['clinched_league'] === 1) {
-            return 'clinch-league';
-        }
-
-        if ($team['clinched_conference'] === 1) {
-            return 'clinch-conference';
-        }
-
-        if ($team['clinched_division'] === 1) {
-            return 'clinch-division';
-        }
-
-        if ($team['clinched_playoffs'] === 1) {
-            return 'clinch-playoffs';
-        }
-
-        return '';
-    }
-
-    /**
-     * Determine which teams are eliminated (bottom-locked) in standings
-     *
-     * When the season is over (all gamesUnplayed = 0), any team without a clinch
-     * flag is eliminated. During the season, cascades from the bottom: a team is
-     * locked if even winning all remaining games can't catch the team above.
-     * The cascade stops at clinched teams or when a team can catch the one above.
-     *
-     * @param list<StandingsRow> $standings Standings data sorted by games back ASC
-     * @return array<int, true> Map of array indexes that are bottom-locked
-     */
-    private function getBottomLockedIndexes(array $standings): array
-    {
-        $count = count($standings);
-        /** @var array<int, true> $locked */
-        $locked = [];
-
-        if ($this->isSeasonOver($standings)) {
-            foreach ($standings as $index => $team) {
-                if (!$this->hasClinchStatus($team)) {
-                    $locked[$index] = true;
-                }
-            }
-
-            return $locked;
-        }
-
-        // During season: cascade from bottom, stop at clinched teams
-        for ($i = $count - 1; $i >= 1; $i--) {
-            if ($this->hasClinchStatus($standings[$i])) {
-                break;
-            }
-
-            $maxPossibleWins = $standings[$i]['wins'] + $standings[$i]['games_unplayed'];
-            if ($maxPossibleWins < $standings[$i - 1]['wins']) {
-                $locked[$i] = true;
-            } else {
-                break;
-            }
-        }
-
-        return $locked;
-    }
-
-    /**
-     * Check if the season is over (all teams have 0 games remaining)
-     *
-     * @param list<StandingsRow> $standings Standings data
-     */
-    private function isSeasonOver(array $standings): bool
-    {
-        foreach ($standings as $team) {
-            if ($team['games_unplayed'] > 0) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Compute clinch tier score for a team (higher = better clinch status)
-     *
-     * @param array{clinched_league: int, clinched_conference: int, clinched_division: int, clinched_playoffs: int, ...} $team
-     */
-    private function getClinchTierScore(array $team): int
-    {
-        return $team['clinched_league'] * 4
-            + $team['clinched_conference'] * 3
-            + $team['clinched_division'] * 2
-            + $team['clinched_playoffs'];
     }
 
     /**
@@ -546,7 +341,7 @@ class StandingsView implements StandingsViewInterface
         for ($i = 1; $i <= $count; $i++) {
             if ($i < $count
                 && $teams[$i]['gamesBack'] === $teams[$groupStart]['gamesBack']
-                && $this->getClinchTierScore($teams[$i]) === $this->getClinchTierScore($teams[$groupStart])
+                && StandingsRowView::getClinchTierScore($teams[$i]) === StandingsRowView::getClinchTierScore($teams[$groupStart])
                 && $teams[$i]['wins'] === $teams[$groupStart]['wins']
             ) {
                 continue;
@@ -595,16 +390,4 @@ class StandingsView implements StandingsViewInterface
         return $group;
     }
 
-    /**
-     * Check if a team has any clinch status (playoffs, division, conference, or league)
-     *
-     * @param StandingsRow $team Team standings data
-     */
-    private function hasClinchStatus(array $team): bool
-    {
-        return $team['clinched_league'] === 1
-            || $team['clinched_conference'] === 1
-            || $team['clinched_division'] === 1
-            || $team['clinched_playoffs'] === 1;
-    }
 }

--- a/ibl5/classes/Standings/StandingsView.php
+++ b/ibl5/classes/Standings/StandingsView.php
@@ -39,6 +39,7 @@ class StandingsView implements StandingsViewInterface
     private ?array $seriesMatrix = null;
 
     private readonly StandingsRowView $rowView;
+    private readonly StandingsTiebreakerResolver $tiebreakerResolver;
 
     /**
      * Constructor
@@ -56,6 +57,7 @@ class StandingsView implements StandingsViewInterface
         $this->seasonYear = $seasonYear;
         $this->seriesRecordsService = $seriesRecordsService;
         $this->rowView = new StandingsRowView();
+        $this->tiebreakerResolver = new StandingsTiebreakerResolver();
     }
 
     /**
@@ -139,7 +141,7 @@ class StandingsView implements StandingsViewInterface
      */
     private function renderStandingsTable(string $region, string $groupingType, array $standings): string
     {
-        $standings = $this->resolveH2HTiedGroups($standings);
+        $standings = $this->tiebreakerResolver->resolveH2HTiedGroups($standings, $this->seriesMatrix);
 
         $html = $this->renderHeader($region, $groupingType);
         $html .= $this->renderRows($standings);
@@ -317,77 +319,5 @@ class StandingsView implements StandingsViewInterface
         return $html;
     }
 
-    /**
-     * Resolve H2H tie-breaking for groups of teams tied on GB, clinch tier, and wins
-     *
-     * Walks the sorted standings list, identifies groups of teams with the same
-     * games-back, clinch tier, and wins, then sorts each group by aggregate H2H
-     * win percentage (best H2H first for standings).
-     *
-     * @param list<StandingsRow> $teams Standings sorted by SQL (GB, clinch, wins)
-     * @return list<StandingsRow> Re-sorted standings with H2H tie-breaking applied
-     */
-    private function resolveH2HTiedGroups(array $teams): array
-    {
-        if (count($teams) <= 1 || $this->seriesMatrix === null || $this->seriesMatrix === []) {
-            return $teams;
-        }
-
-        /** @var list<StandingsRow> $result */
-        $result = [];
-        $count = count($teams);
-        $groupStart = 0;
-
-        for ($i = 1; $i <= $count; $i++) {
-            if ($i < $count
-                && $teams[$i]['gamesBack'] === $teams[$groupStart]['gamesBack']
-                && StandingsRowView::getClinchTierScore($teams[$i]) === StandingsRowView::getClinchTierScore($teams[$groupStart])
-                && $teams[$i]['wins'] === $teams[$groupStart]['wins']
-            ) {
-                continue;
-            }
-
-            $group = array_slice($teams, $groupStart, $i - $groupStart);
-
-            if (count($group) > 1) {
-                $group = $this->sortTiedGroup($group);
-            }
-
-            array_push($result, ...$group);
-            $groupStart = $i;
-        }
-
-        return $result;
-    }
-
-    /**
-     * Sort a tied group by aggregate H2H win percentage (best first for standings)
-     *
-     * For each team, computes aggregate H2H record against all other teams in the
-     * group, then sorts descending by H2H win pct.
-     *
-     * @param list<StandingsRow> $group Teams tied on GB/clinch/wins
-     * @return list<StandingsRow> Sorted group (best H2H first)
-     */
-    private function sortTiedGroup(array $group): array
-    {
-        $tids = array_map(static fn (array $t): int => $t['teamid'], $group);
-        $matrix = $this->seriesMatrix;
-
-        $aggregateH2HPct = AggregateTiebreaker::computeAggregateH2HPcts(
-            $tids,
-            /** @return array{wins: int, losses: int} */
-            static fn (int $tid, int $oppTid): array => [
-                'wins' => $matrix[$tid][$oppTid]['wins'] ?? 0,
-                'losses' => $matrix[$tid][$oppTid]['losses'] ?? 0,
-            ],
-        );
-
-        usort($group, static function (array $a, array $b) use ($aggregateH2HPct): int {
-            return $aggregateH2HPct[$b['teamid']] <=> $aggregateH2HPct[$a['teamid']];
-        });
-
-        return $group;
-    }
-
 }
+

--- a/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
@@ -280,7 +280,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Est. effort:** M
 **Risk if untouched:** Every new standings display variant inflates the view.
 **Provenance:** Seeded 2026-07-24 — ground-truth audit hot-file scan.
-**Status:** Implemented — StandingsRowView + StandingsTiebreakerResolver extracted from StandingsView (2026-08-08, PR pending).
+**Status:** Implemented — StandingsRowView + StandingsTiebreakerResolver extracted from StandingsView (2026-08-08, #1795).
 
 **Table evidence (2026-08-08):** StandingsView 610 LOC — per-division block renderers. Extract per-division renderer collaborators; golden-master pin. (1.32 resolved — can now plan independently.)
 

--- a/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
@@ -273,6 +273,17 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Provenance:** Seeded 2026-07-24 — ground-truth audit hot-file scan.
 **Status:** Implemented 2026-07-26 — `SlotAssignmentResolver` + `SlotAssignmentResolverInterface` extracted; `buildAllSnapshots()` delegates via `resolveSlotSettings()`. Slot resolution now lives in `ibl5/classes/SavedDepthChart/SlotAssignmentResolver.php` behind `Contracts/SlotAssignmentResolverInterface.php`, injected into `SavedDepthChartService` with a nullable default. Behavior byte-identical; pinned by `testBuildAllSnapshots*` characterization tests plus `ibl5/tests/SavedDepthChart/SlotAssignmentResolverTest.php`.
 
+### 1.35 StandingsView — Per-Division Block Renderer (610 LOC)
+**Location:** `ibl5/classes/Standings/StandingsView.php` (610 lines)
+**Problem:** One view renders per-division standings blocks, tiebreaker panels, and playoff-seeding tables for multiple page variants.
+**Suggested direction:** Extract per-division renderer collaborators; golden-master pin. (1.32 resolved 2026-08-08 — can plan independently; no longer a "same chunk" coupling.)
+**Est. effort:** M
+**Risk if untouched:** Every new standings display variant inflates the view.
+**Provenance:** Seeded 2026-07-24 — ground-truth audit hot-file scan.
+**Status:** Implemented — StandingsRowView + StandingsTiebreakerResolver extracted from StandingsView (2026-08-08, PR pending).
+
+**Table evidence (2026-08-08):** StandingsView 610 LOC — per-division block renderers. Extract per-division renderer collaborators; golden-master pin. (1.32 resolved — can now plan independently.)
+
 ### 1.36 FreeAgencyView — Offer-Table / Form / Decision-Panel Renderers (590 LOC)
 **Location:** `ibl5/classes/FreeAgency/FreeAgencyView.php` (590 lines)
 **Problem:** One view renders the offer table, offer form, and decision panels for multiple free-agency page states in a single class.

--- a/ibl5/docs/backlog/maintenance-backlog.md
+++ b/ibl5/docs/backlog/maintenance-backlog.md
@@ -61,7 +61,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 
 **Automouse audit (verified 2026-06-20):**
 
-> ✅ resolved (29): 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.19, 1.20, 1.21, 1.23, 1.24, 1.27, 1.28, 1.29, 1.31, 1.32, 1.34, 1.36 — evidence in [archive](archive/maintenance-backlog-archive.md)
+> ✅ resolved (30): 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.19, 1.20, 1.21, 1.23, 1.24, 1.27, 1.28, 1.29, 1.31, 1.32, 1.34, 1.35, 1.36 — evidence in [archive](archive/maintenance-backlog-archive.md)
 
 | # | Status | Automouse | Evidence / note |
 |---|--------|-----------|-----------------|
@@ -71,7 +71,6 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 | 1.26 | ⬜ Open | 🟩 | BugReportRepository 546 LOC — 24 methods spanning claim/lease/transition state-machine + reporter-profile + queue queries. Split by query group; green-green with DB-integration pins. |
 | 1.30 | ⬜ Open | 🟩 | TradingService 516 LOC — page-data orchestration + offer-grouping + future-salary calc. Extract offer-grouping and salary collaborators; green-green. |
 | 1.33 | ⬜ Open | 🟩 | Player 671 LOC — typed-getter accumulation. Extract per-domain typed-getter groups (contract, stats, identity); green-green. |
-| 1.35 | ⬜ Open | 🟩 | StandingsView 610 LOC — per-division block renderers. Extract per-division renderer collaborators; golden-master pin. (1.32 resolved — can now plan independently.) |
 
 > **Note:** `BaseMysqliRepository.php` (602 LOC) is the 18th hot file but is tracked under **2.29** (global-namespace elimination sweep) and is not seeded as a standalone god-class item here.
 
@@ -128,14 +127,6 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 **Suggested direction:** Extract per-domain typed-getter groups (contract, stats, identity) into focused value-object collaborators; keep `Player` as the root entity.
 **Est. effort:** M
 **Risk if untouched:** Every new player attribute inflates one file; getter search spans the entire class.
-**Provenance:** Seeded 2026-07-24 — ground-truth audit hot-file scan.
-
-### 1.35 StandingsView — Per-Division Block Renderer (610 LOC)
-**Location:** `ibl5/classes/Standings/StandingsView.php` (610 lines)
-**Problem:** One view renders per-division standings blocks, tiebreaker panels, and playoff-seeding tables for multiple page variants.
-**Suggested direction:** Extract per-division renderer collaborators; golden-master pin. (1.32 resolved 2026-08-08 — can plan independently; no longer a "same chunk" coupling.)
-**Est. effort:** M
-**Risk if untouched:** Every new standings display variant inflates the view.
 **Provenance:** Seeded 2026-07-24 — ground-truth audit hot-file scan.
 
 ## Axis 2: Module Structure Inconsistency

--- a/ibl5/phpstan-rules/RequireEscapedOutputRule.php
+++ b/ibl5/phpstan-rules/RequireEscapedOutputRule.php
@@ -126,6 +126,7 @@ final class RequireEscapedOutputRule implements Rule
         'LeagueControlPanel/LeagueControlPanelView.php',
         'NextSim/NextSimView.php',
         'RookieOption/RookieOptionView.php',
+        'Standings/StandingsRowView.php',
         'Standings/StandingsView.php',
         'Team/TeamView.php',
         'TransactionHistory/TransactionHistoryView.php',

--- a/ibl5/tests/PHPStanRules/Fixtures/classes/Standings/StandingsRowView.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/classes/Standings/StandingsRowView.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+$unsafeVariable = 'test';
+
+?>
+<html>
+<body>
+    <?= $unsafeVariable ?>
+</body>
+</html>

--- a/ibl5/tests/PHPStanRules/RequireEscapedOutputRuleTest.php
+++ b/ibl5/tests/PHPStanRules/RequireEscapedOutputRuleTest.php
@@ -102,4 +102,9 @@ final class RequireEscapedOutputRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testStandingsRowViewIsZeroFloor(): void
+    {
+        $this->analyse([__DIR__ . '/Fixtures/classes/Standings/StandingsRowView.php'], [['Unescaped output in View. Wrap the expression in HtmlSanitizer::e() (or another whitelisted safe helper), or cast it to (int)/(float)/(bool) if it is numeric.', 10]]);
+    }
 }

--- a/ibl5/tests/Standings/StandingsViewGoldenMasterTest.php
+++ b/ibl5/tests/Standings/StandingsViewGoldenMasterTest.php
@@ -7,6 +7,7 @@ namespace Tests\Standings;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use SeriesRecords\SeriesRecordsService;
+use Standings\StandingsRowView;
 use Standings\StandingsView;
 use Standings\Contracts\StandingsRepositoryInterface;
 
@@ -21,6 +22,7 @@ use Standings\Contracts\StandingsRepositoryInterface;
  * separate future plan.
  *
  * @covers \Standings\StandingsView
+ * @phpstan-import-type StandingsRow from \Standings\Contracts\StandingsRepositoryInterface
  */
 #[AllowMockObjectsWithoutExpectations]
 class StandingsViewGoldenMasterTest extends TestCase
@@ -145,7 +147,7 @@ class StandingsViewGoldenMasterTest extends TestCase
         ];
     }
 
-    /** @return array<string, mixed> StandingsRow for Team A (teamid=1), tied on GB/wins/clinch-tier — for H2H tiebreak tests */
+    /** @return StandingsRow Team A (teamid=1), tied on GB/wins/clinch-tier — for H2H tiebreak tests */
     private function tiedTeamA(): array
     {
         return [
@@ -172,7 +174,7 @@ class StandingsViewGoldenMasterTest extends TestCase
         ];
     }
 
-    /** @return array<string, mixed> StandingsRow for Team B (teamid=2), tied on GB/wins/clinch-tier — for H2H tiebreak tests */
+    /** @return StandingsRow Team B (teamid=2), tied on GB/wins/clinch-tier — for H2H tiebreak tests */
     private function tiedTeamB(): array
     {
         return [
@@ -199,7 +201,7 @@ class StandingsViewGoldenMasterTest extends TestCase
         ];
     }
 
-    /** @return array<string, mixed> StandingsRow for Team C (teamid=3), tied on GB/wins/clinch-tier — for H2H tiebreak tests */
+    /** @return StandingsRow Team C (teamid=3), tied on GB/wins/clinch-tier — for H2H tiebreak tests */
     private function tiedTeamC(): array
     {
         return [
@@ -458,5 +460,21 @@ class StandingsViewGoldenMasterTest extends TestCase
         $this->assertStringContainsString('</table>', $html);
         $this->assertStringContainsString('<thead>', $html);
         $this->assertSnapshotMatches($html, 'renderRegion-empty.html');
+    }
+
+    public function testStandingsRowViewNegativePath(): void
+    {
+        // All clinch flags = 0 (via tiedTeamA, which has all four flags unset).
+        // getClinchTierClass must return '' and hasClinchStatus must return false.
+        $noClinchedTeam = $this->tiedTeamA();
+
+        $this->assertSame('', StandingsRowView::getClinchTierClass($noClinchedTeam), 'No clinch flags → empty CSS class');
+        $this->assertFalse(StandingsRowView::hasClinchStatus($noClinchedTeam), 'No clinch flags → hasClinchStatus returns false');
+    }
+
+    public function testStandingsRowViewGetBottomLockedIndexesEmptyInput(): void
+    {
+        $rowView = new StandingsRowView();
+        $this->assertSame([], $rowView->getBottomLockedIndexes([]), 'Empty standings → no bottom-locked indexes');
     }
 }

--- a/ibl5/tests/Standings/StandingsViewGoldenMasterTest.php
+++ b/ibl5/tests/Standings/StandingsViewGoldenMasterTest.php
@@ -145,18 +145,104 @@ class StandingsViewGoldenMasterTest extends TestCase
         ];
     }
 
+    /** @return array<string, mixed> StandingsRow for Team A (teamid=1), tied on GB/wins/clinch-tier — for H2H tiebreak tests */
+    private function tiedTeamA(): array
+    {
+        return [
+            'teamid' => 1,
+            'team_name' => 'Team Alpha',
+            'league_record' => '50-32',
+            'pct' => '0.610',
+            'gamesBack' => '0.0',
+            'magicNumber' => 0,
+            'games_unplayed' => 0,
+            'conf_record' => '30-16',
+            'div_record' => '10-4',
+            'home_record' => '28-14',
+            'away_record' => '22-18',
+            'homeGames' => 42,
+            'awayGames' => 40,
+            'clinched_conference' => 0,
+            'clinched_division' => 0,
+            'clinched_playoffs' => 0,
+            'clinched_league' => 0,
+            'wins' => 50,
+            'color1' => '000080',
+            'color2' => 'FFFFFF',
+        ];
+    }
+
+    /** @return array<string, mixed> StandingsRow for Team B (teamid=2), tied on GB/wins/clinch-tier — for H2H tiebreak tests */
+    private function tiedTeamB(): array
+    {
+        return [
+            'teamid' => 2,
+            'team_name' => 'Team Beta',
+            'league_record' => '50-32',
+            'pct' => '0.610',
+            'gamesBack' => '0.0',
+            'magicNumber' => 0,
+            'games_unplayed' => 0,
+            'conf_record' => '30-16',
+            'div_record' => '10-4',
+            'home_record' => '28-14',
+            'away_record' => '22-18',
+            'homeGames' => 42,
+            'awayGames' => 40,
+            'clinched_conference' => 0,
+            'clinched_division' => 0,
+            'clinched_playoffs' => 0,
+            'clinched_league' => 0,
+            'wins' => 50,
+            'color1' => '800000',
+            'color2' => 'FFFFFF',
+        ];
+    }
+
+    /** @return array<string, mixed> StandingsRow for Team C (teamid=3), tied on GB/wins/clinch-tier — for H2H tiebreak tests */
+    private function tiedTeamC(): array
+    {
+        return [
+            'teamid' => 3,
+            'team_name' => 'Team Charlie',
+            'league_record' => '50-32',
+            'pct' => '0.610',
+            'gamesBack' => '0.0',
+            'magicNumber' => 0,
+            'games_unplayed' => 0,
+            'conf_record' => '30-16',
+            'div_record' => '10-4',
+            'home_record' => '28-14',
+            'away_record' => '22-18',
+            'homeGames' => 42,
+            'awayGames' => 40,
+            'clinched_conference' => 0,
+            'clinched_division' => 0,
+            'clinched_playoffs' => 0,
+            'clinched_league' => 0,
+            'wins' => 50,
+            'color1' => '008000',
+            'color2' => 'FFFFFF',
+        ];
+    }
+
     /**
      * Build a fresh StandingsView with the divergence fixture wired in.
      *
      * @param list<array<string, mixed>> $regionEasternRows Rows getStandingsByRegion('Eastern') returns
+     * @param list<array{self: int, opponent: int, wins: int, losses: int}> $seriesRecords Series records for H2H matrix
+     * @param list<array<string, mixed>>|null $bulkRows Override for getAllStandings() (null = default two-team fixture)
      */
-    private function buildView(array $regionEasternRows = []): StandingsView
-    {
+    private function buildView(
+        array $regionEasternRows = [],
+        array $seriesRecords = [],
+        ?array $bulkRows = null
+    ): StandingsView {
         $repo = $this->createMock(StandingsRepositoryInterface::class);
-        $repo->method('getAllStandings')->willReturn([$this->bulkTeamA(), $this->bulkTeamB()]);
+        $repo->method('getAllStandings')->willReturn($bulkRows ?? [$this->bulkTeamA(), $this->bulkTeamB()]);
         $repo->method('getAllStreakData')->willReturn([]);
         $repo->method('getAllPythagoreanStats')->willReturn([]);
-        $repo->method('getSeriesRecords')->willReturn([]);
+        $repo->method('getSeriesRecords')->willReturn($seriesRecords);
         $repo->method('getStandingsByRegion')->willReturnCallback(
             static fn (string $region): array => $region === 'Eastern' ? $regionEasternRows : []
         );
@@ -252,5 +338,125 @@ class StandingsViewGoldenMasterTest extends TestCase
         // Collapse guard — paths still diverge after the refactor
         // @phpstan-ignore method.alreadyNarrowedType (PHPStan narrows these to literal arrays after assertSame; the runtime divergence is what matters here)
         $this->assertNotSame($renderOrder, $regionOrder, 'Divergence guard: render() and renderRegion() must produce different Eastern row orders');
+    }
+
+    public function testRenderRegionAppliesH2HTiebreakToTiedGroup(): void
+    {
+        // Three teams genuinely tied: same gamesBack='0.0', same wins=50, same clinch tier (all 0).
+        // H2H records: C beats A 3-0, C beats B 3-0, A beats B 2-1.
+        // Aggregate H2H pcts: C=1.000, A=0.333, B=0.167 → strict total order → [3, 1, 2].
+        $seriesRecords = [
+            ['self' => 3, 'opponent' => 1, 'wins' => 3, 'losses' => 0],
+            ['self' => 1, 'opponent' => 3, 'wins' => 0, 'losses' => 3],
+            ['self' => 3, 'opponent' => 2, 'wins' => 3, 'losses' => 0],
+            ['self' => 2, 'opponent' => 3, 'wins' => 0, 'losses' => 3],
+            ['self' => 1, 'opponent' => 2, 'wins' => 2, 'losses' => 1],
+            ['self' => 2, 'opponent' => 1, 'wins' => 1, 'losses' => 2],
+        ];
+
+        // SQL order is [A=1, B=2, C=3]; H2H tiebreaker must reorder to [C=3, A=1, B=2]
+        $view = $this->buildView(
+            [$this->tiedTeamA(), $this->tiedTeamB(), $this->tiedTeamC()],
+            $seriesRecords
+        );
+        $html = $view->renderRegion('Eastern');
+
+        preg_match_all('/data-team-id="(\d+)"/', $html, $matches);
+        $teamOrder = array_map('intval', $matches[1]);
+
+        $this->assertSame([3, 1, 2], $teamOrder, 'H2H tiebreaker must place C (best aggregate record) first');
+        $this->assertSnapshotMatches($html, 'renderRegion-h2h-tiebreak.html');
+    }
+
+    public function testRenderRegionLeavesUntiedTeamsInSqlOrder(): void
+    {
+        // Teams share gamesBack='0.0' and clinch tier 0, but differ on wins — not a tied group.
+        // resolveH2HTiedGroups() is a no-op per group, so SQL order is preserved.
+        $seriesRecords = [
+            ['self' => 3, 'opponent' => 1, 'wins' => 3, 'losses' => 0],
+            ['self' => 1, 'opponent' => 3, 'wins' => 0, 'losses' => 3],
+            ['self' => 3, 'opponent' => 2, 'wins' => 3, 'losses' => 0],
+            ['self' => 2, 'opponent' => 3, 'wins' => 0, 'losses' => 3],
+            ['self' => 1, 'opponent' => 2, 'wins' => 2, 'losses' => 1],
+            ['self' => 2, 'opponent' => 1, 'wins' => 1, 'losses' => 2],
+        ];
+
+        $teamB49 = array_merge($this->tiedTeamB(), ['wins' => 49]);
+        $teamC48 = array_merge($this->tiedTeamC(), ['wins' => 48]);
+
+        $view = $this->buildView(
+            [$this->tiedTeamA(), $teamB49, $teamC48],
+            $seriesRecords
+        );
+        $html = $view->renderRegion('Eastern');
+
+        preg_match_all('/data-team-id="(\d+)"/', $html, $matches);
+        $teamOrder = array_map('intval', $matches[1]);
+
+        $this->assertSame([1, 2, 3], $teamOrder, 'Untied teams must stay in SQL-supplied order');
+    }
+
+    public function testRenderRegionMarksBottomLockedRowsMidSeason(): void
+    {
+        // Mid-season: Team A has games_unplayed=10, so isSeasonOver()=false → cascade branch runs.
+        // Team B: wins(30) + games_unplayed(5) = 35 < wins(50) of Team A → bottom-locked.
+        $teamA = array_merge($this->tiedTeamA(), ['wins' => 50, 'games_unplayed' => 10, 'gamesBack' => '0.0']);
+        $teamB = array_merge($this->tiedTeamB(), ['wins' => 30, 'games_unplayed' => 5, 'gamesBack' => '20.0']);
+
+        $view = $this->buildView([$teamA, $teamB]);
+        $html = $view->renderRegion('Eastern');
+
+        $this->assertStringContainsString('bottom-locked', $html, 'Trailing team must be marked bottom-locked');
+        $this->assertSnapshotMatches($html, 'renderRegion-bottom-locked.html');
+    }
+
+    public function testRenderRegionMarksNoRowsLockedWhenLeaderCatchable(): void
+    {
+        // Team B: wins(41) + games_unplayed(9) = 50, which equals Team A's wins(50).
+        // The lock condition is strict <, so equality means catchable → no bottom-locked row.
+        $teamA = array_merge($this->tiedTeamA(), ['wins' => 50, 'games_unplayed' => 10, 'gamesBack' => '0.0']);
+        $teamB = array_merge($this->tiedTeamB(), ['wins' => 41, 'games_unplayed' => 9, 'gamesBack' => '9.0']);
+
+        $view = $this->buildView([$teamA, $teamB]);
+        $html = $view->renderRegion('Eastern');
+
+        $this->assertStringNotContainsString('bottom-locked', $html, 'No team should be bottom-locked when leader is catchable');
+    }
+
+    public function testRenderRegionEmitsEveryClinchTierClass(): void
+    {
+        // Four teams, one per clinch tier. All games_unplayed=0 so isSeasonOver()=true.
+        // Every team must be clinched or the season-over branch marks it bottom-locked instead.
+        $leagueTeam   = array_merge($this->tiedTeamA(), ['clinched_league' => 1]);
+        $confTeam     = array_merge($this->tiedTeamB(), ['teamid' => 2, 'clinched_conference' => 1]);
+        $divTeam      = array_merge($this->tiedTeamC(), ['teamid' => 3, 'clinched_division' => 1]);
+        $playoffTeam  = array_merge($this->tiedTeamC(), [
+            'teamid' => 4,
+            'team_name' => 'Team Delta',
+            'color1' => '4B0082',
+            'clinched_playoffs' => 1,
+        ]);
+
+        $view = $this->buildView([$leagueTeam, $confTeam, $divTeam, $playoffTeam]);
+        $html = $view->renderRegion('Eastern');
+
+        $this->assertStringContainsString('clinch-league', $html, 'clinch-league class must be present');
+        $this->assertStringContainsString('clinch-conference', $html, 'clinch-conference class must be present');
+        $this->assertStringContainsString('clinch-division', $html, 'clinch-division class must be present');
+        $this->assertStringContainsString('clinch-playoffs', $html, 'clinch-playoffs class must be present');
+        $this->assertSnapshotMatches($html, 'renderRegion-clinch-tiers.html');
+    }
+
+    public function testRenderRegionWithNoTeamsStillEmitsTableStructure(): void
+    {
+        // buildView() with no args returns [] for Western; renderRegion must still emit a well-formed table.
+        $view = $this->buildView();
+        $html = $view->renderRegion('Western');
+
+        $this->assertNotEmpty($html, 'Output must be non-empty for an empty standings region');
+        $this->assertStringContainsString('<table', $html);
+        $this->assertStringContainsString('</table>', $html);
+        $this->assertStringContainsString('<thead>', $html);
+        $this->assertSnapshotMatches($html, 'renderRegion-empty.html');
     }
 }

--- a/ibl5/tests/Standings/StandingsViewGoldenMasterTest.php
+++ b/ibl5/tests/Standings/StandingsViewGoldenMasterTest.php
@@ -22,6 +22,7 @@ use Standings\Contracts\StandingsRepositoryInterface;
  * separate future plan.
  *
  * @covers \Standings\StandingsView
+ * @covers \Standings\StandingsTiebreakerResolver
  * @phpstan-import-type StandingsRow from \Standings\Contracts\StandingsRepositoryInterface
  */
 #[AllowMockObjectsWithoutExpectations]
@@ -476,5 +477,46 @@ class StandingsViewGoldenMasterTest extends TestCase
     {
         $rowView = new StandingsRowView();
         $this->assertSame([], $rowView->getBottomLockedIndexes([]), 'Empty standings → no bottom-locked indexes');
+    }
+
+    public function testTiebreakerResolverReturnsInputOrderOnEmptyMatrix(): void
+    {
+        $resolver = new \Standings\StandingsTiebreakerResolver();
+        $teams = [$this->tiedTeamA(), $this->tiedTeamB()];
+        $this->assertSame($teams, $resolver->resolveH2HTiedGroups($teams, []));
+    }
+
+    public function testTiebreakerResolverReturnsInputOrderOnNullMatrix(): void
+    {
+        $resolver = new \Standings\StandingsTiebreakerResolver();
+        $teams = [$this->tiedTeamA(), $this->tiedTeamB()];
+        $this->assertSame($teams, $resolver->resolveH2HTiedGroups($teams, null));
+    }
+
+    public function testTiebreakerResolverEmptyTeamListReturnsEmpty(): void
+    {
+        $resolver = new \Standings\StandingsTiebreakerResolver();
+        $matrix = [1 => [2 => ['wins' => 2, 'losses' => 0]]];
+        $this->assertSame([], $resolver->resolveH2HTiedGroups([], $matrix));
+    }
+
+    public function testTiebreakerResolverSingleTeamReturnsUnchanged(): void
+    {
+        $resolver = new \Standings\StandingsTiebreakerResolver();
+        $matrix = [1 => [2 => ['wins' => 2, 'losses' => 0]]];
+        $teams = [$this->tiedTeamA()];
+        $this->assertSame($teams, $resolver->resolveH2HTiedGroups($teams, $matrix));
+    }
+
+    public function testTiebreakerResolverHandlesMissingMatrixEntry(): void
+    {
+        // Team 1 has no entry for team 2 in the matrix — must exercise the ?? 0 fallbacks.
+        // Both aggregate pcts land at 0.0, PHP's stable sort preserves input order [1, 2].
+        $resolver = new \Standings\StandingsTiebreakerResolver();
+        $matrix = [1 => []];
+        $teams = [$this->tiedTeamA(), $this->tiedTeamB()];
+        $result = $resolver->resolveH2HTiedGroups($teams, $matrix);
+        $teamOrder = array_map(static fn (array $t): int => $t['teamid'], $result);
+        $this->assertSame([1, 2], $teamOrder, 'Missing matrix entry must fall back to 0 wins/losses and preserve input order');
     }
 }

--- a/ibl5/tests/Standings/__snapshots__/renderRegion-bottom-locked.html
+++ b/ibl5/tests/Standings/__snapshots__/renderRegion-bottom-locked.html
@@ -1,0 +1,66 @@
+        <h2 class="ibl-title">Eastern Conference</h2>
+        <div class="table-scroll-wrapper">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Eastern Conference Standings">
+        <table class="sortable ibl-data-table">
+            <thead>
+                <tr>
+                    <th class="sticky-col">Team</th>
+                    <th>W-L</th>
+                    <th>Win%</th>
+                    <th>Pyth<br>W-L%</th>
+                    <th>GB</th>
+                    <th>Magic<br>#</th>
+                    <th>Games<br>Left</th>
+                    <th>Conf.</th>
+                    <th>Div.</th>
+                    <th>Home</th>
+                    <th>Away</th>
+                    <th>Home<br>Played</th>
+                    <th>Away<br>Played</th>
+                    <th>Last 10<br>W-L</th>
+                    <th>Streak</th>
+                    <th>Power<br>Rank</th>
+                    <th>SOS</th>
+                    <th>Rem.<br>SOS</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr data-team-id="1">
+            <td class="ibl-team-cell--colored sticky-col" style="--team-cell-bg: #000080; --team-cell-color: #FFFFFF;"><a href="modules.php?name=Team&amp;op=team&amp;teamid=1" class="ibl-team-cell__name" aria-label="Team Alpha"><img src="images/logo/new1.png" alt="" class="ibl-team-cell__logo" width="24" height="24" loading="lazy"><span class="ibl-team-cell__text">Team Alpha</span></a></td>            <td>50-32</td>
+            <td>0.610</td>
+            <td>0.000</td>
+            <td>0.0</td>
+            <td>0</td>
+            <td>10</td>
+            <td>30-16</td>
+            <td>10-4</td>
+            <td>28-14</td>
+            <td>22-18</td>
+            <td>42</td>
+            <td>40</td>
+            <td>0-0</td>
+            <td sorttable_customkey="0"> 0</td>
+            <td><span class="ibl-stat-highlight">0</span></td>
+            <td>0.000</td>
+            <td>0.000</td>
+        </tr>
+                <tr data-team-id="2" class="bottom-locked">
+            <td class="ibl-team-cell--colored sticky-col" style="--team-cell-bg: #800000; --team-cell-color: #FFFFFF;"><a href="modules.php?name=Team&amp;op=team&amp;teamid=2" class="ibl-team-cell__name" aria-label="Team Beta"><img src="images/logo/new2.png" alt="" class="ibl-team-cell__logo" width="24" height="24" loading="lazy"><span class="ibl-team-cell__text">Team Beta</span></a></td>            <td>50-32</td>
+            <td>0.610</td>
+            <td>0.000</td>
+            <td>20.0</td>
+            <td>0</td>
+            <td>5</td>
+            <td>30-16</td>
+            <td>10-4</td>
+            <td>28-14</td>
+            <td>22-18</td>
+            <td>42</td>
+            <td>40</td>
+            <td>0-0</td>
+            <td sorttable_customkey="0"> 0</td>
+            <td><span class="ibl-stat-highlight">0</span></td>
+            <td>0.000</td>
+            <td>0.000</td>
+        </tr>
+        </tbody></table></div></div>

--- a/ibl5/tests/Standings/__snapshots__/renderRegion-clinch-tiers.html
+++ b/ibl5/tests/Standings/__snapshots__/renderRegion-clinch-tiers.html
@@ -1,0 +1,104 @@
+        <h2 class="ibl-title">Eastern Conference</h2>
+        <div class="table-scroll-wrapper">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Eastern Conference Standings">
+        <table class="sortable ibl-data-table">
+            <thead>
+                <tr>
+                    <th class="sticky-col">Team</th>
+                    <th>W-L</th>
+                    <th>Win%</th>
+                    <th>Pyth<br>W-L%</th>
+                    <th>GB</th>
+                    <th>Magic<br>#</th>
+                    <th>Games<br>Left</th>
+                    <th>Conf.</th>
+                    <th>Div.</th>
+                    <th>Home</th>
+                    <th>Away</th>
+                    <th>Home<br>Played</th>
+                    <th>Away<br>Played</th>
+                    <th>Last 10<br>W-L</th>
+                    <th>Streak</th>
+                    <th>Power<br>Rank</th>
+                    <th>SOS</th>
+                    <th>Rem.<br>SOS</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr data-team-id="1" class="clinch-league">
+            <td class="ibl-team-cell--colored sticky-col" style="--team-cell-bg: #000080; --team-cell-color: #FFFFFF;"><a href="modules.php?name=Team&amp;op=team&amp;teamid=1" class="ibl-team-cell__name" aria-label="Team Alpha"><img src="images/logo/new1.png" alt="" class="ibl-team-cell__logo" width="24" height="24" loading="lazy"><span class="ibl-team-cell__text"><span class="ibl-clinched-indicator">W</span>-Team Alpha</span></a></td>            <td>50-32</td>
+            <td>0.610</td>
+            <td>0.000</td>
+            <td>0.0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>30-16</td>
+            <td>10-4</td>
+            <td>28-14</td>
+            <td>22-18</td>
+            <td>42</td>
+            <td>40</td>
+            <td>0-0</td>
+            <td sorttable_customkey="0"> 0</td>
+            <td><span class="ibl-stat-highlight">0</span></td>
+            <td>0.000</td>
+            <td>0.000</td>
+        </tr>
+                <tr data-team-id="2" class="clinch-conference">
+            <td class="ibl-team-cell--colored sticky-col" style="--team-cell-bg: #800000; --team-cell-color: #FFFFFF;"><a href="modules.php?name=Team&amp;op=team&amp;teamid=2" class="ibl-team-cell__name" aria-label="Team Beta"><img src="images/logo/new2.png" alt="" class="ibl-team-cell__logo" width="24" height="24" loading="lazy"><span class="ibl-team-cell__text"><span class="ibl-clinched-indicator">Z</span>-Team Beta</span></a></td>            <td>50-32</td>
+            <td>0.610</td>
+            <td>0.000</td>
+            <td>0.0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>30-16</td>
+            <td>10-4</td>
+            <td>28-14</td>
+            <td>22-18</td>
+            <td>42</td>
+            <td>40</td>
+            <td>0-0</td>
+            <td sorttable_customkey="0"> 0</td>
+            <td><span class="ibl-stat-highlight">0</span></td>
+            <td>0.000</td>
+            <td>0.000</td>
+        </tr>
+                <tr data-team-id="3" class="clinch-division">
+            <td class="ibl-team-cell--colored sticky-col" style="--team-cell-bg: #008000; --team-cell-color: #FFFFFF;"><a href="modules.php?name=Team&amp;op=team&amp;teamid=3" class="ibl-team-cell__name" aria-label="Team Charlie"><img src="images/logo/new3.png" alt="" class="ibl-team-cell__logo" width="24" height="24" loading="lazy"><span class="ibl-team-cell__text"><span class="ibl-clinched-indicator">Y</span>-Team Charlie</span></a></td>            <td>50-32</td>
+            <td>0.610</td>
+            <td>0.000</td>
+            <td>0.0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>30-16</td>
+            <td>10-4</td>
+            <td>28-14</td>
+            <td>22-18</td>
+            <td>42</td>
+            <td>40</td>
+            <td>0-0</td>
+            <td sorttable_customkey="0"> 0</td>
+            <td><span class="ibl-stat-highlight">0</span></td>
+            <td>0.000</td>
+            <td>0.000</td>
+        </tr>
+                <tr data-team-id="4" class="clinch-playoffs">
+            <td class="ibl-team-cell--colored sticky-col" style="--team-cell-bg: #4B0082; --team-cell-color: #FFFFFF;"><a href="modules.php?name=Team&amp;op=team&amp;teamid=4" class="ibl-team-cell__name" aria-label="Team Delta"><img src="images/logo/new4.png" alt="" class="ibl-team-cell__logo" width="24" height="24" loading="lazy"><span class="ibl-team-cell__text"><span class="ibl-clinched-indicator">X</span>-Team Delta</span></a></td>            <td>50-32</td>
+            <td>0.610</td>
+            <td>0.000</td>
+            <td>0.0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>30-16</td>
+            <td>10-4</td>
+            <td>28-14</td>
+            <td>22-18</td>
+            <td>42</td>
+            <td>40</td>
+            <td>0-0</td>
+            <td sorttable_customkey="0"> 0</td>
+            <td><span class="ibl-stat-highlight">0</span></td>
+            <td>0.000</td>
+            <td>0.000</td>
+        </tr>
+        </tbody></table></div></div>

--- a/ibl5/tests/Standings/__snapshots__/renderRegion-empty.html
+++ b/ibl5/tests/Standings/__snapshots__/renderRegion-empty.html
@@ -1,0 +1,28 @@
+        <h2 class="ibl-title">Western Conference</h2>
+        <div class="table-scroll-wrapper">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Western Conference Standings">
+        <table class="sortable ibl-data-table">
+            <thead>
+                <tr>
+                    <th class="sticky-col">Team</th>
+                    <th>W-L</th>
+                    <th>Win%</th>
+                    <th>Pyth<br>W-L%</th>
+                    <th>GB</th>
+                    <th>Magic<br>#</th>
+                    <th>Games<br>Left</th>
+                    <th>Conf.</th>
+                    <th>Div.</th>
+                    <th>Home</th>
+                    <th>Away</th>
+                    <th>Home<br>Played</th>
+                    <th>Away<br>Played</th>
+                    <th>Last 10<br>W-L</th>
+                    <th>Streak</th>
+                    <th>Power<br>Rank</th>
+                    <th>SOS</th>
+                    <th>Rem.<br>SOS</th>
+                </tr>
+            </thead>
+            <tbody>
+        </tbody></table></div></div>

--- a/ibl5/tests/Standings/__snapshots__/renderRegion-h2h-tiebreak.html
+++ b/ibl5/tests/Standings/__snapshots__/renderRegion-h2h-tiebreak.html
@@ -1,0 +1,85 @@
+        <h2 class="ibl-title">Eastern Conference</h2>
+        <div class="table-scroll-wrapper">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Eastern Conference Standings">
+        <table class="sortable ibl-data-table">
+            <thead>
+                <tr>
+                    <th class="sticky-col">Team</th>
+                    <th>W-L</th>
+                    <th>Win%</th>
+                    <th>Pyth<br>W-L%</th>
+                    <th>GB</th>
+                    <th>Magic<br>#</th>
+                    <th>Games<br>Left</th>
+                    <th>Conf.</th>
+                    <th>Div.</th>
+                    <th>Home</th>
+                    <th>Away</th>
+                    <th>Home<br>Played</th>
+                    <th>Away<br>Played</th>
+                    <th>Last 10<br>W-L</th>
+                    <th>Streak</th>
+                    <th>Power<br>Rank</th>
+                    <th>SOS</th>
+                    <th>Rem.<br>SOS</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr data-team-id="3" class="bottom-locked">
+            <td class="ibl-team-cell--colored sticky-col" style="--team-cell-bg: #008000; --team-cell-color: #FFFFFF;"><a href="modules.php?name=Team&amp;op=team&amp;teamid=3" class="ibl-team-cell__name" aria-label="Team Charlie"><img src="images/logo/new3.png" alt="" class="ibl-team-cell__logo" width="24" height="24" loading="lazy"><span class="ibl-team-cell__text">Team Charlie</span></a></td>            <td>50-32</td>
+            <td>0.610</td>
+            <td>0.000</td>
+            <td>0.0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>30-16</td>
+            <td>10-4</td>
+            <td>28-14</td>
+            <td>22-18</td>
+            <td>42</td>
+            <td>40</td>
+            <td>0-0</td>
+            <td sorttable_customkey="0"> 0</td>
+            <td><span class="ibl-stat-highlight">0</span></td>
+            <td>0.000</td>
+            <td>0.000</td>
+        </tr>
+                <tr data-team-id="1" class="bottom-locked">
+            <td class="ibl-team-cell--colored sticky-col" style="--team-cell-bg: #000080; --team-cell-color: #FFFFFF;"><a href="modules.php?name=Team&amp;op=team&amp;teamid=1" class="ibl-team-cell__name" aria-label="Team Alpha"><img src="images/logo/new1.png" alt="" class="ibl-team-cell__logo" width="24" height="24" loading="lazy"><span class="ibl-team-cell__text">Team Alpha</span></a></td>            <td>50-32</td>
+            <td>0.610</td>
+            <td>0.000</td>
+            <td>0.0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>30-16</td>
+            <td>10-4</td>
+            <td>28-14</td>
+            <td>22-18</td>
+            <td>42</td>
+            <td>40</td>
+            <td>0-0</td>
+            <td sorttable_customkey="0"> 0</td>
+            <td><span class="ibl-stat-highlight">0</span></td>
+            <td>0.000</td>
+            <td>0.000</td>
+        </tr>
+                <tr data-team-id="2" class="bottom-locked">
+            <td class="ibl-team-cell--colored sticky-col" style="--team-cell-bg: #800000; --team-cell-color: #FFFFFF;"><a href="modules.php?name=Team&amp;op=team&amp;teamid=2" class="ibl-team-cell__name" aria-label="Team Beta"><img src="images/logo/new2.png" alt="" class="ibl-team-cell__logo" width="24" height="24" loading="lazy"><span class="ibl-team-cell__text">Team Beta</span></a></td>            <td>50-32</td>
+            <td>0.610</td>
+            <td>0.000</td>
+            <td>0.0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>30-16</td>
+            <td>10-4</td>
+            <td>28-14</td>
+            <td>22-18</td>
+            <td>42</td>
+            <td>40</td>
+            <td>0-0</td>
+            <td sorttable_customkey="0"> 0</td>
+            <td><span class="ibl-stat-highlight">0</span></td>
+            <td>0.000</td>
+            <td>0.000</td>
+        </tr>
+        </tbody></table></div></div>


### PR DESCRIPTION
## Summary

Extracts two collaborator classes from the 610-LOC `StandingsView` as backlog item 1.35:

- **`StandingsRowView`** — single-row HTML rendering + clinch tier helpers (7 methods moved). Registered in `RequireEscapedOutputRule`'s non-baselineable zero-violation array so XSS enforcement carries across.
- **`StandingsTiebreakerResolver`** — H2H tie-break ordering within tied groups (2 methods moved). Matrix passed as method parameter (not constructor arg) because it is a mutable per-render lazy cache.

Golden-master characterization tests (6 new PHPUnit tests pinning previously-uncovered branches: H2H tiebreaker, bottom-locked rows, clinch-tier CSS classes) added pre-extraction to verify refactor is behavior-preserving.

Stacked on: #1794 (merged ✅)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
