### PR TITLE
chore: compress meta-tooling-bar and doc-freshness resident rules

### DIFF
--- a/.claude/rules/doc-freshness.md
+++ b/.claude/rules/doc-freshness.md
@@ -1,6 +1,6 @@
 ---
 description: Frontmatter schema (including `paths:` residency semantics — repo-relative only, never glob an always-loaded rule), 60-day staleness policy, on-touch verification rule, dead-reference rule, and the retired-figure rule enforced by bin/check-docs
-last_verified: 2026-07-28
+last_verified: 2026-08-08
 paths: "**/*.md"
 ---
 
@@ -25,8 +25,8 @@ paths: "glob-or-list"  # only meaningful for .claude/rules/*
 
 `paths:` is the residency selector. **No `paths:` ⇒ always-loaded** into every system prompt; **with `paths:` ⇒ lazy**, attaching only when a matching file is touched. Two constraints on writing one:
 
-- **Repo-relative only.** A `~/`- or `/`-prefixed entry does not match in practice, so it is not a trigger at all — even when the doc exists to explain that out-of-repo file. Verified 2026-07-28 across session transcripts: sessions that edited the hook named in `work-triage-detail.md`'s `paths:` attached the doc zero times.
-- **Never glob an always-loaded rule's own path.** Compaction restore re-materializes the resident set as file attachments, and that re-materialization is itself a *touch* — so a companion globbing its parent re-attaches every window, self-sustaining, with no tool call anywhere in the window touching the trigger. Three companions did this until PR #1730. The per-window cost is real but varies by session — the restore set is "whatever was resident," not a fixed list — so measure it on your own transcript rather than trusting a quoted figure. Point the glob at the **source surface** the doc explains instead.
+- **Repo-relative only.** A `~/`- or `/`-prefixed entry does not match in practice, so it is not a trigger at all — even when the doc exists to explain that out-of-repo file (verified 2026-07-28 across session transcripts: `work-triage-detail.md` attached zero times in sessions that edited the hook its `paths:` named).
+- **Never glob an always-loaded rule's own path.** Compaction restore re-materializes the resident set as file attachments, and that re-materialization is itself a *touch* — so a companion globbing its parent re-attaches every window, self-sustaining, with no tool call touching the trigger (three companions did this until PR #1730). The per-window cost varies by session, since the restore set is "whatever was resident" — measure it on your own transcript rather than trusting a quoted figure. Point the glob at the **source surface** the doc explains instead.
 
 This is not an argument for narrow globs generally. A deliberately broad glob aimed at a real surface — this doc's `**/*.md`, `meta-tooling-bar.md`'s `.claude/**` — re-attaches on restores too, and that is intended: both docs govern the surface being restored. The defect is a glob whose *only* purpose is to ride its parent's residency.
 
@@ -34,22 +34,22 @@ A companion left with no live trigger is **Read-on-demand only**. That is legiti
 
 ## On-Touch Rule
 
-When editing any in-scope `.md` file, verify its content still matches reality, confirm the `description` field accurately reflects the content, and bump `last_verified` to today — all in the same edit.
+When editing any in-scope `.md` file, verify its content still matches reality, confirm the `description` field accurately reflects the content, and bump `last_verified` to today — all in the same edit. A `last_verified` over **60 days** old is stale (the PR gate runs `--no-staleness`, so an untouched stale doc never blocks an unrelated change; the nightly audit owns repo-wide staleness).
 
-This is enforced in CI by `bin/check-docs --since=<base-ref>`, which fails any PR that changes an in-scope `.md` body without bumping `last_verified` (a base-vs-head value comparison, never date-equality-to-today, so a PR opened one day and merged later does not false-fail). Exception: if the doc was already verified earlier the **same day**, the value cannot bump higher without going into the future — so an unchanged value still passes when it equals the edit's git commit date. That escape keys off the immutable commit date, not the CI clock, so it does not reintroduce a midnight false-fail. The practical effect: a same-UTC-day re-edit of a doc verified earlier that day does not have to wait for UTC rollover. Trade-off: at one-day granularity the escape cannot tell a genuine same-day re-verification from a same-day edit that skipped re-checking — an accepted loosening, since the alternative (a hard same-day deadlock) was worse.
+Enforced in CI by `bin/check-docs --since=<base-ref>`, which fails any PR that changes an in-scope `.md` body without bumping `last_verified`. The comparison is base-vs-head, never date-equality-to-today, so a PR opened one day and merged later does not false-fail; and an unchanged value still passes when it equals the edit's **git commit date**, so a same-UTC-day re-edit of a doc verified earlier that day need not wait for UTC rollover.
 
 ## Dead-Reference Rule
 
-`bin/check-docs` scans doc bodies for repo-path tokens (`bin/<name>`, `ibl5/<path>`, `.claude/<path>`, `.github/<path>`) and fails on any token that does not resolve to an existing file or directory. Shell variables like `$FOO/bar` are ignored. Paths with glob characters (`*`, `?`, `[`, `]`) are also skipped automatically. For intentional non-resolving literal paths, append `(example)` immediately after the closing backtick — e.g. `` `bin/some-path` (example) `` — and `bin/check-docs` will skip the reference.
+`bin/check-docs` scans doc bodies for repo-path tokens (`bin/<name>`, `ibl5/<path>`, `.claude/<path>`, `.github/<path>`) and fails on any token that does not resolve to an existing file or directory. Shell variables like `$FOO/bar` are ignored, and paths with glob characters (`*`, `?`, `[`, `]`) are skipped automatically. For intentional non-resolving literal paths, append `(example)` immediately after the closing backtick — e.g. `` `bin/some-path` (example) `` — and `bin/check-docs` will skip the reference.
 
 ## Retired-Figure Rule
 
-When a dated correction retires a *figure* (not just a claim), the correction has to propagate to every doc that cites it. The observed failure mode (PRs #1620, #1622, #1626) is a superseded number re-surfacing in a doc the sweep missed — so `bin/check-docs`'s full scan fails on any in-scope doc line matching a `RETIRED_FIGURES` pattern with no correction marker nearby.
+When a dated correction retires a *figure* (not just a claim), the correction has to propagate to every doc that cites it — the observed failure mode (PRs #1620, #1622, #1626) is a superseded number re-surfacing in a doc the sweep missed. So `bin/check-docs`'s full scan fails on any in-scope doc line matching a `RETIRED_FIGURES` pattern with no correction marker nearby.
 
 - **Markers:** `[CORRECTED …]`, `[SUPERSEDED …]`, `**Superseded by:**`, or `RETIRED-OK` (the last usually in an HTML comment, for a line that *is* the correction and quotes the old value only to replace it).
 - **Scope of an exemption:** the marker must be on the line or within 3 lines of it. A heading whose text names a correction (`## Addendum …`, `## Correction …`) exempts its whole section, up to the next heading. Frontmatter is exempt wholesale — a `description:` is a summary, not a claim site.
 - **`⚠` is deliberately not a marker.** It's a generic emphasis glyph, so accepting it would let an unrelated nearby warning silently exempt a genuinely stale figure, and a false negative here is invisible.
 
-**Adding an entry is a high bar.** A figure qualifies only when its retired form is distinctive enough that a legitimate live use is implausible. `~100× smaller` was considered and rejected: ADR-0094 uses that exact phrase for a different, still-correct comparison, so gating it would force stamping correct prose as if it were retired. When a figure fails that bar, correct the docs and skip the gate.
+**Adding an entry is a high bar.** A figure qualifies only when its retired form is distinctive enough that a legitimate live use is implausible. `~100× smaller` was rejected on exactly that test: ADR-0094 uses the phrase for a different, still-correct comparison, so gating it would force stamping correct prose as retired. When a figure fails the bar, correct the docs and skip the gate.
 
 **Known scope limit:** the check reads the in-scope markdown globs only. It would not have caught the PR #1622 miss, which lived in a JSON test artifact field. Run `bin/check-docs --self-test` to exercise the exemption logic (fixtures cover exemptions only — a wrong pattern fails loudly on the next PR, a wrong exemption does not).

--- a/.claude/rules/meta-tooling-bar.md
+++ b/.claude/rules/meta-tooling-bar.md
@@ -1,6 +1,6 @@
 ---
 description: Before adding a new hook, CI gate, workflow, or bin/ script, first ask whether an existing one can be extended; quarterly cull retires dead meta-tooling.
-last_verified: 2026-07-28
+last_verified: 2026-08-08
 paths:
   - "bin/**"
   - ".github/workflows/**"
@@ -9,17 +9,15 @@ paths:
 
 # Meta-Tooling Bar
 
-The repo carries a large and growing meta-tooling surface — `bin/` scripts, CI workflows, hooks, and always-loaded rules (recount them with the block below; the numbers move too fast to pin here). Roughly a quarter of `bin/` (`test-*`) exists to maintain the other three-quarters — every gate is itself code that needs upkeep and can carry its own bugs. Evidence that gates need upkeep (not that they are broken now): the persist-gate append blindspot (fixed 2026-07-04) and the check-docs rebase author-date bug (fixed PR #1262). This rule caps growth two ways: an **extend-before-add bar** checked at creation time, and a **quarterly cull** that retires dead tooling.
-
-Recount at any time:
+The meta-tooling surface — `bin/` scripts, CI workflows, hooks, always-loaded rules — keeps growing, and every gate is itself code that needs upkeep and can carry its own bugs. This rule caps growth two ways: an **extend-before-add bar** checked at creation time, and a **quarterly cull** that retires dead tooling. Recount the surface any time:
 
 ```bash
-ls bin/ | wc -l                         # bin total
-ls bin/ | grep -c '^test-'              # bin test-*
-ls bin/ | grep -c '^check-'             # bin check-*
-ls .github/workflows/*.yml | wc -l      # CI workflows
-ls ~/.claude/hooks/*.sh | wc -l         # hooks
-ls .claude/rules/*.md | wc -l           # always-loaded rules
+ls bin/ | wc -l                    # bin total
+ls bin/ | grep -c '^test-'         # test-*
+ls bin/ | grep -c '^check-'        # check-*
+ls .github/workflows/*.yml | wc -l # workflows
+ls ~/.claude/hooks/*.sh | wc -l    # hooks
+ls .claude/rules/*.md | wc -l      # rules
 ```
 
 ## The extend-before-add bar
@@ -28,11 +26,9 @@ Before adding a new hook, CI gate, workflow, or `bin/` script, first ask whether
 
 **Add-new only when ALL hold:**
 - **No host to extend** — no existing hook/gate/workflow/script owns this surface, and bolting a branch onto one would strain its single responsibility.
-- **Distinct trigger** — it fires on a genuinely different event/surface than any existing gate, not a variant foldable in as a flag.
+- **Distinct trigger** — a genuinely different event/surface, not a variant foldable in as a flag.
 - **Earns its upkeep** — the surface it guards is live and recurring; the gate pays back the maintenance (and its own future bugs) it will cost.
-- **No cheaper alternative** — the same protection can't come from an always-loaded rule doc (zero `test-*` overhead), a doc note, or extending a config.
-
-An always-loaded rule doc (like this one) carries ZERO `test-*`/gate overhead and is the cheap enforcement lever — prefer a rule over a hook when a documented norm plus review suffices.
+- **No cheaper alternative** — the same protection can't come from a doc note, an extended config, or an always-loaded rule doc, which carries ZERO `test-*`/gate overhead and is the cheap enforcement lever: prefer a rule over a hook when a documented norm plus review suffices.
 
 ## Quarterly cull
 
@@ -40,20 +36,18 @@ A recurring review that retires meta-tooling no longer earning its keep. **First
 
 The teeth are documented hand-run greps, not a maintained script (a `bin/cull-audit` (example) would itself violate the bar). Run these at each cull:
 
-- **Orphaned `test-*`** — a `test-*` in `bin/` whose target no longer exists: list `bin/`'s `test-*`, derive each target, confirm it still exists.
+- **Orphaned `test-*`** — a `test-*` whose target no longer exists: list `bin/`'s `test-*`, derive each target, confirm it still exists.
 - **Unreferenced gate** — a `check-*` referenced by no `.github/workflows/*.yml`: grep the workflows dir for each `check-*` name; zero hits ⇒ candidate.
-- **Unwired `test-*`** — a `test-*` whose target still exists but which **no workflow ever runs**: `for t in bin/test-*; do n=$(basename "$t"); grep -rqF "$n" .github/workflows/ || echo "UNWIRED $n"; done`, then check each hit for an invoking wrapper (a wrapper counts as wired). Such a test passes locally forever and protects nothing — it sits between the two checks above, which is how `bin/test-plan-now` went unrun from creation until 2026-07-28. The disposition is **wire it or retire it**, judgment-gated as usual; a test that self-skips off-platform (`bin/test-automouse-single`, macOS-only) is a legitimate stay-unwired, since wiring it to a Linux runner buys a SKIP line. This is the *inverse* of the trap below — it never mandates a new `test-*`, it only asks whether an existing one runs.
-- **Buggy gate/hook** — a gate/hook with bugs recorded in memory: is it still earning its keep, or has its cost outgrown its value?
+- **Unwired `test-*`** — target still exists, but **no workflow ever runs it**: `for t in bin/test-*; do n=$(basename "$t"); grep -rqF "$n" .github/workflows/ || echo "UNWIRED $n"; done`, then check each hit for an invoking wrapper (a wrapper counts as wired). Such a test passes locally forever and protects nothing — how `bin/test-plan-now` went unrun until 2026-07-28. Disposition: **wire it or retire it**; a test that self-skips off-platform (`bin/test-automouse-single`, macOS-only) is a legitimate stay-unwired, since wiring it to a Linux runner buys a SKIP line. This is the *inverse* of the trap below — it never mandates a new `test-*`, only asks whether an existing one runs.
+- **Buggy gate/hook** — bugs recorded in memory: still earning its keep, or has its cost outgrown its value?
 - **Dead rule / silent hook** — a rule superseded by another, or a hook that never fires: confirm against recent logs/PRs.
 
 Each hit is a **CANDIDATE**, judgment-gated — the cull PROPOSES retirements; a human confirms.
 
 **Trap to avoid:** the bar caps gate/hook/workflow proliferation; `test-*` is the SYMPTOM (a quarter of `bin/` tests the rest), not the enemy — do NOT mandate "every new gate needs a matching `test-*`", because that ADDS the very thing being capped. Test coverage for a gate is a separate per-gate call, never a blanket requirement this rule imposes.
 
-After each cull, bump the reminder `⏰` +1 quarter.
-
 ## Calibration
 
-Surface the extend-before-add question only when the change ADDS a governance mechanism (hook, gate, workflow, `bin/` script); skip the ritual for editing an existing one or for a plain rule-doc/prose change (zero-overhead).
+Surface the extend-before-add question only when the change ADDS a governance mechanism (hook, gate, workflow, `bin/` script); skip it for editing an existing one or for a plain rule-doc/prose change (zero-overhead).
 
-**Headless:** no-op under headless/automouse — no human to weigh the extend-vs-add call, and automouse runs only pre-vetted plans; governs interactive tooling-authoring only.
+**Headless:** no-op under headless/automouse — no human to weigh the extend-vs-add call; governs interactive tooling-authoring only.


### PR DESCRIPTION
Compresses two path-unscoped resident rules to fit under the 5000-byte per-file and 16000-byte aggregate byte budgets.

**Changes:**
- `.claude/rules/meta-tooling-bar.md`: compressed to reduce byte count while preserving all governance clauses
- `.claude/rules/doc-freshness.md`: compressed to reduce byte count while preserving all governance clauses

**Byte budget:** all checks pass (`bin/check-rules-byte-budget` exits 0)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.