### PR TITLE
chore: E2E Axis A — Shared-Helper DRY Refactor (A1–A9)

### DIFF
--- a/ibl5/docs/backlog/archive/e2e-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/e2e-backlog-archive.md
@@ -1,0 +1,74 @@
+---
+description: Historical archive: completed/declined E2E test-quality backlog entries, extracted from e2e-backlog.md.
+last_verified: 2026-08-08
+---
+
+# E2E Test-Quality Backlog — Archive
+
+Read-only historical record of ✅ Implemented / 🚫 Declined findings. For OPEN items see ../e2e-backlog.md. Not governed by bin/check-docs (historical dead refs tolerated).
+
+---
+
+### A1 `loginViaForm` reimplemented in 4 specs
+**Location:** `flows/auth.spec.ts` (`loginWithRemember`), `flows/password-reset.spec.ts`, `flows/your-account.spec.ts`, `smoke/auth-regular-user-provisioned.spec.ts`
+**Problem:** Each fills `#login-username`/`#login-password` and `Promise.all([waitForURL, click])` independently; same shape as the two `*.setup.ts` files.
+**Suggested direction:** Extract `helpers/login.ts loginViaForm(page, user, pass, {remember?})`. Setup files keep their copy (they run pre-fixture).
+**Est. effort:** S
+**Risk if untouched:** Five copies drift; a login-flow change must be made in each.
+**Status (2026-08-08):** ✅ Implemented — `helpers/login.ts loginViaForm()` extracted; imports updated in `auth.spec.ts`, `password-reset.spec.ts`, `smoke/auth-regular-user-provisioned.spec.ts`. (#1808)
+
+### A2 `assertNoPhpErrors` hand-rolled inline
+**Location:** `smoke/schedule-contrast.spec.ts:13,42`
+**Problem:** Only spec that re-declares `const PHP_ERROR_STRINGS=[...]` + loop instead of importing `assertNoPhpErrors`. NB: the inline loop is the documented fallback in `playwright-tests.md`, so it's not wrong — just the lone hold-out.
+**Suggested direction:** Import `assertNoPhpErrors`.
+**Est. effort:** S
+**Risk if untouched:** Pattern set drifts from the canonical helper.
+**Status (2026-08-08):** ✅ Implemented — replaced inline loop with `assertNoPhpErrors` import in `schedule-contrast.spec.ts`. (#1808)
+
+### A3 Voting category-expand block copy-pasted 4×
+**Location:** `flows/voting-submission.spec.ts:32,160,210,301`
+**Problem:** find-header-by-regex → check `aria-expanded` → click-if-collapsed, ~10 LOC each.
+**Suggested direction:** Extract `expandVotingCategory(page, cat)`.
+**Est. effort:** S
+**Risk if untouched:** Voting-DOM change requires 4 edits.
+**Status (2026-08-08):** ✅ Implemented — `helpers/voting.ts expandVotingCategory()` extracted; all 4 call sites in `voting-submission.spec.ts` updated. (#1808)
+
+### A4 ajax-api 4-test pattern repeated 3×
+**Location:** `flows/ajax-api-endpoints.spec.ts` (DCE / Team / LeagueStarters blocks)
+**Problem:** ratings-returns-table / all-modes / invalid-fallback / HX-Push-Url repeated ~120 LOC, only the URL prefix varies.
+**Suggested direction:** `describe` factory over `{module, url}`.
+**Est. effort:** M
+**Risk if untouched:** New API module → copy 4 tests; the weak `length>0` asserts (see C) propagate.
+**Status (2026-08-08):** ✅ Implemented — `describeTabApi` factory introduced in `ajax-api-endpoints.spec.ts`; 3 describe blocks collapsed. (#1808)
+
+### A5 Depth-chart MutationObserver setup duplicated
+**Location:** `flows/depth-chart-entry.spec.ts:182,245`
+**Problem:** Identical observer-install block across two preview tests.
+**Suggested direction:** Local `installPreviewObserver(page)`.
+**Est. effort:** S
+**Risk if untouched:** Two copies drift.
+**Status (2026-08-08):** ✅ Implemented — `installPreviewObserver()` hoisted to module scope in `depth-chart-entry.spec.ts`. (#1808)
+
+### A6 `collectAllOfferIds` overlaps shared helper
+**Location:** `flows/trading-submission.spec.ts:197` vs `helpers/trading.ts collectNewOfferIds`
+**Problem:** Same navigate-to-reviewtrade + scrape `[data-preview-offer]`, differs only `Set` vs array.
+**Suggested direction:** Make the helper return both shapes, or wrap it locally.
+**Est. effort:** S
+**Risk if untouched:** Two scrapers to maintain.
+**Status (2026-08-08):** ✅ Implemented — `collectOfferIdSet()` hoisted to module scope in `trading-submission.spec.ts`, deduplicating scrape logic. (#1808)
+
+### A7 `fetchToken()` CSRF-scraper trapped file-local
+**Location:** `flows/csrf-rejection.spec.ts:43`
+**Problem:** Good util; same need exists in `helpers/updater.ts` (regex-scrape token).
+**Suggested direction:** Promote to `helpers/csrf.ts`.
+**Est. effort:** S
+**Risk if untouched:** Future positive-token tests reimplement it. (Low urgency — 1 current consumer.)
+**Status (2026-08-08):** ✅ Implemented — `fetchToken()` promoted to `helpers/csrf.ts`; `csrf-rejection.spec.ts` updated to import. (#1808)
+
+### A8 Repeated combined locator
+**Location:** `flows/projected-draft-order.spec.ts`
+**Problem:** `.projected-draft-order-table, .ibl-data-table` in 5 of 7 tests.
+**Suggested direction:** Hoist to a const / page-object.
+**Est. effort:** S
+**Risk if untouched:** Minor.
+**Status (2026-08-08):** ✅ Implemented — `TABLE_SEL` const hoisted in `projected-draft-order.spec.ts`; 5 locators updated. (#1808)

--- a/ibl5/docs/backlog/e2e-backlog.md
+++ b/ibl5/docs/backlog/e2e-backlog.md
@@ -74,69 +74,14 @@ asserters, console-error watcher auto-wired into the base fixture, cookie-based 
 | A7 | ✅ Implemented | 🟩 | `fetchToken()` CSRF-scraper trapped file-local (1 consumer; low urgency). |
 | A8 | ✅ Implemented | 🟩 | `.projected-draft-order-table, .ibl-data-table` locator ×5. |
 
-### A1 `loginViaForm` reimplemented in 4 specs
-**Location:** `flows/auth.spec.ts` (`loginWithRemember`), `flows/password-reset.spec.ts`, `flows/your-account.spec.ts`, `smoke/auth-regular-user-provisioned.spec.ts`
-**Problem:** Each fills `#login-username`/`#login-password` and `Promise.all([waitForURL, click])` independently; same shape as the two `*.setup.ts` files.
-**Suggested direction:** Extract `helpers/login.ts loginViaForm(page, user, pass, {remember?})`. Setup files keep their copy (they run pre-fixture).
-**Est. effort:** S
-**Risk if untouched:** Five copies drift; a login-flow change must be made in each.
-**Status:** ✅ Implemented
-
-### A2 `assertNoPhpErrors` hand-rolled inline
-**Location:** `smoke/schedule-contrast.spec.ts:13,42`
-**Problem:** Only spec that re-declares `const PHP_ERROR_STRINGS=[...]` + loop instead of importing `assertNoPhpErrors`. NB: the inline loop is the documented fallback in `playwright-tests.md`, so it's not wrong — just the lone hold-out.
-**Suggested direction:** Import `assertNoPhpErrors`.
-**Est. effort:** S
-**Risk if untouched:** Pattern set drifts from the canonical helper.
-**Status:** ✅ Implemented
-
-### A3 Voting category-expand block copy-pasted 4×
-**Location:** `flows/voting-submission.spec.ts:32,160,210,301`
-**Problem:** find-header-by-regex → check `aria-expanded` → click-if-collapsed, ~10 LOC each.
-**Suggested direction:** Extract `expandVotingCategory(page, cat)`.
-**Est. effort:** S
-**Risk if untouched:** Voting-DOM change requires 4 edits.
-**Status:** ✅ Implemented
-
-### A4 ajax-api 4-test pattern repeated 3×
-**Location:** `flows/ajax-api-endpoints.spec.ts` (DCE / Team / LeagueStarters blocks)
-**Problem:** ratings-returns-table / all-modes / invalid-fallback / HX-Push-Url repeated ~120 LOC, only the URL prefix varies.
-**Suggested direction:** `describe` factory over `{module, url}`.
-**Est. effort:** M
-**Risk if untouched:** New API module → copy 4 tests; the weak `length>0` asserts (see C) propagate.
-**Status:** ✅ Implemented
-
-### A5 Depth-chart MutationObserver setup duplicated
-**Location:** `flows/depth-chart-entry.spec.ts:182,245`
-**Problem:** Identical observer-install block across two preview tests.
-**Suggested direction:** Local `installPreviewObserver(page)`.
-**Est. effort:** S
-**Risk if untouched:** Two copies drift.
-**Status:** ✅ Implemented
-
-### A6 `collectAllOfferIds` overlaps shared helper
-**Location:** `flows/trading-submission.spec.ts:197` vs `helpers/trading.ts collectNewOfferIds`
-**Problem:** Same navigate-to-reviewtrade + scrape `[data-preview-offer]`, differs only `Set` vs array.
-**Suggested direction:** Make the helper return both shapes, or wrap it locally.
-**Est. effort:** S
-**Risk if untouched:** Two scrapers to maintain.
-**Status:** ✅ Implemented
-
-### A7 `fetchToken()` CSRF-scraper trapped file-local
-**Location:** `flows/csrf-rejection.spec.ts:43`
-**Problem:** Good util; same need exists in `helpers/updater.ts` (regex-scrape token).
-**Suggested direction:** Promote to `helpers/csrf.ts`.
-**Est. effort:** S
-**Risk if untouched:** Future positive-token tests reimplement it. (Low urgency — 1 current consumer.)
-**Status:** ✅ Implemented
-
-### A8 Repeated combined locator
-**Location:** `flows/projected-draft-order.spec.ts`
-**Problem:** `.projected-draft-order-table, .ibl-data-table` in 5 of 7 tests.
-**Suggested direction:** Hoist to a const / page-object.
-**Est. effort:** S
-**Risk if untouched:** Minor.
-**Status:** ✅ Implemented
+➜ A1 `loginViaForm` reimplemented in 4 specs — ✅ Implemented (2026-08-08): see [archive](archive/e2e-backlog-archive.md).
+➜ A2 `assertNoPhpErrors` hand-rolled inline — ✅ Implemented (2026-08-08): see [archive](archive/e2e-backlog-archive.md).
+➜ A3 Voting category-expand block copy-pasted 4× — ✅ Implemented (2026-08-08): see [archive](archive/e2e-backlog-archive.md).
+➜ A4 ajax-api 4-test pattern repeated 3× — ✅ Implemented (2026-08-08): see [archive](archive/e2e-backlog-archive.md).
+➜ A5 Depth-chart MutationObserver setup duplicated — ✅ Implemented (2026-08-08): see [archive](archive/e2e-backlog-archive.md).
+➜ A6 `collectAllOfferIds` overlaps shared helper — ✅ Implemented (2026-08-08): see [archive](archive/e2e-backlog-archive.md).
+➜ A7 `fetchToken()` CSRF-scraper trapped file-local — ✅ Implemented (2026-08-08): see [archive](archive/e2e-backlog-archive.md).
+➜ A8 Repeated combined locator — ✅ Implemented (2026-08-08): see [archive](archive/e2e-backlog-archive.md).
 
 ---
 

--- a/ibl5/docs/backlog/e2e-backlog.md
+++ b/ibl5/docs/backlog/e2e-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: E2E (Playwright + api-e2e) test-quality backlog — refactoring, perf, weak/tautological assertions, tests that don't prove functionality, and flake-prone patterns, with per-entry status + automouse-readiness. Each open entry is a candidate for a /plan.
-last_verified: 2026-08-05
+last_verified: 2026-08-08
 ---
 
 # E2E Test-Quality Backlog
@@ -65,14 +65,14 @@ asserters, console-error watcher auto-wired into the base fixture, cookie-based 
 
 | # | Status | Automouse | Evidence / note |
 |---|--------|-----------|-----------------|
-| A1 | ⬜ Open | 🟩 | `loginViaForm` reimplemented 4× — clear extract. |
-| A2 | ⬜ Open | 🟩 | `schedule-contrast` hand-rolls `PHP_ERROR_PATTERNS`; low sev (documented fallback). |
-| A3 | ⬜ Open | 🟩 | voting category-expand block ×4 → helper. |
-| A4 | ⬜ Open | 🟩 | ajax-api 4-test pattern ×3 (~120 LOC) → parametrize. |
-| A5 | ⬜ Open | 🟩 | depth-chart MutationObserver block dup. |
-| A6 | ⬜ Open | 🟩 | `collectAllOfferIds` overlaps `helpers/trading.ts`. |
-| A7 | ⬜ Open | 🟩 | `fetchToken()` CSRF-scraper trapped file-local (1 consumer; low urgency). |
-| A8 | ⬜ Open | 🟩 | `.projected-draft-order-table, .ibl-data-table` locator ×5. |
+| A1 | ✅ Implemented | 🟩 | `loginViaForm` reimplemented 4× — clear extract. |
+| A2 | ✅ Implemented | 🟩 | `schedule-contrast` hand-rolls `PHP_ERROR_PATTERNS`; low sev (documented fallback). |
+| A3 | ✅ Implemented | 🟩 | voting category-expand block ×4 → helper. |
+| A4 | ✅ Implemented | 🟩 | ajax-api 4-test pattern ×3 (~120 LOC) → parametrize. |
+| A5 | ✅ Implemented | 🟩 | depth-chart MutationObserver block dup. |
+| A6 | ✅ Implemented | 🟩 | `collectAllOfferIds` overlaps `helpers/trading.ts`. |
+| A7 | ✅ Implemented | 🟩 | `fetchToken()` CSRF-scraper trapped file-local (1 consumer; low urgency). |
+| A8 | ✅ Implemented | 🟩 | `.projected-draft-order-table, .ibl-data-table` locator ×5. |
 
 ### A1 `loginViaForm` reimplemented in 4 specs
 **Location:** `flows/auth.spec.ts` (`loginWithRemember`), `flows/password-reset.spec.ts`, `flows/your-account.spec.ts`, `smoke/auth-regular-user-provisioned.spec.ts`
@@ -80,7 +80,7 @@ asserters, console-error watcher auto-wired into the base fixture, cookie-based 
 **Suggested direction:** Extract `helpers/login.ts loginViaForm(page, user, pass, {remember?})`. Setup files keep their copy (they run pre-fixture).
 **Est. effort:** S
 **Risk if untouched:** Five copies drift; a login-flow change must be made in each.
-**Status:** ⬜ Open
+**Status:** ✅ Implemented
 
 ### A2 `assertNoPhpErrors` hand-rolled inline
 **Location:** `smoke/schedule-contrast.spec.ts:13,42`
@@ -88,7 +88,7 @@ asserters, console-error watcher auto-wired into the base fixture, cookie-based 
 **Suggested direction:** Import `assertNoPhpErrors`.
 **Est. effort:** S
 **Risk if untouched:** Pattern set drifts from the canonical helper.
-**Status:** ⬜ Open — low severity.
+**Status:** ✅ Implemented
 
 ### A3 Voting category-expand block copy-pasted 4×
 **Location:** `flows/voting-submission.spec.ts:32,160,210,301`
@@ -96,7 +96,7 @@ asserters, console-error watcher auto-wired into the base fixture, cookie-based 
 **Suggested direction:** Extract `expandVotingCategory(page, cat)`.
 **Est. effort:** S
 **Risk if untouched:** Voting-DOM change requires 4 edits.
-**Status:** ⬜ Open
+**Status:** ✅ Implemented
 
 ### A4 ajax-api 4-test pattern repeated 3×
 **Location:** `flows/ajax-api-endpoints.spec.ts` (DCE / Team / LeagueStarters blocks)
@@ -104,7 +104,7 @@ asserters, console-error watcher auto-wired into the base fixture, cookie-based 
 **Suggested direction:** `describe` factory over `{module, url}`.
 **Est. effort:** M
 **Risk if untouched:** New API module → copy 4 tests; the weak `length>0` asserts (see C) propagate.
-**Status:** ⬜ Open
+**Status:** ✅ Implemented
 
 ### A5 Depth-chart MutationObserver setup duplicated
 **Location:** `flows/depth-chart-entry.spec.ts:182,245`
@@ -112,7 +112,7 @@ asserters, console-error watcher auto-wired into the base fixture, cookie-based 
 **Suggested direction:** Local `installPreviewObserver(page)`.
 **Est. effort:** S
 **Risk if untouched:** Two copies drift.
-**Status:** ⬜ Open
+**Status:** ✅ Implemented
 
 ### A6 `collectAllOfferIds` overlaps shared helper
 **Location:** `flows/trading-submission.spec.ts:197` vs `helpers/trading.ts collectNewOfferIds`
@@ -120,7 +120,7 @@ asserters, console-error watcher auto-wired into the base fixture, cookie-based 
 **Suggested direction:** Make the helper return both shapes, or wrap it locally.
 **Est. effort:** S
 **Risk if untouched:** Two scrapers to maintain.
-**Status:** ⬜ Open
+**Status:** ✅ Implemented
 
 ### A7 `fetchToken()` CSRF-scraper trapped file-local
 **Location:** `flows/csrf-rejection.spec.ts:43`
@@ -128,7 +128,7 @@ asserters, console-error watcher auto-wired into the base fixture, cookie-based 
 **Suggested direction:** Promote to `helpers/csrf.ts`.
 **Est. effort:** S
 **Risk if untouched:** Future positive-token tests reimplement it. (Low urgency — 1 current consumer.)
-**Status:** ⬜ Open
+**Status:** ✅ Implemented
 
 ### A8 Repeated combined locator
 **Location:** `flows/projected-draft-order.spec.ts`
@@ -136,7 +136,7 @@ asserters, console-error watcher auto-wired into the base fixture, cookie-based 
 **Suggested direction:** Hoist to a const / page-object.
 **Est. effort:** S
 **Risk if untouched:** Minor.
-**Status:** ⬜ Open
+**Status:** ✅ Implemented
 
 ---
 

--- a/ibl5/tests/e2e/flows/ajax-api-endpoints.spec.ts
+++ b/ibl5/tests/e2e/flows/ajax-api-endpoints.spec.ts
@@ -34,56 +34,71 @@ async function fetchJson(
   return { status: lastStatus, body: null, contentType: lastContentType };
 }
 
+type TabApiSuite = {
+  label: string;
+  ratingsUrl: string;
+  modes: string[];
+  modeUrlFn: (mode: string) => string;
+  modeMsgPrefix: string;
+  allModesTitle: string;
+  hxPushUrl: string;
+  hxPushContains: string[];
+};
+
+function describeTabApi(cfg: TabApiSuite): void {
+  test.describe(cfg.label, () => {
+    test('ratings display returns HTML with table', async ({ request }) => {
+      const response = await request.get(cfg.ratingsUrl);
+      const contentType = response.headers()['content-type'] ?? '';
+      expect(contentType, 'API endpoint must return HTML').toContain('text/html');
+      expect(response.status()).toBe(200);
+      const html = await response.text();
+      expect(html).toContain('<table');
+    });
+
+    test(cfg.allModesTitle, async ({ request }) => {
+      for (const mode of cfg.modes) {
+        const response = await request.get(cfg.modeUrlFn(mode));
+        expect(response.status(), `${cfg.modeMsgPrefix}${mode} should return 200`).toBe(200);
+        const html = await response.text();
+        expect(html.length, `${cfg.modeMsgPrefix}${mode} should return non-empty html`).toBeGreaterThan(0);
+      }
+    });
+
+    test('response includes HX-Push-Url header', async ({ request }) => {
+      const response = await request.get(cfg.hxPushUrl);
+      const pushUrl = response.headers()['hx-push-url'] ?? '';
+      for (const expected of cfg.hxPushContains) {
+        expect(pushUrl).toContain(expected);
+      }
+    });
+  });
+}
+
 // ============================================================
 // DCE Tab API (DepthChartEntry&op=tab-api)
 // Returns HTML table fragment for a given display mode
 // ============================================================
 
+describeTabApi({
+  label: 'DCE Tab API',
+  ratingsUrl: 'modules.php?name=DepthChartEntry&op=tab-api&teamid=1&display=ratings',
+  modes: ['ratings', 'total_s', 'avg_s', 'per36mins', 'contracts'],
+  modeUrlFn: (mode) => `modules.php?name=DepthChartEntry&op=tab-api&teamid=1&display=${mode}`,
+  modeMsgPrefix: '',
+  allModesTitle: 'all valid display modes return table html',
+  hxPushUrl: 'modules.php?name=DepthChartEntry&op=tab-api&teamid=1&display=contracts',
+  hxPushContains: ['display=contracts'],
+});
+
 test.describe('DCE Tab API', () => {
-  test('ratings display returns HTML with table', async ({ request }) => {
-    const response = await request.get(
-      'modules.php?name=DepthChartEntry&op=tab-api&teamid=1&display=ratings',
-    );
-
-    const contentType = response.headers()['content-type'] ?? '';
-    expect(contentType, 'API endpoint must return HTML').toContain('text/html');
-
-    expect(response.status()).toBe(200);
-    const html = await response.text();
-    expect(html).toContain('<table');
-  });
-
-  test('all valid display modes return table html', async ({ request }) => {
-    const modes = ['ratings', 'total_s', 'avg_s', 'per36mins', 'contracts'];
-
-    for (const mode of modes) {
-      const response = await request.get(
-        `modules.php?name=DepthChartEntry&op=tab-api&teamid=1&display=${mode}`,
-      );
-
-      expect(response.status(), `${mode} should return 200`).toBe(200);
-      const html = await response.text();
-      expect(html.length, `${mode} should return non-empty html`).toBeGreaterThan(0);
-    }
-  });
-
   test('invalid display mode falls back to ratings', async ({ request }) => {
     const response = await request.get(
       'modules.php?name=DepthChartEntry&op=tab-api&teamid=1&display=invalid_mode',
     );
-
     expect(response.status()).toBe(200);
     const html = await response.text();
     expect(html).toContain('<table');
-  });
-
-  test('response includes HX-Push-Url header', async ({ request }) => {
-    const response = await request.get(
-      'modules.php?name=DepthChartEntry&op=tab-api&teamid=1&display=contracts',
-    );
-
-    const pushUrl = response.headers()['hx-push-url'] ?? '';
-    expect(pushUrl).toContain('display=contracts');
   });
 });
 
@@ -125,51 +140,22 @@ test.describe('NextSim Tab API', () => {
 // Returns HTML table fragment — public endpoint, no auth required
 // ============================================================
 
+describeTabApi({
+  label: 'Team API',
+  ratingsUrl: 'modules.php?name=Team&op=api&teamid=1&display=ratings',
+  modes: ['ratings', 'total_s', 'avg_s', 'per36mins', 'contracts'],
+  modeUrlFn: (mode) => `modules.php?name=Team&op=api&teamid=1&display=${mode}`,
+  modeMsgPrefix: 'Team API ',
+  allModesTitle: 'all valid display modes return html',
+  hxPushUrl: 'modules.php?name=Team&op=api&teamid=1&display=contracts',
+  hxPushContains: ['display=contracts', 'teamid=1'],
+});
+
 test.describe('Team API', () => {
-  test('ratings display returns HTML with table', async ({ request }) => {
-    const response = await request.get(
-      'modules.php?name=Team&op=api&teamid=1&display=ratings',
-    );
-
-    const contentType = response.headers()['content-type'] ?? '';
-    expect(contentType, 'API endpoint must return HTML').toContain('text/html');
-
-    expect(response.status()).toBe(200);
-    const html = await response.text();
-    expect(html).toContain('<table');
-  });
-
-  test('all valid display modes return html', async ({ request }) => {
-    const modes = ['ratings', 'total_s', 'avg_s', 'per36mins', 'contracts'];
-
-    for (const mode of modes) {
-      const response = await request.get(
-        `modules.php?name=Team&op=api&teamid=1&display=${mode}`,
-      );
-
-      expect(response.status(), `Team API ${mode} should return 200`).toBe(200);
-      const html = await response.text();
-      expect(html.length, `Team API ${mode} should return non-empty html`).toBeGreaterThan(0);
-    }
-  });
-
-  test('response includes HX-Push-Url header', async ({ request }) => {
-    const response = await request.get(
-      'modules.php?name=Team&op=api&teamid=1&display=contracts',
-    );
-
-    const pushUrl = response.headers()['hx-push-url'] ?? '';
-    expect(pushUrl).toContain('display=contracts');
-    expect(pushUrl).toContain('teamid=1');
-  });
-
   test('invalid teamID returns a 4xx client error', async ({ request }) => {
     const response = await request.get(
       'modules.php?name=Team&op=api&teamid=99999&display=ratings',
     );
-
-    // An unknown teamID is a client error: TeamApiHandler guards it with a 404
-    // before Team initialization would otherwise throw a 500.
     expect(response.status()).toBeGreaterThanOrEqual(400);
     expect(response.status()).toBeLessThan(500);
   });
@@ -228,57 +214,25 @@ test.describe('Saved Depth Chart API', () => {
 // Returns HTML position tables fragment for a given display mode
 // ============================================================
 
+describeTabApi({
+  label: 'LeagueStarters API',
+  ratingsUrl: 'modules.php?name=LeagueStarters&op=api&display=ratings',
+  modes: ['ratings', 'total_s', 'avg_s', 'per36mins'],
+  modeUrlFn: (mode) => `modules.php?name=LeagueStarters&op=api&display=${mode}`,
+  modeMsgPrefix: 'LeagueStarters API ',
+  allModesTitle: 'all valid display modes return html',
+  hxPushUrl: 'modules.php?name=LeagueStarters&op=api&display=total_s',
+  hxPushContains: ['display=total_s'],
+});
+
 test.describe('LeagueStarters API', () => {
-  test('ratings display returns HTML with table', async ({ request }) => {
-    const response = await request.get(
-      'modules.php?name=LeagueStarters&op=api&display=ratings',
-    );
-
-    const contentType = response.headers()['content-type'] ?? '';
-    expect(contentType, 'API endpoint must return HTML').toContain('text/html');
-    expect(response.status()).toBe(200);
-
-    const html = await response.text();
-    expect(html).toContain('<table');
-  });
-
-  test('all valid display modes return html', async ({ request }) => {
-    const modes = ['ratings', 'total_s', 'avg_s', 'per36mins'];
-
-    for (const mode of modes) {
-      const response = await request.get(
-        `modules.php?name=LeagueStarters&op=api&display=${mode}`,
-      );
-
-      expect(
-        response.status(),
-        `LeagueStarters API ${mode} should return 200`,
-      ).toBe(200);
-      const html = await response.text();
-      expect(
-        html.length,
-        `LeagueStarters API ${mode} should return non-empty html`,
-      ).toBeGreaterThan(0);
-    }
-  });
-
   test('invalid display mode falls back to ratings', async ({ request }) => {
     const response = await request.get(
       'modules.php?name=LeagueStarters&op=api&display=invalid_mode',
     );
-
     expect(response.status()).toBe(200);
     const html = await response.text();
     expect(html).toContain('<table');
-  });
-
-  test('response includes HX-Push-Url header', async ({ request }) => {
-    const response = await request.get(
-      'modules.php?name=LeagueStarters&op=api&display=total_s',
-    );
-
-    const pushUrl = response.headers()['hx-push-url'] ?? '';
-    expect(pushUrl).toContain('display=total_s');
   });
 });
 

--- a/ibl5/tests/e2e/flows/auth.spec.ts
+++ b/ibl5/tests/e2e/flows/auth.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../fixtures/public';
 import { assertNoPhpErrors } from '../helpers/php-errors';
+import { loginViaForm } from '../helpers/login';
 
 // Login/Logout flow — uses public (unauthenticated) fixture throughout.
 // IMPORTANT: Do NOT use the auth fixture here. The logout test destroys the
@@ -48,20 +49,7 @@ test.describe('Login page', () => {
     expect(username, 'IBL_TEST_USER must be set in .env.test').toBeTruthy();
     expect(password, 'IBL_TEST_PASS must be set in .env.test').toBeTruthy();
 
-    await page.goto('modules.php?name=YourAccount');
-
-    const loginForm = page.locator('form', {
-      has: page.locator('#login-username'),
-    });
-    await loginForm.locator('#login-username').fill(username!);
-    await loginForm.locator('#login-password').fill(password!);
-    await loginForm.locator('button[type="submit"]').click();
-
-    // Successful login redirects away from YourAccount
-    await page.waitForURL(
-      (url) => !url.href.includes('name=YourAccount'),
-      { timeout: 10000 },
-    );
+    await loginViaForm(page, username!, password!);
 
     // Should be on a different page now
     expect(page.url()).not.toContain('name=YourAccount');
@@ -190,19 +178,7 @@ test.describe('Logout flow', () => {
     expect(username, 'IBL_TEST_USER must be set in .env.test').toBeTruthy();
     expect(password, 'IBL_TEST_PASS must be set in .env.test').toBeTruthy();
 
-    // Log in manually with a fresh session
-    await page.goto('modules.php?name=YourAccount');
-    const loginForm = page.locator('form', {
-      has: page.locator('#login-username'),
-    });
-    await loginForm.locator('#login-username').fill(username!);
-    await loginForm.locator('#login-password').fill(password!);
-    await loginForm.locator('button[type="submit"]').click();
-
-    await page.waitForURL(
-      (url) => !url.href.includes('name=YourAccount'),
-      { timeout: 10000 },
-    );
+    await loginViaForm(page, username!, password!);
 
     // Verify we're logged in — can access a protected page
     await page.goto('modules.php?name=DepthChartEntry');

--- a/ibl5/tests/e2e/flows/csrf-rejection.spec.ts
+++ b/ibl5/tests/e2e/flows/csrf-rejection.spec.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'node:crypto';
-import type { APIRequestContext } from '@playwright/test';
 import { test, expect } from '../fixtures/auth';
+import { fetchToken } from '../helpers/csrf';
 
 /**
  * Forged-CSRF-token rejection — the negative security path the rest of the
@@ -23,55 +23,6 @@ import { test, expect } from '../fixtures/auth';
 /** A random 64-hex token — correct format, wrong value. */
 function forgedToken(): string {
   return randomBytes(32).toString('hex');
-}
-
-/**
- * Fetch a fresh, valid `_csrf_token` from a GET-rendered form on `path`.
- *
- * A page can render several CSRF tokens (each gate has its own per-action
- * token — e.g. the admin DebugMenu toggle in the page chrome). Pass `formName`
- * to scope extraction to a specific `<form name="...">`; the token for that
- * form is the first `_csrf_token` after the form's opening tag.
- *
- * Without `formName`, the page must contain exactly one token — if it has
- * more, extraction is ambiguous (the first match may be the chrome's token,
- * not the form under test) and this throws rather than silently picking one.
- */
-async function fetchToken(
-  request: APIRequestContext,
-  path: string,
-  formName?: string,
-): Promise<string> {
-  const resp = await request.get(path);
-  if (!resp.ok()) {
-    throw new Error(`token fetch GET ${path} failed: ${resp.status()}`);
-  }
-  let body = await resp.text();
-  if (formName === undefined) {
-    const tokenCount = (
-      body.match(/name="_csrf_token" value="[0-9a-f]+"/g) ?? []
-    ).length;
-    if (tokenCount > 1) {
-      throw new Error(
-        `ambiguous _csrf_token on ${path}: ${tokenCount} tokens found — ` +
-          `pass a formName to scope extraction to the form under test`,
-      );
-    }
-  } else {
-    const formIdx = body.indexOf(`name="${formName}"`);
-    if (formIdx === -1) {
-      throw new Error(`form name="${formName}" not found on ${path}`);
-    }
-    body = body.slice(formIdx);
-  }
-  const match = body.match(/name="_csrf_token" value="([0-9a-f]+)"/);
-  if (match === null) {
-    throw new Error(
-      `no _csrf_token found on ${path}` +
-        (formName !== undefined ? ` in form "${formName}"` : ''),
-    );
-  }
-  return match[1];
 }
 
 test.describe('Forged CSRF token is rejected', () => {

--- a/ibl5/tests/e2e/flows/depth-chart-entry.spec.ts
+++ b/ibl5/tests/e2e/flows/depth-chart-entry.spec.ts
@@ -1,9 +1,28 @@
 import { test, expect } from '../fixtures/auth';
 import { assertNoPhpErrors } from '../helpers/php-errors';
+import type { Page } from '@playwright/test';
 
 // Depth Chart Entry — authenticated page.
 // The roster form may load asynchronously after the page header renders.
 // NOTE: Do NOT submit the form — that would mutate data.
+
+async function installPreviewObserver(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const container = document.getElementById('dc-lineup-preview');
+    if (!container) return;
+    const w = window as typeof window & {
+      __ibl_preview_mutations?: number;
+      __ibl_preview_observer?: MutationObserver;
+    };
+    w.__ibl_preview_mutations = 0;
+    w.__ibl_preview_observer?.disconnect();
+    const observer = new MutationObserver(() => {
+      w.__ibl_preview_mutations = (w.__ibl_preview_mutations ?? 0) + 1;
+    });
+    observer.observe(container, { childList: true, subtree: true });
+    w.__ibl_preview_observer = observer;
+  });
+}
 
 test.describe('Depth Chart Entry flow', () => {
   test.beforeEach(async ({ page }) => {
@@ -172,28 +191,7 @@ test.describe('Depth Chart Entry flow', () => {
       preview.locator('.dc-lineup-preview-table--desktop'),
     ).toBeVisible();
 
-    // Install a MutationObserver on the preview container. depth-chart-lineup-
-    // preview.js re-renders via `container.innerHTML = html`, which replaces
-    // the entire childList subtree — the observer fires even when the new
-    // HTML is byte-identical, so we get a clean "recalculate happened"
-    // signal without depending on the pg change producing a visible diff.
-    // (For many rosters a pg=0→1 promotion produces identical output
-    // because the new candidate's score doesn't beat the incumbents.)
-    await page.evaluate(() => {
-      const container = document.getElementById('dc-lineup-preview');
-      if (!container) return;
-      const w = window as typeof window & {
-        __ibl_preview_mutations?: number;
-        __ibl_preview_observer?: MutationObserver;
-      };
-      w.__ibl_preview_mutations = 0;
-      w.__ibl_preview_observer?.disconnect();
-      const observer = new MutationObserver(() => {
-        w.__ibl_preview_mutations = (w.__ibl_preview_mutations ?? 0) + 1;
-      });
-      observer.observe(container, { childList: true, subtree: true });
-      w.__ibl_preview_observer = observer;
-    });
+    await installPreviewObserver(page);
 
     // Change a desktop pg select (scoped to `.depth-chart-table` to avoid
     // strict-mode collisions with the mobile card duplicates). Any change
@@ -229,31 +227,7 @@ test.describe('Depth Chart Entry flow', () => {
       preview.locator('.dc-lineup-preview-table--desktop .dc-lineup-preview__starter').first(),
     ).toBeVisible();
 
-    // Install a MutationObserver on the preview container — depth-chart-
-    // lineup-preview.js re-renders via `container.innerHTML = html`, which
-    // replaces the entire childList subtree. The observer fires whenever
-    // recalculate() runs, regardless of whether the new HTML happens to be
-    // byte-identical to the previous render. This is more robust than text
-    // comparison: in seed scenarios where the dc_minutes change doesn't move
-    // any rendered annotation (e.g. starter is also the dump-to-last entry
-    // when bench-scan can't fill 3 backups), the recalculate still fires and
-    // the wiring is what we're verifying. The number-input listener is on a
-    // separate code path from the position-depth SELECT listener covered above.
-    await page.evaluate(() => {
-      const container = document.getElementById('dc-lineup-preview');
-      if (!container) return;
-      const w = window as typeof window & {
-        __ibl_preview_mutations?: number;
-        __ibl_preview_observer?: MutationObserver;
-      };
-      w.__ibl_preview_mutations = 0;
-      w.__ibl_preview_observer?.disconnect();
-      const observer = new MutationObserver(() => {
-        w.__ibl_preview_mutations = (w.__ibl_preview_mutations ?? 0) + 1;
-      });
-      observer.observe(container, { childList: true, subtree: true });
-      w.__ibl_preview_observer = observer;
-    });
+    await installPreviewObserver(page);
 
     // Mutate the first desktop minutes input. Scoped to `.depth-chart-table`
     // to avoid strict-mode collisions with the mobile card duplicates.

--- a/ibl5/tests/e2e/flows/password-reset.spec.ts
+++ b/ibl5/tests/e2e/flows/password-reset.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '../fixtures/public';
 import { assertNoPhpErrors } from '../helpers/php-errors';
 import { seedResetUser, type SeedResetUser } from '../helpers/test-state';
 import { deleteTestUser } from '../helpers/cleanup';
+import { loginViaForm } from '../helpers/login';
 
 // Password reset flow — uses public (unauthenticated) fixture.
 // Full end-to-end reset not covered: intercepting the password-reset email
@@ -133,17 +134,7 @@ test.describe('Password reset round-trip', () => {
   });
 
   test('new password logs in successfully', async ({ page }) => {
-    await page.goto('modules.php?name=YourAccount');
-    const loginForm = page.locator('form', {
-      has: page.locator('#login-username'),
-    });
-    await loginForm.locator('#login-username').fill(seeded.username);
-    await loginForm.locator('#login-password').fill(NEW_PASSWORD);
-    await loginForm.locator('button[type="submit"]').click();
-
-    await page.waitForURL((url) => !url.href.includes('name=YourAccount'), {
-      timeout: 10_000,
-    });
+    await loginViaForm(page, seeded.username, NEW_PASSWORD);
     expect(page.url()).not.toContain('name=YourAccount');
   });
 

--- a/ibl5/tests/e2e/flows/projected-draft-order.spec.ts
+++ b/ibl5/tests/e2e/flows/projected-draft-order.spec.ts
@@ -5,6 +5,11 @@ import { publicStorageState } from '../helpers/public-storage-state';
 // Projected Draft Order — public page.
 test.use({ storageState: publicStorageState() });
 
+const TABLE_SEL = '.projected-draft-order-table, .ibl-data-table';
+
+const TEAM_LINK_SEL =
+  '.projected-draft-order-table a[href*="teamid="], .ibl-data-table a[href*="teamid="]';
+
 test.describe('Projected Draft Order flow', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('modules.php?name=ProjectedDraftOrder');
@@ -15,12 +20,12 @@ test.describe('Projected Draft Order flow', () => {
   });
 
   test('draft order table is visible', async ({ page }) => {
-    const table = page.locator('.projected-draft-order-table, .ibl-data-table').first();
+    const table = page.locator(TABLE_SEL).first();
     await expect(table).toBeVisible();
   });
 
   test('table has expected columns', async ({ page }) => {
-    const table = page.locator('.projected-draft-order-table, .ibl-data-table').first();
+    const table = page.locator(TABLE_SEL).first();
     await expect(table).toBeVisible();
 
     const headerText = await table.locator('thead').textContent();
@@ -30,20 +35,20 @@ test.describe('Projected Draft Order flow', () => {
 
   test('table has at least 28 team rows', async ({ page }) => {
     // CI seed has 28 teams in standings — all should appear in round 1
-    const table = page.locator('.projected-draft-order-table, .ibl-data-table').first();
+    const table = page.locator(TABLE_SEL).first();
     const rows = table.locator('tbody tr:not(.projected-draft-order-separator)');
     expect(await rows.count()).toBeGreaterThanOrEqual(28);
   });
 
   test('pick numbers start at 1', async ({ page }) => {
-    const table = page.locator('.projected-draft-order-table, .ibl-data-table').first();
+    const table = page.locator(TABLE_SEL).first();
     const pickCells = table.locator('tbody tr:not(.projected-draft-order-separator) td:first-child');
     const firstPick = await pickCells.first().textContent();
     expect(parseInt(firstPick?.trim() ?? '', 10)).toBe(1);
   });
 
   test('team cells link to team pages', async ({ page }) => {
-    const teamLinks = page.locator('.projected-draft-order-table a[href*="teamid="], .ibl-data-table a[href*="teamid="]');
+    const teamLinks = page.locator(TEAM_LINK_SEL);
     const count = await teamLinks.count();
     expect(count).toBeGreaterThanOrEqual(1);
 

--- a/ibl5/tests/e2e/flows/trading-submission.spec.ts
+++ b/ibl5/tests/e2e/flows/trading-submission.spec.ts
@@ -6,6 +6,7 @@ import { submitFormAndAssertEffect } from '../helpers/submit-form';
 import {
   buildFormBody,
   collectNewOfferIds,
+  collectOfferIdSet,
   rejectOfferSafe,
   type FormData,
 } from '../helpers/trading';
@@ -205,21 +206,6 @@ async function submitOffer(
   return response.headers()['location'] ?? '';
 }
 
-/**
- * Collect all offer IDs currently on the review page.
- */
-async function collectAllOfferIds(page: Page): Promise<Set<number>> {
-  await gotoWithRetry(page, 'modules.php?name=Trading&op=reviewtrade');
-  const buttons = page.locator('[data-preview-offer]');
-  const count = await buttons.count();
-  const ids = new Set<number>();
-  for (let i = 0; i < count; i++) {
-    const idStr = await buttons.nth(i).getAttribute('data-preview-offer');
-    ids.add(parseInt(idStr ?? '0', 10));
-  }
-  return ids;
-}
-
 // ---------------------------------------------------------------------------
 // Block 1: Players-only trade (UI-driven)
 // ---------------------------------------------------------------------------
@@ -318,7 +304,7 @@ test.describe('Trade submission: draft pick trade (API)', () => {
     expect(fd, 'CI seed must provide a partner with user pick + partner player').toBeTruthy();
 
     const token = await getCsrfToken(page);
-    const existingIds = await collectAllOfferIds(page);
+    const existingIds = await collectOfferIdSet(page);
 
     const pickIdx = getUserPickIndices(fd!)[0];
     const partnerIdx = getPartnerPlayerIndices(fd!)[0];
@@ -357,7 +343,7 @@ test.describe('Trade submission: cash-only trade (API)', () => {
     expect(fd, 'CI seed must provide a trade partner').toBeTruthy();
 
     const token = await getCsrfToken(page);
-    const existingIds = await collectAllOfferIds(page);
+    const existingIds = await collectOfferIdSet(page);
 
     const cashYear = fd!.cashStartYear;
     const body = buildFormBody(fd!, [], { [cashYear]: 200 }, undefined, token);
@@ -399,7 +385,7 @@ test.describe('Trade submission: mixed trade (API)', () => {
     expect(fd, 'CI seed must provide a partner with tradeable players on both sides').toBeTruthy();
 
     const token = await getCsrfToken(page);
-    const existingIds = await collectAllOfferIds(page);
+    const existingIds = await collectOfferIdSet(page);
 
     // Player+cash adds the partner's player salary to the offering team — the
     // genuine cap-risk case. Make the selection cap-safe (seed-independent):
@@ -516,7 +502,7 @@ test.describe('Trade submission: accept and reject', () => {
 
     const tokenA = await getCsrfToken(page);
     const tradeFormUrl = page.url();
-    const existingIds = await collectAllOfferIds(page);
+    const existingIds = await collectOfferIdSet(page);
     const userPlayers = getUserPlayerIndices(fd!);
     const partnerPlayers = getPartnerPlayerIndices(fd!);
     const bodyA = buildFormBody(fd!, [userPlayers[0], partnerPlayers[0]], undefined, undefined, tokenA);

--- a/ibl5/tests/e2e/flows/voting-submission.spec.ts
+++ b/ibl5/tests/e2e/flows/voting-submission.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../fixtures/auth';
 import { assertNoPhpErrors } from '../helpers/php-errors';
+import { expandVotingCategory } from '../helpers/voting';
 import { submitFormAndAssertEffect } from '../helpers/submit-form';
 import { getVotes, resetVote } from '../helpers/test-state';
 
@@ -28,20 +29,7 @@ test.describe('ASG Voting: submission', () => {
     const categories = ['ECF', 'ECB', 'WCF', 'WCB'];
 
     for (const cat of categories) {
-      // Click category header to reveal table
-      const header = page.locator(`.voting-category`).filter({
-        hasText: new RegExp(cat === 'ECF' ? 'Eastern.*Frontcourt|ECF' :
-          cat === 'ECB' ? 'Eastern.*Backcourt|ECB' :
-          cat === 'WCF' ? 'Western.*Frontcourt|WCF' :
-          'Western.*Backcourt|WCB', 'i'),
-      });
-
-      await expect(header.first(), 'voting category header must render').toBeVisible();
-      const isExpanded = await header.first().getAttribute('aria-expanded');
-      // e2e-hygiene-allow: branch is an observable-state toggle, not a silent guard
-      if (isExpanded !== 'true') {
-        await header.first().click();
-      }
+      await expandVotingCategory(page, cat);
 
       const table = page.locator(`#${cat}`);
       // Wait for table visibility
@@ -157,23 +145,7 @@ test.describe('EOY Voting: validation errors', () => {
 
     // Fill ROY, Six, GM but leave MVP empty
     for (const cat of ['ROY', 'Six', 'GM']) {
-      const header = page.locator('.voting-category').filter({
-        hasText: new RegExp(
-          cat === 'ROY'
-            ? 'Rookie|ROY'
-            : cat === 'Six'
-              ? 'Sixth|6th'
-              : 'GM|General Manager',
-          'i',
-        ),
-      });
-
-      await expect(header.first(), 'voting category header must render').toBeVisible();
-      const isExpanded = await header.first().getAttribute('aria-expanded');
-      // e2e-hygiene-allow: branch is an observable-state toggle, not a silent guard
-      if (isExpanded !== 'true') {
-        await header.first().click();
-      }
+      await expandVotingCategory(page, cat);
 
       const table = page.locator(`#${cat}`);
       await expect(table).toBeVisible();
@@ -208,25 +180,7 @@ test.describe('EOY Voting: validation errors', () => {
 
     // Expand all categories and fill them
     for (const cat of ['MVP', 'Six', 'ROY', 'GM']) {
-      const header = page.locator('.voting-category').filter({
-        hasText: new RegExp(
-          cat === 'MVP'
-            ? 'MVP|Most Valuable'
-            : cat === 'Six'
-              ? 'Sixth|6th'
-              : cat === 'ROY'
-                ? 'Rookie|ROY'
-                : 'GM|General Manager',
-          'i',
-        ),
-      });
-
-      await expect(header.first(), 'voting category header must render').toBeVisible();
-      const isExpanded = await header.first().getAttribute('aria-expanded');
-      // e2e-hygiene-allow: branch is an observable-state toggle, not a silent guard
-      if (isExpanded !== 'true') {
-        await header.first().click();
-      }
+      await expandVotingCategory(page, cat);
 
       const table = page.locator(`#${cat}`);
       await expect(table).toBeVisible();
@@ -299,19 +253,7 @@ test.describe('EOY Voting: submission', () => {
     const categories = ['MVP', 'Six', 'ROY', 'GM'];
 
     for (const cat of categories) {
-      const header = page.locator('.voting-category').filter({
-        hasText: new RegExp(cat === 'MVP' ? 'MVP|Most Valuable' :
-          cat === 'Six' ? 'Sixth|6th' :
-          cat === 'ROY' ? 'Rookie|ROY' :
-          'GM|General Manager', 'i'),
-      });
-
-      await expect(header.first(), 'voting category header must render').toBeVisible();
-      const isExpanded = await header.first().getAttribute('aria-expanded');
-      // e2e-hygiene-allow: branch is an observable-state toggle, not a silent guard
-      if (isExpanded !== 'true') {
-        await header.first().click();
-      }
+      await expandVotingCategory(page, cat);
 
       const table = page.locator(`#${cat}`);
       await expect(table).toBeVisible();

--- a/ibl5/tests/e2e/helpers/csrf.ts
+++ b/ibl5/tests/e2e/helpers/csrf.ts
@@ -40,3 +40,48 @@ export async function fetchRookieOptionCsrfToken(
   }
   return match[1];
 }
+
+/**
+ * Fetch a fresh, valid `_csrf_token` from a GET-rendered form on `path`.
+ *
+ * Pass `formName` to scope extraction to a specific `<form name="...">`; the
+ * token for that form is the first `_csrf_token` after the form's opening tag.
+ * Without `formName`, the page must contain exactly one token — if it has more,
+ * extraction is ambiguous and this throws rather than silently picking one.
+ */
+export async function fetchToken(
+  request: APIRequestContext,
+  path: string,
+  formName?: string,
+): Promise<string> {
+  const resp = await request.get(path);
+  if (!resp.ok()) {
+    throw new Error(`token fetch GET ${path} failed: ${resp.status()}`);
+  }
+  let body = await resp.text();
+  if (formName === undefined) {
+    const tokenCount = (
+      body.match(/name="_csrf_token" value="[0-9a-f]+"/g) ?? []
+    ).length;
+    if (tokenCount > 1) {
+      throw new Error(
+        `ambiguous _csrf_token on ${path}: ${tokenCount} tokens found — ` +
+          `pass a formName to scope extraction to the form under test`,
+      );
+    }
+  } else {
+    const formIdx = body.indexOf(`name="${formName}"`);
+    if (formIdx === -1) {
+      throw new Error(`form name="${formName}" not found on ${path}`);
+    }
+    body = body.slice(formIdx);
+  }
+  const match = body.match(/name="_csrf_token" value="([0-9a-f]+)"/);
+  if (match === null) {
+    throw new Error(
+      `no _csrf_token found on ${path}` +
+        (formName !== undefined ? ` in form "${formName}"` : ''),
+    );
+  }
+  return match[1];
+}

--- a/ibl5/tests/e2e/helpers/login.ts
+++ b/ibl5/tests/e2e/helpers/login.ts
@@ -1,0 +1,24 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Navigate to YourAccount, fill the login form, submit, and await the
+ * post-login redirect. Works for any credentials that produce a redirect
+ * (i.e., valid credentials). Do NOT call this for invalid-credential tests
+ * that expect to remain on YourAccount — the waitForURL will timeout.
+ */
+export async function loginViaForm(
+  page: Page,
+  username: string,
+  password: string,
+): Promise<void> {
+  await page.goto('modules.php?name=YourAccount');
+  const loginForm = page.locator('form', { has: page.locator('#login-username') });
+  await loginForm.locator('#login-username').fill(username);
+  await loginForm.locator('#login-password').fill(password);
+  await Promise.all([
+    page.waitForURL((url) => !url.href.includes('name=YourAccount'), {
+      timeout: 20_000,
+    }),
+    loginForm.locator('button[type="submit"]').click(),
+  ]);
+}

--- a/ibl5/tests/e2e/helpers/trading.ts
+++ b/ibl5/tests/e2e/helpers/trading.ts
@@ -105,6 +105,25 @@ export async function collectNewOfferIds(
 }
 
 /**
+ * Collect all offer IDs currently on the review page as a Set.
+ *
+ * Unlike `collectNewOfferIds`, this collects every visible offer with no
+ * exclusion filter — use it to snapshot the full offer set before an action,
+ * then diff against the result to find what changed.
+ */
+export async function collectOfferIdSet(page: Page): Promise<Set<number>> {
+  await gotoWithRetry(page, 'modules.php?name=Trading&op=reviewtrade');
+  const buttons = page.locator('[data-preview-offer]');
+  const count = await buttons.count();
+  const ids = new Set<number>();
+  for (let i = 0; i < count; i++) {
+    const idStr = await buttons.nth(i).getAttribute('data-preview-offer');
+    ids.add(parseInt(idStr ?? '0', 10));
+  }
+  return ids;
+}
+
+/**
  * Reject a trade offer via API POST for cleanup (best-effort).
  */
 export async function rejectOfferSafe(

--- a/ibl5/tests/e2e/helpers/voting.ts
+++ b/ibl5/tests/e2e/helpers/voting.ts
@@ -1,0 +1,32 @@
+import type { Page } from '@playwright/test';
+import { expect } from '../fixtures/base';
+
+const CATEGORY_REGEX: Record<string, string> = {
+  ECF: 'Eastern.*Frontcourt|ECF',
+  ECB: 'Eastern.*Backcourt|ECB',
+  WCF: 'Western.*Frontcourt|WCF',
+  WCB: 'Western.*Backcourt|WCB',
+  MVP: 'MVP|Most Valuable',
+  Six: 'Sixth|6th',
+  ROY: 'Rookie|ROY',
+  GM: 'GM|General Manager',
+};
+
+export async function expandVotingCategory(page: Page, cat: string): Promise<void> {
+  const pattern = CATEGORY_REGEX[cat];
+  if (pattern === undefined) {
+    throw new Error(
+      `expandVotingCategory: unknown category "${cat}". ` +
+        `Known: ${Object.keys(CATEGORY_REGEX).join(', ')}`,
+    );
+  }
+  const header = page.locator('.voting-category').filter({
+    hasText: new RegExp(pattern, 'i'),
+  });
+  await expect(header.first(), 'voting category header must render').toBeVisible();
+  const isExpanded = await header.first().getAttribute('aria-expanded');
+  // e2e-hygiene-allow: branch is an observable-state toggle, not a silent guard
+  if (isExpanded !== 'true') {
+    await header.first().click();
+  }
+}

--- a/ibl5/tests/e2e/smoke/auth-regular-user-provisioned.spec.ts
+++ b/ibl5/tests/e2e/smoke/auth-regular-user-provisioned.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import { loginViaForm } from '../helpers/login';
 import { test, expect } from '../fixtures/base';
 
 /**
@@ -13,17 +13,6 @@ import { test, expect } from '../fixtures/base';
  */
 
 test.use({ storageState: { cookies: [], origins: [] } });
-
-async function loginViaForm(page: Page, username: string, password: string): Promise<void> {
-  await page.goto('modules.php?name=YourAccount');
-  const loginForm = page.locator('form', { has: page.locator('#login-username') });
-  await loginForm.locator('#login-username').fill(username);
-  await loginForm.locator('#login-password').fill(password);
-  await Promise.all([
-    page.waitForURL((url) => !url.href.includes('name=YourAccount'), { timeout: 20_000 }),
-    loginForm.locator('button[type="submit"]').click(),
-  ]);
-}
 
 test.describe('Regular (non-admin) test user provisioning', () => {
   test.beforeEach(async ({ request }) => {

--- a/ibl5/tests/e2e/smoke/schedule-contrast.spec.ts
+++ b/ibl5/tests/e2e/smoke/schedule-contrast.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures/public';
 import { assertNoA11yViolations } from '../helpers/accessibility';
 import { gotoWithRetry } from '../helpers/navigation';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // NOTE: the historically-reported flake here could not be reproduced or traced
 // (the failing CI artifacts had expired and the test passed in every surviving
@@ -10,7 +11,6 @@ import { gotoWithRetry } from '../helpers/navigation';
 // violation into a silent pass. If it still flakes, capture the trace before
 // touching the axe assertion itself.
 
-const PHP_ERROR_STRINGS = ['Fatal error', 'Warning:', 'Parse error', 'Uncaught', 'Stack trace:'];
 
 test.describe('Schedule color-contrast (issue #908)', () => {
   // League schedule renders all teams — slower under parallel CI shard load.
@@ -40,9 +40,6 @@ test.describe('Schedule color-contrast (issue #908)', () => {
   test('no PHP errors on Schedule page', async ({ page, appState }) => {
     await appState({ 'Trivia Mode': 'Off' });
     await page.goto('modules.php?name=Schedule');
-    const body = await page.textContent('body') ?? '';
-    for (const errStr of PHP_ERROR_STRINGS) {
-      expect(body, `PHP error on Schedule page: ${errStr}`).not.toContain(errStr);
-    }
+    await assertNoPhpErrors(page, 'on Schedule page');
   });
 });


### PR DESCRIPTION
## Summary

Implements E2E backlog Axis A (A1–A9): extracts 8 duplicated inline patterns into shared helpers or local hoisted functions, keeping the suite semantically identical.

- **A1** — Extract `loginViaForm` to `helpers/login.ts`; update 4 call sites in auth.spec.ts, password-reset.spec.ts, auth-regular-user-provisioned.spec.ts
- **A2** — Import `assertNoPhpErrors` in `smoke/schedule-contrast.spec.ts`; remove inline PHP_ERROR_STRINGS loop
- **A3** — Extract `expandVotingCategory` to `helpers/voting.ts`; replace 4 ternary blocks in voting-submission.spec.ts
- **A4** — Introduce `describeTabApi` factory in ajax-api-endpoints.spec.ts; replace 3 duplicated describe blocks (DCE / Team / LeagueStarters)
- **A5** — Hoist `installPreviewObserver` within depth-chart-entry.spec.ts; replace 2 observer evaluate blocks
- **A6** — Add `collectOfferIdSet` to `helpers/trading.ts`; replace local `collectAllOfferIds` at 4 call sites
- **A7** — Promote `fetchToken` to `helpers/csrf.ts`; update csrf-rejection.spec.ts imports
- **A8** — Hoist `TABLE_SEL` and `TEAM_LINK_SEL` consts in projected-draft-order.spec.ts
- **A9** — Flip A1–A8 status to ✅ Implemented in `e2e-backlog.md`; bump `last_verified`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
