### PR TITLE
fix(post-plan-now): escape prompts through launchd boundary

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -9,11 +9,13 @@ on:
     paths:
       - 'tools/postplan-harness/**'
       - '.github/workflows/python-tests.yml'
+      - 'bin/post-plan-now'
   push:
     branches: [master]
     paths:
       - 'tools/postplan-harness/**'
       - '.github/workflows/python-tests.yml'
+      - 'bin/post-plan-now'
 
 permissions:
   contents: read

--- a/bin/docfix-run
+++ b/bin/docfix-run
@@ -13,6 +13,17 @@
 
 set -euo pipefail
 
+# shq <string> — single-quote for the FAR side of the launchd boundary; xml_escape —
+# entity-escape for the plist <string> element. Both are needed, and for different
+# hazards: the plist text is parsed as XML by launchd AND as shell by `/bin/bash -lc`.
+# Interpolating $PROMPT inside \"…\" left its many `backticks` live at that second
+# parse — every backticked span was EXECUTED and then deleted from what the model
+# received (2026-08-08 run: `bin/post-plan-now` actually fired mid-assembly; see the
+# "command not found" lines in /tmp/docfix-run-*.log). Twin of the same defect in
+# bin/post-plan-now, whose shq() header carries the full rationale.
+shq()        { local q="'\\''"; printf "'%s'" "${1//\'/$q}"; }
+xml_escape() { printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'; }
+
 # --- 1. Validate args (negative path) -----------------------------------------
 ISSUE_NUM="${1:-}"
 SIG="${2:-}"
@@ -74,6 +85,9 @@ PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
 TODAY="$(date -u +%Y-%m-%d)"
 
 PROMPT="You are fixing doc findings with NO human present — never ask questions or wait for input; make the safe choice and continue. The findings are the nightly Doc Freshness Audit set for issue #$ISSUE_NUM. Work ONLY on these paths (comma-separated): $SIG. First run \`bin/check-docs --staleness-report\` and split its JSON with jq into entries whose \`reason\` is \`stale\` and entries whose \`reason\` is \`dead-glob\`; that command is the authoritative finding list, and the body of issue #$ISSUE_NUM shows the same two tables for reference. For each \`stale\` entry: re-verify its content against the current reality of the codebase, correct drifted content, and bump its \`last_verified\` to today ($TODAY). For each \`dead-glob\` entry: the named file declares a \`paths:\` frontmatter glob matching no tracked file, so that rule can never load — PREFER correcting the glob so it matches the tracked files it was meant to cover, and delete the \`paths:\` entry only when no correction is identifiable. IF you delete a glob you MUST disclose it: add one line per deletion to the commit message body AND to the PR body under a heading reading \`## Dead globs deleted\`, in exactly this form: \`Dead glob deleted: in FILE_PATH, removed paths: entry GLOB — REASON\`, substituting the real repo-relative path, the exact glob text, and one clause saying why no correction was possible, so the maintainer can review the deletion without opening the diff. Never delete a whole file, and never remove a \`paths:\` key that still carries a working glob. Then run \`bin/check-docs --fix-dates --since=master\` to bump any in-scope doc you changed but did not hand-bump, and re-run \`bin/check-docs --staleness-report\` to confirm every finding you were given is gone. Do NOT touch any doc outside the list above. Commit with a message whose body contains the line \`Closes #$ISSUE_NUM\`. Then fire \`bin/post-plan-now\` (NOT --auto) to open the PR; the PR body MUST include \`Closes #$ISSUE_NUM\` so merging it closes the stale-docs issue."
+# Shell-quote first (far-side bash), then XML-escape (launchd's plist parser). Order
+# matters: shq's output is what has to survive into the <string> element intact.
+PROMPT_ARG=$(xml_escape "$(shq "$PROMPT")")
 
 # launchd runs a minimal env → same PATH prelude as bin/post-plan-now:94.
 cat > "$PLIST" <<PLIST_EOF
@@ -87,7 +101,7 @@ cat > "$PLIST" <<PLIST_EOF
 	<array>
 		<string>/bin/bash</string>
 		<string>-lc</string>
-		<string>export PATH="/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH"; cd "$WT_ROOT" &amp;&amp; CLAUDE_HEADLESS=1 caffeinate -s claude -p "$PROMPT" --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name "$LABEL"; rm -f "$PLIST"; launchctl bootout gui/\$(id -u)/$LABEL</string>
+		<string>export PATH="/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH"; cd "$WT_ROOT" &amp;&amp; CLAUDE_HEADLESS=1 caffeinate -s claude -p $PROMPT_ARG --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name "$LABEL"; rm -f "$PLIST"; launchctl bootout gui/\$(id -u)/$LABEL</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>

--- a/bin/post-plan-now
+++ b/bin/post-plan-now
@@ -41,6 +41,17 @@
 # `declare -f`, so the tested logic here is exactly what runs there.
 should_fallback() { case "$1" in 0|3) return 1 ;; *) return 0 ;; esac; }
 
+# shq <string> — single-quote <string> for the FAR side of the launchd boundary.
+# Everything this script assembles into $CMD is parsed by a shell a SECOND time, when
+# launchd runs `/bin/bash -lc "$CMD"`. Embedding a variable there in DOUBLE quotes leaves
+# `…`, $(…), $VAR and \ live at that second parse. That is not theoretical: the prompt's
+# literal backticks around <slug>-N.md fired as command substitution in every plan-blind
+# run, bash logged `line 10: slug: No such file or directory`, and the backticked span was
+# SILENTLY DELETED from the prompt the model received — the plan-disambiguation
+# instruction never arrived. Single quotes close the whole class for any future wording.
+# Defined above the sourced-guard so the unit test can source and exercise it.
+shq() { local q="'\\''"; printf "'%s'" "${1//\'/$q}"; }
+
 # Sourced-guard: the unit test does `source bin/post-plan-now` to load should_fallback, then this
 # returns before the body executes. Must sit before `set -euo pipefail` (sourcing must not alter
 # the caller's shell options).
@@ -132,7 +143,7 @@ GATE_CLOSE=""
 ENGINE="Sonnet 4.6 /post-plan skill session"
 if [ "${POST_PLAN_SKILL:-0}" != "1" ] && [ -x "$HARNESS/run" ]; then
     FALLBACK_FN="$(declare -f should_fallback); "
-    PLAN_ARG="${PLAN_OVERRIDE:+ --plan \"$PLAN_OVERRIDE\"}"
+    PLAN_ARG="${PLAN_OVERRIDE:+ --plan $(shq "$PLAN_OVERRIDE")}"
     HARNESS_SEG="CLAUDE_HEADLESS=1 caffeinate -s \"$HARNESS/run\" isolated \"$ROOT\" \"$HARNESS/out/live-$SLUG-$TS\" --live${PLAN_ARG}; rc=\$?; "
     GATE_OPEN="if should_fallback \"\$rc\"; then "
     GATE_CLOSE="; elif [ \"\$rc\" = 3 ]; then echo \"post-plan-now: harness exited 3 (rebase-conflict fail-closed sentinel). SKIPPING the /post-plan skill fallback; a human must resolve the stacked-branch rebase conflict, then re-run bin/post-plan-now. See $LOG.\"; fi"
@@ -156,9 +167,18 @@ fi
 # what broke this script before: a prompt containing `<slug>-N.md` made the
 # <string> element malformed XML, so `launchctl bootstrap` died with
 # "Bootstrap failed: 5: Input/output error" and no log was ever written.
+#
+# XML escaping is only HALF the boundary. $CMD is also re-parsed as SHELL by
+# `/bin/bash -lc` at the far end, so every variable carrying FREE-FORM TEXT — the
+# prompt and the --plan path — is quoted with shq() (see its header) rather than
+# interpolated inside \"…\". (The rest — $ROOT, $LABEL, $PLIST, $LOG — are values
+# this script controls, so \"…\" is fine for them.) Interpolation is what let
+# the same `<slug>-N.md` string break a second way — as command substitution that
+# silently deleted itself from the prompt. Both hazards, one string, different fixes:
+# do not "simplify" either one away.
 xml_escape() { printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'; }
 
-CMD="export PATH=\"/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH\"; cd \"$ROOT\" && { ${FALLBACK_FN}${HARNESS_SEG}${GATE_OPEN}CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 CLAUDE_HEADLESS=1 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 caffeinate -s claude -p \"$PROMPT\" --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name \"$LABEL\"${GATE_CLOSE}; }; rm -f \"$PLIST\"; launchctl bootout gui/\$(id -u)/$LABEL"
+CMD="export PATH=\"/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH\"; cd \"$ROOT\" && { ${FALLBACK_FN}${HARNESS_SEG}${GATE_OPEN}CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 CLAUDE_HEADLESS=1 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 caffeinate -s claude -p $(shq "$PROMPT") --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name \"$LABEL\"${GATE_CLOSE}; }; rm -f \"$PLIST\"; launchctl bootout gui/\$(id -u)/$LABEL"
 
 CMD_XML=$(xml_escape "$CMD")
 LABEL_XML=$(xml_escape "$LABEL")

--- a/bin/test-docfix-run
+++ b/bin/test-docfix-run
@@ -455,5 +455,41 @@ SB="$(build_sandbox)"
   && ok "(19c) poll completes under launchd's minimal PATH and fires the launcher" \
   || bad "(19c) poll broken under launchd minimal PATH"
 
+# --- Case 20: prompt-fidelity round-trip ----------------------------------------
+# Verifies that backticks in $PROMPT survive the launchd double-parse intact.
+# Fix: shq() single-quotes $PROMPT so bash treats backticks as literals at the
+# second parse (the one launchd triggers with `/bin/bash -lc`).
+# Old failure: every `backtick span` was executed and then DELETED from the prompt
+# the model received (2026-08-08 run: `bin/post-plan-now` fired mid-assembly).
+SB="$(build_sandbox)"
+run_docfix "$SB" "" "" "9999" "probe.md" >/dev/null
+PLIST_F20="$(plist_of "$SB")"
+if [ -n "$PLIST_F20" ]; then
+    # Extract the <string> element bearing the bash command; XML-unescape (&amp; LAST
+    # to avoid double-unescaping e.g. &amp;lt; → <).
+    CMD_LINE20=$(grep 'claude -p' "$PLIST_F20" \
+        | sed 's/&lt;/</g; s/&gt;/>/g; s/&amp;/\&/g')
+    # Pull the claude -p token (single-quoted after fix; double-quoted in old script).
+    PROMPT_TOKEN20=$(printf '%s' "$CMD_LINE20" \
+        | sed -n 's/.*claude -p \(.*\) --dangerously.*/\1/p')
+    if [ -n "$PROMPT_TOKEN20" ]; then
+        # Run from an empty scratch dir so relative paths like bin/check-docs and
+        # bin/post-plan-now cannot resolve if the old double-quoted token executes them.
+        STDERR_F20="$(mktemp)"
+        RT_DIR20="$(mktemp -d)"
+        ROUND_TRIP20="$(cd "$RT_DIR20" && bash -c "printf '%s' $PROMPT_TOKEN20" 2>"$STDERR_F20")"
+        STDERR_OUT20="$(cat "$STDERR_F20")"; rm -f "$STDERR_F20"
+        rmdir "$RT_DIR20" 2>/dev/null || true
+        { [ -z "$STDERR_OUT20" ] \
+            && printf '%s' "$ROUND_TRIP20" | grep -qF '`bin/check-docs --staleness-report`'; } \
+          && ok "(20) prompt-fidelity: backticks survive bash second-parse (no stderr; literal text present)" \
+          || bad "(20) prompt-fidelity: backticks corrupted at bash second parse"
+    else
+        bad "(20) prompt-fidelity: could not extract claude -p argument from plist"
+    fi
+else
+    bad "(20) prompt-fidelity: plist not generated"
+fi
+
 if [ "$FAILED" -eq 0 ]; then echo "All docfix-run checks passed."; else echo "Some docfix-run checks FAILED."; fi
 exit "$FAILED"

--- a/tools/postplan-harness/tests/test_post_plan_now_fallback.py
+++ b/tools/postplan-harness/tests/test_post_plan_now_fallback.py
@@ -18,6 +18,65 @@ def test_generic_failures_fall_back():            # negative path: real failures
     assert _fb(2) == "0"
     assert _fb(130) == "0"
 
+def _bash(script):
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+
+
+def test_shq_survives_a_second_shell_parse():
+    """shq() output must reproduce its input byte-for-byte when a SECOND shell parses it.
+
+    $CMD is re-parsed by `/bin/bash -lc` inside the launchd plist, so anything the
+    prompt carries gets a second round of shell evaluation. Grepping the source for
+    backticks would not catch this — only a real round-trip does.
+    """
+    hostile = [
+        "plain",
+        "has `backticks` here",
+        "has $(cmd) and $VAR",
+        "it's got a single quote",
+        r"a\b backslash",
+        "<slug>-N.md",
+        "mix: `x` $y 'z' \\w",
+    ]
+    for s in hostile:
+        script = f'source "{PPN}" >/dev/null 2>&1; q=$(shq "$1"); bash -c "printf %s $q"'
+        r = subprocess.run(["bash", "-c", script, "_", s], capture_output=True, text=True)
+        assert r.stderr == "", f"{s!r}: second parse wrote to stderr: {r.stderr!r}"
+        assert r.stdout == s, f"{s!r}: round-tripped to {r.stdout!r}"
+
+
+def test_plan_blind_prompt_reaches_the_model_intact():
+    """The real plan-blind prompt literal, round-tripped through the far-side shell.
+
+    Regression: it carried literal backticks around <slug>-N.md, was embedded as
+    `claude -p \\"$PROMPT\\"`, and `/bin/bash -lc` ran the backticks as command
+    substitution — logging `slug: No such file or directory` and silently deleting the
+    plan-disambiguation clause from the prompt the model received.
+    """
+    import re
+    src = open(PPN).read()
+    prompts = re.findall(r'^\s*(PROMPT="(?:[^"\\]|\\.)*")$', src, re.M)
+    assert len(prompts) == 2, f"expected the --plan and plan-blind prompts, got {len(prompts)}"
+    plan_blind = prompts[1]
+    assert "<slug>-N.md" in plan_blind, "plan-blind prompt no longer names the variant rule"
+
+    script = (f'source "{PPN}" >/dev/null 2>&1\n'
+              f'{plan_blind}\n'
+              'q=$(shq "$PROMPT")\n'
+              'bash -c "printf %s $q"\n')
+    r = _bash(script)
+    assert r.stderr == "", f"far-side shell wrote to stderr: {r.stderr!r}"
+    assert "`<slug>-N.md`" in r.stdout, f"backticked span did not survive: {r.stdout!r}"
+    assert "never ask questions" in r.stdout
+
+
+def test_embed_sites_are_shell_quoted():
+    src = open(PPN).read()
+    assert 'claude -p $(shq "$PROMPT")' in src      # not \"$PROMPT\" — see shq() header
+    assert r'claude -p \"$PROMPT\"' not in src
+    assert '--plan $(shq "$PLAN_OVERRIDE")' in src
+
+
 def test_plist_wiring_regression():
     src = open(PPN).read()
     assert "--live || " not in src               # old unconditional fallback chain removed


### PR DESCRIPTION
## Summary
- Added `shq()` shell function to safely single-quote prompts and plan paths across the launchd `/bin/bash -lc` boundary
- Fixed bug where backticks in prompts (e.g., `` `<slug>-N.md` ``) were executed as command substitution at the second shell parse, silently deleting the backticked span from the prompt the model received
- Applied fix to both `bin/post-plan-now` (claude invocation) and `bin/docfix-run` (automated doc fixing)
- Added comprehensive round-trip tests: `test_shq_survives_a_second_shell_parse()`, `test_plan_blind_prompt_reaches_the_model_intact()`, and shell-based test case 20 to verify backticks survive the double parse intact
- Updated CI workflow trigger to include `bin/post-plan-now` changes

## Manual Testing

No manual testing needed — verified by automated tests.
