### PR TITLE
chore(scripts-archive): restrict web access to CLI-only scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ depthcharts
 .htaccess
 !/ibl5/ibl/IBL/.htaccess
 !/ibl5/scripts/.htaccess
+!/ibl5/scripts/archive/.htaccess
 
 # Logs — runtime-generated (e.g. ibl5/IBL5.log, the multi-GB simulation log).
 # Never committed; lives next to source only because the sim writes it there.

--- a/ibl5/phpstan-baseline.neon
+++ b/ibl5/phpstan-baseline.neon
@@ -1093,18 +1093,6 @@ parameters:
 			path: scripts/archive/importBoxscoresFromHtml.php
 
 		-
-			rawMessage: 'Path in require() __DIR__ . ''/../mainfile.php'' is not a file or it does not exist.'
-			identifier: require.fileNotFound
-			count: 1
-			path: scripts/archive/importBoxscoresFromHtml.php
-
-		-
-			rawMessage: Binary operation "." between mixed and '/ibl5/../IBL5.bxs' results in an error.
-			identifier: binaryOp.invalid
-			count: 1
-			path: scripts/archive/importBxsMissing.php
-
-		-
 			rawMessage: 'Function parseBxsHeader() has parameter $teamNameToId with no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
 			count: 1
@@ -1119,12 +1107,6 @@ parameters:
 		-
 			rawMessage: 'Parameter #1 $db of class Boxscore\BoxscoreRepository constructor expects mysqli, mixed given.'
 			identifier: argument.type
-			count: 1
-			path: scripts/archive/importBxsMissing.php
-
-		-
-			rawMessage: 'Path in require() __DIR__ . ''/../mainfile.php'' is not a file or it does not exist.'
-			identifier: require.fileNotFound
 			count: 1
 			path: scripts/archive/importBxsMissing.php
 

--- a/ibl5/scripts/archive/.htaccess
+++ b/ibl5/scripts/archive/.htaccess
@@ -1,0 +1,6 @@
+# Retained one-time scripts — none is browser-invoked, so unlike the
+# file-scoped denies in ibl5/scripts/.htaccess this deny is directory-wide.
+# They connect with production credentials and write via BoxscoreRepository or
+# rewrite IBL5.plr in place. Defense in depth: each script also refuses non-CLI
+# SAPIs with a PHP_SAPI guard (security constraint 4).
+Require all denied

--- a/ibl5/scripts/archive/README.md
+++ b/ibl5/scripts/archive/README.md
@@ -15,6 +15,8 @@ data operation was performed, in case a similar fix-up is ever needed again.
 > for a specific point-in-time backfill and hard-code dates, team-id maps, and
 > file-format offsets.
 
+Web access to this directory is denied outright by `ibl5/scripts/archive/.htaccess`, and each script additionally refuses non-CLI SAPIs (security constraint 4). Run them only as `php ibl5/scripts/archive/<name>.php`.
+
 ## Contents
 
 | Script | Archived | Purpose |

--- a/ibl5/scripts/archive/importBoxscoresFromHtml.php
+++ b/ibl5/scripts/archive/importBoxscoresFromHtml.php
@@ -14,7 +14,17 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../mainfile.php';
+// ── CLI-only guard (security constraint 4) — must stay the FIRST executable
+//    statement: a web hit must be refused before any resource is touched.
+//    Paired with the directory-wide deny in ibl5/scripts/archive/.htaccess
+//    (defense in depth).
+if (PHP_SAPI !== 'cli') {
+    http_response_code(403);
+    echo 'This script must be run from the command line.';
+    exit(1);
+}
+
+require __DIR__ . '/../../mainfile.php';
 
 global $mysqli_db;
 

--- a/ibl5/scripts/archive/importBxsMissing.php
+++ b/ibl5/scripts/archive/importBxsMissing.php
@@ -16,7 +16,17 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../mainfile.php';
+// ── CLI-only guard (security constraint 4) — must stay the FIRST executable
+//    statement: a web hit must be refused before any resource is touched.
+//    Paired with the directory-wide deny in ibl5/scripts/archive/.htaccess
+//    (defense in depth).
+if (PHP_SAPI !== 'cli') {
+    http_response_code(403);
+    echo 'This script must be run from the command line.';
+    exit(1);
+}
+
+require __DIR__ . '/../../mainfile.php';
 
 global $mysqli_db;
 
@@ -26,11 +36,10 @@ $repository = new Boxscore\BoxscoreRepository($mysqli_db);
 
 // --- Configuration ---
 
-$bxsPath = $_SERVER['DOCUMENT_ROOT'] . '/ibl5/../IBL5.bxs';
-if (!is_file($bxsPath)) {
-    // Fallback: try from script directory
-    $bxsPath = dirname(__DIR__, 2) . '/IBL5.bxs';
-}
+// The JSB data files live in ibl5/ (see .gitignore's ibl5/*.plr, ibl5/*.sco).
+// Resolved from __DIR__ rather than $_SERVER['DOCUMENT_ROOT'], which is unset
+// under CLI — this script is CLI-only.
+$bxsPath = dirname(__DIR__, 2) . '/IBL5.bxs';
 
 $BXS_RECORD_SIZE = 3000;
 $BXS_PLAYER_SIZE = 94;

--- a/ibl5/scripts/archive/plrScratchpad.php
+++ b/ibl5/scripts/archive/plrScratchpad.php
@@ -1,5 +1,15 @@
 <?php
 
+// ── CLI-only guard (security constraint 4) — must stay the FIRST executable
+//    statement: a web hit must be refused before any resource is touched.
+//    Paired with the directory-wide deny in ibl5/scripts/archive/.htaccess
+//    (defense in depth).
+if (PHP_SAPI !== 'cli') {
+    http_response_code(403);
+    echo 'This script must be run from the command line.';
+    exit(1);
+}
+
 require __DIR__ . '/../../mainfile.php';
 
 $plrFile = fopen("IBL5.plr", "rb+");


### PR DESCRIPTION
## Summary
- Add `.htaccess` with directory-wide deny for `ibl5/scripts/archive/` (defense in depth)
- Add CLI-only SAPI guard to all archive scripts; must be first executable statement
- Document security constraint 4 in README and via inline comments
- Fix require paths from `/../mainfile.php` to `/../../mainfile.php`
- Remove phpstan baseline errors for require/binaryOp now resolved by guard placement and CLI-only context

## Manual Testing

No manual testing needed — verified by automated tests.
