### PR TITLE
chore(ci): regenerate codebase-map on master push

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -562,6 +562,42 @@ jobs:
           git push
         fi
 
+  regen-codebase-map:
+    name: Regenerate codebase-map
+    # Master-push only, mirroring `regen-schema-dump` in migration-safety.yml.
+    # Replaces the old PR-side `git diff --exit-code` check, which measured the
+    # PR's map against master-merged classes/ and so fired on base drift rather
+    # than on real signal. Regenerating on master instead makes the map
+    # self-healing: whatever squash-merge landed, master converges within one
+    # push. `bin/generate-codebase-map` normalizes the date before comparing, so
+    # a bot commit only happens when module content actually changed.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        token: ${{ secrets.CI_PAT }}
+
+    - name: Regenerate codebase map
+      run: bin/generate-codebase-map
+
+    - name: Commit regenerated map if changed
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add .claude/rules/codebase-map.md
+        if git diff --cached --quiet; then
+          echo "No codebase-map changes"
+        else
+          git commit -m "ci: regenerate codebase-map [auto]"
+          git push
+        fi
+
   static-guards:
     name: Static guards
     runs-on: ubuntu-latest
@@ -653,15 +689,6 @@ jobs:
             exit 1
           fi
           echo "OK: no unguarded shallow git fetch"
-      # codebase-map-freshness: .claude/rules/codebase-map.md is tracked and
-      # must reflect ibl5/classes/ state. generate-codebase-map is idempotent
-      # (normalizes the date before comparing); any remaining diff signals a
-      # module was added or renamed without committing the updated map.
-      - name: Check codebase-map is up to date
-        run: |
-          bin/generate-codebase-map
-          git diff --exit-code .claude/rules/codebase-map.md \
-            || { echo "FAIL: run bin/generate-codebase-map and commit the result"; exit 1; }
 
   harness-tests:
     name: Shell harness regression tests
@@ -750,7 +777,7 @@ jobs:
   gate:
     name: Tests and Analysis
     if: always()
-    needs: [changes, test, audit-php, audit-js, ibl5-ts-unit, iblbot, db-integration, phpstan, phpunit-hygiene, shellcheck, host-mariadb-guard, automouse-impl-model-test, update-baselines, static-guards, harness-tests, pinact-check]
+    needs: [changes, test, audit-php, audit-js, ibl5-ts-unit, iblbot, db-integration, phpstan, phpunit-hygiene, shellcheck, host-mariadb-guard, automouse-impl-model-test, update-baselines, regen-codebase-map, static-guards, harness-tests, pinact-check]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/bin/generate-codebase-map
+++ b/bin/generate-codebase-map
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Generate .claude/rules/codebase-map.md from ibl5/classes/ structure.
 # Run: bin/generate-codebase-map
-# Auto-run: SessionStart hook + git pre-commit hook
+# Auto-run: SessionStart hook + git pre-commit hook + master-push CI job in .github/workflows/tests.yml
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- Moved codebase-map freshness check from PR-side `static-guards` to new master-push `regen-codebase-map` job
- Job auto-regenerates and commits map when module content changes, making it self-healing
- Eliminates false failures from base drift; master converges to actual `classes/` state within one push

## Manual Testing

No manual testing needed — verified by automated tests.
