### PR TITLE
fix(bpgh): route diagnostics to stderr only

### DIFF
--- a/bin/lib/bug-pipeline-gh.sh
+++ b/bin/lib/bug-pipeline-gh.sh
@@ -21,13 +21,15 @@
 : "${GH_BIN:=gh}"
 : "${BUG_PIPELINE_ISSUE_REPO:=}"
 
-# Prefer the driver's log(); fall back to a timestamped stderr line when sourced bare.
+# STDERR, ALWAYS. Do NOT route this through the driver's log() — that writes to STDOUT,
+# and every value-returning function below is consumed by the caller as $( ). A diagnostic
+# on stdout IS the captured value: bpgh_ensure_issue's failure line sails past its callers'
+# `[ -n "$n" ]` guard and becomes an --issue= argument; bpgh_pr_failing_checks' lines are
+# parsed as PR rows. That is the same failure mode that dispatched 84 hunters against
+# report id "" on 2026-08-04 (see cli() in bin/bug-pipeline-tick). launchd captures our
+# stderr separately (StandardErrorPath), so nothing is lost by keeping diagnostics here.
 _bpgh_log() {
-    if command -v log >/dev/null 2>&1; then
-        log "$*"
-    else
-        printf '[%s] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$*" >&2
-    fi
+    printf '[%s] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$*" >&2
 }
 
 # Returns 0 iff issue tracking is configured and gh is available.

--- a/bin/test-bug-pipeline-ci-autofix
+++ b/bin/test-bug-pipeline-ci-autofix
@@ -42,11 +42,19 @@ bpt_add_wt() {
 
 # Run bpgh_pr_failing_checks in a subshell (sources only the gh lib — no full driver).
 # Prints whatever the function emits to stdout.
+#
+# The shim DEFINES log() writing to stdout, exactly as bin/bug-pipeline-tick does. That is
+# load-bearing, not scenery: _bpgh_log once preferred an in-scope log(), so under the real
+# driver its diagnostics landed on stdout — the stream the caller command-substitutes — and
+# were parsed as PR rows. A shim without log() exercised the stderr fallback instead, so
+# every skip row below passed while production was corrupted. Keep log() here so the rows
+# assert the production stream, and see r-detect-6 for the explicit regression.
 GH_LIB="$(cd "$(dirname "$0")" && pwd)/lib/bug-pipeline-gh.sh"
 bpt_detect() {
     BUG_PIPELINE_CODE_REPO="test/code-fake" \
     GH_BIN="$STUB/bin/gh" \
-        bash -c 'source "$1"; bpgh_pr_failing_checks' bpt-unit-shim \
+        bash -c 'log() { printf "[%s] %s\n" "$(date "+%Y-%m-%dT%H:%M:%S")" "$*"; }
+                 source "$1"; bpgh_pr_failing_checks' bpt-unit-shim \
         "$GH_LIB" 2>/dev/null
 }
 
@@ -95,6 +103,23 @@ out="$(bpt_detect)"
 # STUB_PR_VIEW_FAIL unset inside bpt_reset on next call; unset here for safety
 unset STUB_PR_VIEW_FAIL
 bpt_expect_eq "r-detect-5: unreadable merge state → skip (fail-closed)" "" "$out"
+
+# r-detect-6 — ★ REGRESSION: every stdout line is a PR row, never a diagnostic.
+# The caller does red_prs="$(bpgh_pr_failing_checks 2>/dev/null)" and splits each line on
+# spaces into num/branch/sha/failing, so a diagnostic on stdout becomes a phantom PR row
+# (num="[2026-08-09T23:03:23]", branch="bpgh_pr_failing_checks:"). Observed in production
+# on 2026-08-09; same class as the 84-hunters-against-report-id-"" outage of 2026-08-04.
+# Two skip paths that BOTH log, in one run, so the shape assertion has something to catch.
+bpt_reset
+bpt_set_gh_pr_list_ci "42 feature-tests abc123
+43 other-branch def456"
+bpt_set_gh_pr_checks_for 42 "FAILURE phpunit"
+bpt_set_gh_pr_checks_for 43 "PENDING phpunit"
+export STUB_MERGE_STATE=CONFLICTING
+out="$(bpt_detect)"
+unset STUB_MERGE_STATE
+bad="$(printf '%s\n' "$out" | grep -vE '^[0-9]+ |^$' || true)"
+bpt_expect_eq "r-detect-6: no diagnostic reaches stdout (parsed as a PR row)" "" "$bad"
 
 # ═══════════════════════════════════════════════════════════════════
 # DISPATCH ROWS — integration via bpt_run

--- a/bin/test-bug-pipeline-issue
+++ b/bin/test-bug-pipeline-issue
@@ -40,6 +40,11 @@ bpt_set_claude_result '{"class":"bug","bug_has_enough_info":true,"issue_title":"
 GH_FAIL=1 bpt_run
 bpt_expect_eq "gh-failure tick still exits 0" 0 "$BPT_RC"
 bpt_log_has "$STUB" transition.log "queued --class=bug" "gh failure → DB transition still fires"
+# ★ REGRESSION: bpgh_ensure_issue's callers capture it as $( ) and gate on [ -n "$n" ].
+# When its create-failed diagnostic went to stdout it BECAME the return value — non-empty,
+# so it sailed past that guard and rode into `cli transition --issue=<timestamped log line>`
+# and bpgh_add_label. Diagnostics are stderr-only now; a failed create must yield NO issue.
+bpt_log_lacks "$STUB" transition.log "--issue=" "gh create failure → no phantom --issue= argument"
 
 # ── state->label: thin-bug → needs-info ───────────────────────────────────────
 bpt_reset; bpt_set_actionable "$BUG_NEW"


### PR DESCRIPTION
## Summary
Diagnostic messages were leaking to stdout, where callers captured them as return values via `$( )`, causing phantom PR rows and invalid --issue= arguments. Fixed by removing the conditional log() call—_bpgh_log() now always writes to stderr.

- Simplify _bpgh_log() to always use stderr (remove driver's log() conditional)
- Update test shim to define log() matching production behavior
- Add regression tests r-detect-6 and issue-create-fail to catch diagnostic leakage

## Manual Testing

No manual testing needed — verified by automated tests.
