### PR TITLE
chore(headless): inherit interactive window setting

### DIFF
--- a/bin/automouse/run
+++ b/bin/automouse/run
@@ -177,25 +177,26 @@ fi
 # Worktree Preview Environment — no human present to verify)
 export CLAUDE_HEADLESS=1
 
-# Match the interactive autoCompactWindow pin (~/.claude/settings.json, which
-# is 140000 — NOT the 120K this comment claimed until 2026-08-10). The export
-# stays rather than being deleted so the window is versioned with the repo
-# instead of inherited from unversioned host state, and so the "rationale in
-# bin/automouse/run" pointers in bin/post-plan-now and bin/plan-now still land
-# somewhere. Env var overrides the settings.json pin per-process.
+# DELIBERATELY NO CLAUDE_CODE_AUTO_COMPACT_WINDOW export here (nor in
+# bin/post-plan-now / bin/plan-now). `claude -p` reads the same user-level
+# settings an interactive session does, so with no override the headless window
+# IS the interactive window — currently the `autoCompactWindow` pin in
+# ~/.claude/settings.json — and tracks it by construction. An explicit export
+# was two numbers to keep in sync and drifted: it sat at 200000 with a comment
+# claiming the pin was 120K, when the pin had moved to 140000.
 #
-# Tripwire — this is a real regression risk, deliberately accepted. Headless
+# Tripwire before you re-add one. Inheriting is the smaller window: headless
 # sessions carry ~44K of fixed context (system prompt + rules + memory +
 # compaction summary) and compaction fires at ~73% of the window, so working
-# room drops from ~102K (200K window) to ~58K (140K). The 2026-08-10 run that
+# room is ~58K at a 140K window versus ~102K at 200K. The 2026-08-10 run that
 # was aborted by hand had already reached peak_ctx=72063 during reconnaissance
-# — 21 tools in, before a single edit — i.e. most of the way to the 140K
-# trigger point (~102K) with the whole implementation still ahead of it. If
-# impl runs start showing repeated compactions (2026-07-07, at a window around
-# 120K: 5 compactions in 19 min, 21% of the 5h budget, zero edits made), raise
-# this back toward 200000, which keeps peak context at/below the ~200K
-# degradation and 2x-cost edge.
-export CLAUDE_CODE_AUTO_COMPACT_WINDOW=140000
+# — 21 tools in, before a single edit — i.e. most of the way to the ~102K
+# trigger point with the whole implementation still ahead of it. If impl runs
+# start showing repeated compactions (2026-07-07, at a window around 120K: 5
+# compactions in 19 min, 21% of the 5h budget, zero edits made), the fix is to
+# export a larger window again — 200000 keeps peak context at/below the ~200K
+# degradation and 2x-cost edge — and to accept that it no longer tracks the
+# interactive setting.
 
 REPO="/Users/ajaynicolas/GitHub/IBL5"
 NIGHTLY_DIR="$HOME/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/automouse"

--- a/bin/plan-now
+++ b/bin/plan-now
@@ -295,8 +295,9 @@ promote_draft() {
 }
 
 # CLAUDE_HEADLESS=1 marks the run unattended (skills branch on it).
-# CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 lifts the interactive 120K
-# autoCompactWindow pin — rationale in bin/automouse/run.
+# No CLAUDE_CODE_AUTO_COMPACT_WINDOW is set: with no override the run inherits
+# the same autoCompactWindow setting an interactive session uses — rationale and
+# the tripwire for re-adding an explicit window in bin/automouse/run.
 # caffeinate -s keeps the Mac awake on AC for the run's duration.
 # 5400s: the first two real runs took 36 and 42 minutes, too close to the old
 # 3600s cap. claude -p does not stream, so $OUT stays empty until it exits — and with
@@ -311,7 +312,7 @@ promote_draft() {
 # $PLANS_DIR/.drafts/. 0 means wait indefinitely (the CLI says so itself);
 # timeout 5400 above remains the hard cap.
 CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 \
-    CLAUDE_HEADLESS=1 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 caffeinate -s \
+    CLAUDE_HEADLESS=1 caffeinate -s \
     timeout 5400 "$CLAUDE_BIN" -p "$(cat "$PROMPT")" \
     --dangerously-skip-permissions \
     --model "$MODEL" \

--- a/bin/post-plan-now
+++ b/bin/post-plan-now
@@ -155,8 +155,9 @@ fi
 # marks the detached run unattended: /post-plan skips the Phase 10 preview rebuild
 # and BLOCKS auto-merge on a golden-snapshot change instead of merely warning.
 # caffeinate -s keeps the Mac awake on AC for the run's duration.
-# CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 lifts the interactive 120K
-# autoCompactWindow pin for this headless run — rationale in bin/automouse/run.
+# No CLAUDE_CODE_AUTO_COMPACT_WINDOW is set: with no override the run inherits
+# the same autoCompactWindow setting an interactive session uses — rationale and
+# the tripwire for re-adding an explicit window in bin/automouse/run.
 # CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 stops the harness terminating a
 # long-running backgrounded sub-agent mid-run (see bin/plan-now for the full
 # rationale). Applies to the /post-plan skill fallback only.
@@ -178,7 +179,7 @@ fi
 # do not "simplify" either one away.
 xml_escape() { printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'; }
 
-CMD="export PATH=\"/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH\"; cd \"$ROOT\" && { ${FALLBACK_FN}${HARNESS_SEG}${GATE_OPEN}CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 CLAUDE_HEADLESS=1 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 caffeinate -s claude -p $(shq "$PROMPT") --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name \"$LABEL\"${GATE_CLOSE}; }; rm -f \"$PLIST\"; launchctl bootout gui/\$(id -u)/$LABEL"
+CMD="export PATH=\"/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH\"; cd \"$ROOT\" && { ${FALLBACK_FN}${HARNESS_SEG}${GATE_OPEN}CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 CLAUDE_HEADLESS=1 caffeinate -s claude -p $(shq "$PROMPT") --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name \"$LABEL\"${GATE_CLOSE}; }; rm -f \"$PLIST\"; launchctl bootout gui/\$(id -u)/$LABEL"
 
 CMD_XML=$(xml_escape "$CMD")
 LABEL_XML=$(xml_escape "$LABEL")


### PR DESCRIPTION
## Summary
- Remove explicit `CLAUDE_CODE_AUTO_COMPACT_WINDOW` exports from headless launchers (bin/automouse/run, bin/plan-now, bin/post-plan-now)
- Headless sessions now inherit the `autoCompactWindow` setting from interactive sessions instead of maintaining a separate, drift-prone value
- Updated rationale and added tripwire comments explaining the change and conditions for re-adding an explicit override

## Manual Testing

No manual testing needed — verified by automated tests.
