### PR TITLE
chore: add /pr-ready skill — PR readiness and plan-fidelity checker

### DIFF
--- a/.claude/skills/pr-ready/SKILL.md
+++ b/.claude/skills/pr-ready/SKILL.md
@@ -101,12 +101,12 @@ Read `.claude/skills/pr-ready/_rebase-and-conflicts.md` now and follow it end-to
 
 1. **Load the deferred watcher tools here, not in Phase 0:** `ToolSearch("select:Monitor,TaskStop")`. Deferring keeps `Monitor`'s long schema out of context for the phases that never use it.
 
-2. **Lost-work proof, two signals.** `git cherry -v origin/<branch> HEAD` is the weak signal: after a squash **every** replayed commit shows `+` by design, so `git cherry` alone cannot carry the proof. The authoritative check is content equivalence of the tree diff captured before and after the rebase (the Phase 2 include wrote `/tmp/pr-ready-diff-pre-$$.patch`):
+2. **Lost-work proof, two signals.** `git cherry -v origin/<branch> HEAD` is the weak signal: after a squash **every** replayed commit shows `+` by design, so `git cherry` alone cannot carry the proof. The authoritative check is content equivalence of the tree diff captured before and after the rebase (the Phase 2 include wrote `/tmp/pr-ready-diff-pre-<N>.patch`, keyed to the PR number — **never `$$`**, which differs between that call's shell and this one's):
 
    ```bash
-   git diff origin/master...HEAD > /tmp/pr-ready-diff-post-$$.patch
-   diff <(git apply --numstat /tmp/pr-ready-diff-pre-$$.patch | sort) \
-        <(git apply --numstat /tmp/pr-ready-diff-post-$$.patch | sort) \
+   git diff origin/master...HEAD > /tmp/pr-ready-diff-post-<N>.patch
+   diff <(git apply --numstat /tmp/pr-ready-diff-pre-<N>.patch | sort) \
+        <(git apply --numstat /tmp/pr-ready-diff-post-<N>.patch | sort) \
      && echo "TREE-EQUIVALENT" || echo "TREE DIVERGED — inspect before pushing"
    ```
 
@@ -114,13 +114,15 @@ Read `.claude/skills/pr-ready/_rebase-and-conflicts.md` now and follow it end-to
 
 3. `git push --force-with-lease` — never a bare `--force`. The lease is what catches a concurrent push into the same branch.
 
-4. **`mergeable=UNKNOWN` handling — bounded, no loop.** GitHub computes mergeability asynchronously, so the first read right after a push is usually `UNKNOWN`. Check once; if `UNKNOWN`, wait ~30s and check exactly once more; then report whatever the second read says. Do **not** loop:
+4. **`mergeable=UNKNOWN` handling — bounded, and never with a foreground `sleep`.** GitHub computes mergeability asynchronously, so the first read right after a push is usually `UNKNOWN`. Read once:
 
    ```bash
-   gh pr view <N> --json mergeable,mergeStateStatus
-   sleep 30
    gh pr view <N> --json mergeable,mergeStateStatus,state
    ```
+
+   If the answer is anything other than `UNKNOWN`, act on it now — in particular `mergeStateStatus=DIRTY` means the rebase did not actually clear the conflict, so stop and re-run Phases 2–3 rather than pushing on. If it **is** `UNKNOWN`, **do not wait here**: proceed to step 5, whose watcher polls `mergeStateStatus` on every iteration and breaks immediately on `DIRTY`. That is the resolution path — the watcher is the wait, and a conflict surfaces on its first poll rather than after CI finishes. Do not re-read here, and do not loop.
+
+   **Never insert a foreground `sleep` to bridge the gap.** The harness refuses one (`Blocked: sleep 30 … To wait for a condition, use Monitor with an until-loop … Do not chain shorter sleeps to work around this block`), so a `sleep`-based wait does not merely cost time — it hard-fails the call and stalls the run.
 
 5. **CI watcher — exactly one, keyed to the head SHA.** If a watcher from an earlier iteration is live, kill it first with `TaskStop(task_id: "<the id recorded when it was armed>")`. **Record the id `Monitor` returns in the run notes at arm time** — `TaskStop` has no "stop all" form, so an unrecorded id is an orphaned watcher. **Never** poll with `sleep N; gh pr checks` on the main thread: that re-reads the full orchestrator context on every call, the spend bug `.claude/rules/work-triage.md` names.
 
@@ -136,11 +138,17 @@ Read `.claude/skills/pr-ready/_rebase-and-conflicts.md` now and follow it end-to
    ```
 
    ```bash
-   HEAD_SHA="$(git rev-parse HEAD)"; prev=""
+   HEAD_SHA="$(git rev-parse HEAD)"; prev=""; prev_ms=""
    while true; do
-     live="$(gh pr view <N> --json headRefOid --jq .headRefOid 2>/dev/null || echo "")"
+     v="$(gh pr view <N> --json headRefOid,mergeStateStatus 2>/dev/null || echo '{}')"
+     live="$(jq -r '.headRefOid // ""' <<<"$v")"
      if [ -n "$live" ] && [ "$live" != "$HEAD_SHA" ]; then
        echo "STALE: head moved $HEAD_SHA -> $live; this watcher is obsolete"; break
+     fi
+     ms="$(jq -r '.mergeStateStatus // ""' <<<"$v")"
+     if [ -n "$ms" ] && [ "$ms" != "$prev_ms" ]; then echo "mergeStateStatus: $ms"; prev_ms="$ms"; fi
+     if [ "$ms" = "DIRTY" ]; then
+       echo "MERGE CONFLICT: mergeStateStatus=DIRTY; stop and re-run Phases 2-3"; break
      fi
      s="$(gh pr checks <N> --json name,bucket 2>/dev/null || echo '[]')"
      cur="$(jq -r '.[] | select(.bucket!="pending") | "\(.name): \(.bucket)"' <<<"$s" | sort)"
@@ -151,7 +159,7 @@ Read `.claude/skills/pr-ready/_rebase-and-conflicts.md` now and follow it end-to
    done
    ```
 
-   The emitted line is `"\(.name): \(.bucket)"` and **not** a success-only filter because **silence is not success**. A filter matching only `pass` stays mute through `fail`, `cancel`, `skipping`, and `action_required`, and mute is indistinguishable from "still running". The stale-SHA break is what stops an orphaned watcher from reporting on a superseded push.
+   The emitted line is `"\(.name): \(.bucket)"` and **not** a success-only filter because **silence is not success**. A filter matching only `pass` stays mute through `fail`, `cancel`, `skipping`, and `action_required`, and mute is indistinguishable from "still running". The stale-SHA break is what stops an orphaned watcher from reporting on a superseded push. The `mergeStateStatus` line is emitted on **change**, which is what resolves step 4's `UNKNOWN` without a wait — the first poll prints the real value, and `DIRTY` breaks out on that same poll rather than after CI finishes.
 
 **Phase 5 — strict re-check loop.**
 
@@ -192,15 +200,18 @@ Read `.claude/skills/pr-ready/_plan-fidelity-review.md` now and perform the revi
 
    `<!-- pr-ready-verdict -->`
 
+   **First write the composed comment body to `/tmp/pr-ready-verdict-<N>.md` with the `Write` tool.** The path is keyed to the PR number for the same reason Phase 2a's is: a `tmpfile=$(mktemp)` assigned in one Bash call is gone by the next one, so the post below would send an empty `--body-file`. Compose the body in full, write it, then run the post.
+
    There is no helper in `bin/lib/` for this, so use the find-and-update-else-create shape from `bin/pr-canary-check` (`STICKY_MARKER` at line 19, `post_sticky()` below it):
 
    ```bash
    id=$(gh api "repos/{owner}/{repo}/issues/<N>/comments" --paginate \
      --jq '.[] | select(.body | contains("<!-- pr-ready-verdict -->")) | .id' | head -1)
    if [ -n "$id" ]; then
-     gh api --method PATCH "repos/{owner}/{repo}/issues/comments/$id" -F body=@"$tmpfile"
+     gh api --method PATCH "repos/{owner}/{repo}/issues/comments/$id" \
+       -F body=@/tmp/pr-ready-verdict-<N>.md --jq .html_url
    else
-     gh pr comment <N> --body-file "$tmpfile"
+     gh pr comment <N> --body-file /tmp/pr-ready-verdict-<N>.md
    fi
    ```
 

--- a/.claude/skills/pr-ready/SKILL.md
+++ b/.claude/skills/pr-ready/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: pr-ready
+description: Take one open PR from conflicted-or-unknown state to a posted readiness verdict — rebase onto master, resolve conflicts, wait for CI, judge plan fidelity, post a sticky verdict comment, then stop.
+disable-model-invocation: true
+disallowed-tools:
+  - EnterPlanMode
+  - ExitPlanMode
+  - Skill
+last_verified: 2026-08-10
+---
+<!-- NO `model:` KEY — DELIBERATE, DO NOT ADD ONE.
+     Runtime Phase 6 (plan-intent fidelity review) is Opus-column judgment:
+     .claude/rules/agent-tiering.md — "Never delegate understanding." A `model:`
+     pin would force this skill onto a fixed tier regardless of the invoking
+     session's model. Do NOT "harmonise" this file with /pr-review's
+     `model: claude-sonnet-4-6` — that skill is a pure diff review with no
+     fidelity judgment, so a Sonnet pin is correct there and wrong here. -->
+
+# /pr-ready — PR readiness and plan-fidelity checker
+
+Drives **one** open PR from "conflicted / unknown state" to a posted readiness verdict: enter the PR's existing worktree, delegate the rebase chore, resolve conflicts and push, watch CI, judge the implementation against its plan's stated intent, post a sticky verdict comment — then stop.
+
+This skill adds **semantic** judgment the existing pipeline does not cover. `/post-plan` Phase 5.0 checks mechanical declared-artifact conformance; Phase 4B runs structured code review over the **pre-rebase** diff. Neither asks whether the code does what the plan *intended*. `/pr-ready` asks exactly that and nothing else — it does not re-run structured code review, does not define review agents, and does not reference the shared review-agent definitions.
+
+## Invariants — stated once; later phases cite these rather than repeat them
+
+- **One PR per invocation.** No batch mode, no PR-list iteration.
+- **The orchestrator never delegates runtime Phase 6.** The fidelity judgment is the deliverable; delegating it is a defect.
+- **Sub-agent returns are thin pointers** — `path:line`, SHAs, status words. Never pasted diffs or file bodies.
+- **Flat fan-out only.** A delegate may not spawn a delegate.
+- **Every glob is quoted** — `--include="*.md"`, never `--include=*.md`.
+- **The run STOPS at the verdict.** No merge, no auto-merge arming, no backlog housekeeping, no `/post-plan` chain, no worktree teardown.
+- **`STOP:` lines are hard stops for the model, not just for the shell.** Three blocks below print a `STOP:` line: the Phase 0 argument gate, the Phase 0 canonical-root guard, and the Phase 1 plan check. Where such a block runs `exit 1`, that `exit` terminates **only that Bash invocation** — it does not terminate the skill, because a skill's blocks are run by the model. The contract is therefore: **on a non-zero rc, or on printing a `STOP:` line, stop the run and make no further tool call.** None of the three relies on shell exit status to halt anything but the shell.
+
+## Runtime phases
+
+**Phase 0 — enter the worktree.**
+
+1. **Argument gate.** `/pr-ready` takes exactly one argument, the PR number. If it is missing or does not match `^[0-9]+$`, print
+
+   `STOP: /pr-ready needs exactly one PR number, e.g. /pr-ready 1742`
+
+   and stop without any further tool call.
+
+2. **Load the deferred tool first.** `ToolSearch("select:EnterWorktree")` is the **first** tool call of the run, before any worktree read. `EnterWorktree` is deferred, so calling it without loading the schema fails with `InputValidationError`; and a worktree read attempted first trips the cross-worktree straddle gate in `~/.claude/hooks/plan-gate-edit.sh`.
+
+3. **Canonical-root guard.** `EnterWorktree`'s `path:` form only accepts a target listed in `git worktree list` *for the current repo* and, from inside a worktree, only targets under that repo's `.claude/worktrees/` (example) directory. This repo's worktrees live at `~/GitHub/IBL5-worktrees/<slug>`, so a worktree→worktree switch is rejected — the skill must be invoked from the main checkout. Run this block first:
+
+   ```bash
+   source "$(git rev-parse --show-toplevel)/bin/lib/git-helpers.sh"
+   if is_in_worktree; then
+     echo "STOP: /pr-ready must be invoked from the main checkout (/Users/ajaynicolas/GitHub/IBL5), not from a worktree. EnterWorktree cannot switch worktree-to-worktree for IBL5-worktrees paths."
+     exit 1
+   fi
+   ```
+
+   Source via `$(git rev-parse --show-toplevel)`, not a bare relative path: the skill's cwd is not guaranteed to be the repo root. `is_in_worktree()` is defined in `bin/lib/git-helpers.sh` and compares `--absolute-git-dir` against `--git-common-dir`. Per the invariants above, a non-zero rc here ends the run.
+
+4. **Resolve the slug and enter.**
+
+   ```bash
+   SLUG=$(gh pr view <N> --json headRefName --jq .headRefName)
+   git worktree list
+   ```
+
+   Confirm `~/GitHub/IBL5-worktrees/$SLUG` appears in the `git worktree list` output. If it does not, print
+
+   `STOP: no existing worktree for branch $SLUG — /pr-ready enters an existing worktree, it never creates one.`
+
+   and stop. Otherwise call `EnterWorktree(path: "/Users/ajaynicolas/GitHub/IBL5-worktrees/$SLUG")`.
+
+5. **Docker note** — only if a later step needs the app running. Derive the slug from the tree you are actually in, `basename "$(git rev-parse --show-toplevel)"`, then `docker start ibl5-db-<slug> ibl5-php-<slug>`. Never hardcode a slug from a previous session; never use `main.localhost` from a worktree; always navigate `/ibl5/` paths, never bare `/`.
+
+**Phase 1 — plan, master pin, protection, prior-review probe.**
+
+1. **Read the plan.** `PLAN=~/claude-plans/"$(git rev-parse --abbrev-ref HEAD)".md`. If it does not exist, print loudly
+
+   `STOP: no plan at $PLAN. /pr-ready's Phase 6 judges implementation against the plan's stated intent; without the plan there is nothing to judge against. Re-run once the plan file is restored, or run /pr-review instead for a plain code review.`
+
+   and stop. Do **not** fall back to the PR body for plan intent — the PR body is one of the things Phase 6 audits.
+
+2. `git fetch origin`. Nothing in this skill ever runs a bare `git rebase` against `origin/master`; see the `--onto` recipe in the Phase 2 include.
+
+3. **Pin master before spawning anything:** `MASTER_SHA=$(git rev-parse origin/master)`. Every later step, and the Phase 2 delegate, use this pinned SHA — never a re-resolved `origin/master`.
+
+4. **Branch-protection strict flag.**
+
+   ```bash
+   STRICT=$(gh api "repos/{owner}/{repo}/branches/master/protection" --jq '.required_status_checks.strict // false')
+   ```
+
+   On a 403/404 (a token without admin read), set `STRICT=true` and say so in the verdict. Failing closed costs one extra divergence check; failing open ships a stale-base merge.
+
+5. **Prior-Phase-4B probe.** `gh pr view <N> --json comments,reviews` and look for a `### Code review` heading from the post-plan bot in **both** the issue comments and the review bodies — findings are posted as a review body with inline threads, not only as issue comments. Record the boolean as `PHASE_4B_RAN`. This is a **probe, not a gate**: the value is reported in Phase 6 and never used to skip work.
+
+**Phases 2 and 3 — rebase and conflict resolution.**
+
+Read `.claude/skills/pr-ready/_rebase-and-conflicts.md` now and follow it end-to-end before continuing. It holds the Phase 2 delegation packet and the Phase 3 three-way conflict-resolution procedure. Pass the delegate the pinned `$MASTER_SHA` — never let it resolve `origin/master` itself.
+
+**Phase 4 — prove nothing was lost, push, watch CI.**
+
+1. **Load the deferred watcher tools here, not in Phase 0:** `ToolSearch("select:Monitor,TaskStop")`. Deferring keeps `Monitor`'s long schema out of context for the phases that never use it.
+
+2. **Lost-work proof, two signals.** `git cherry -v origin/<branch> HEAD` is the weak signal: after a squash **every** replayed commit shows `+` by design, so `git cherry` alone cannot carry the proof. The authoritative check is content equivalence of the tree diff captured before and after the rebase (the Phase 2 include wrote `/tmp/pr-ready-diff-pre-$$.patch`):
+
+   ```bash
+   git diff origin/master...HEAD > /tmp/pr-ready-diff-post-$$.patch
+   diff <(git apply --numstat /tmp/pr-ready-diff-pre-$$.patch | sort) \
+        <(git apply --numstat /tmp/pr-ready-diff-post-$$.patch | sort) \
+     && echo "TREE-EQUIVALENT" || echo "TREE DIVERGED — inspect before pushing"
+   ```
+
+   `TREE DIVERGED` is expected **only** when Phase 3 resolved a real conflict; in that case name each diverging path in the Phase 6 verdict. Any other divergence stops the run.
+
+3. `git push --force-with-lease` — never a bare `--force`. The lease is what catches a concurrent push into the same branch.
+
+4. **`mergeable=UNKNOWN` handling — bounded, no loop.** GitHub computes mergeability asynchronously, so the first read right after a push is usually `UNKNOWN`. Check once; if `UNKNOWN`, wait ~30s and check exactly once more; then report whatever the second read says. Do **not** loop:
+
+   ```bash
+   gh pr view <N> --json mergeable,mergeStateStatus
+   sleep 30
+   gh pr view <N> --json mergeable,mergeStateStatus,state
+   ```
+
+5. **CI watcher — exactly one, keyed to the head SHA.** If a watcher from an earlier iteration is live, kill it first with `TaskStop(task_id: "<the id recorded when it was armed>")`. **Record the id `Monitor` returns in the run notes at arm time** — `TaskStop` has no "stop all" form, so an unrecorded id is an orphaned watcher. **Never** poll with `sleep N; gh pr checks` on the main thread: that re-reads the full orchestrator context on every call, the spend bug `.claude/rules/work-triage.md` names.
+
+   Arm one `Monitor` with `description`, `persistent`, and `timeout_ms` all set (all three are required):
+
+   ```
+   Monitor(
+     description: "CI checks for PR <N> @ <HEAD_SHA>",
+     persistent: false,
+     timeout_ms: 3600000,
+     command: <the bash loop below>
+   )
+   ```
+
+   ```bash
+   HEAD_SHA="$(git rev-parse HEAD)"; prev=""
+   while true; do
+     live="$(gh pr view <N> --json headRefOid --jq .headRefOid 2>/dev/null || echo "")"
+     if [ -n "$live" ] && [ "$live" != "$HEAD_SHA" ]; then
+       echo "STALE: head moved $HEAD_SHA -> $live; this watcher is obsolete"; break
+     fi
+     s="$(gh pr checks <N> --json name,bucket 2>/dev/null || echo '[]')"
+     cur="$(jq -r '.[] | select(.bucket!="pending") | "\(.name): \(.bucket)"' <<<"$s" | sort)"
+     comm -13 <(printf '%s\n' "$prev") <(printf '%s\n' "$cur")
+     prev="$cur"
+     jq -e 'length > 0 and all(.[]; .bucket!="pending")' <<<"$s" >/dev/null && { echo "CI COMPLETE"; break; }
+     sleep 30
+   done
+   ```
+
+   The emitted line is `"\(.name): \(.bucket)"` and **not** a success-only filter because **silence is not success**. A filter matching only `pass` stays mute through `fail`, `cancel`, `skipping`, and `action_required`, and mute is indistinguishable from "still running". The stale-SHA break is what stops an orphaned watcher from reporting on a superseded push.
+
+**Phase 5 — strict re-check loop.**
+
+If `STRICT` is false, skip this phase. If true, then after CI reports complete and green, re-check divergence against the *current* master:
+
+```bash
+git fetch origin
+gh pr view <N> --json mergeStateStatus --jq .mergeStateStatus   # BEHIND => must re-base
+```
+
+If `BEHIND`, re-pin `MASTER_SHA=$(git rev-parse origin/master)` and loop back to Phase 2 with a fresh delegate on the new pin. **Bound the loop at 3 iterations**; on the fourth, stop and report `master is moving faster than this branch can rebase — merge manually or retry when master quiets`. An unbounded loop is the failure mode a strict-protection repo with a busy master produces.
+
+**Phase 6 — plan-intent fidelity review.**
+
+Read `.claude/skills/pr-ready/_plan-fidelity-review.md` now and perform the review **yourself**. This phase is NEVER delegated — `.claude/rules/agent-tiering.md`: "Never delegate understanding." Spawning any sub-agent for this phase is a defect.
+
+**Phase 7 — verdict and stop.**
+
+1. **Run the shared hold predicates.** `bin/lib/pr-armable.sh` is **sourced, not executed** — it carries no `set -euo pipefail` at file scope by design. Reuse its six predicates rather than re-deriving any hold logic:
+
+   ```bash
+   source bin/lib/pr-armable.sh
+   BODY="$(gh pr view <N> --json body --jq .body)"
+   TITLE="$(gh pr view <N> --json title --jq .title)"
+   LABELS="$(gh pr view <N> --json labels --jq '.labels')"
+   FILES="$(gh pr view <N> --json files --jq '.files')"
+   pr_manual_testing_clearance "$BODY"
+   pr_golden_hold "$FILES"
+   pr_dep_holds "$BODY"
+   pr_feat_hold "$TITLE" "$LABELS"
+   pr_pipeline_authored_hold "$LABELS"
+   pr_unresolved_findings_hold <N>
+   ```
+
+   Report each predicate's result as one line in the verdict. These are **advisory inputs to the human's merge decision** — `/pr-ready` never arms auto-merge and never merges.
+
+2. **Post the sticky verdict.** Marker, placed as the **last line of the body** so an update matches:
+
+   `<!-- pr-ready-verdict -->`
+
+   There is no helper in `bin/lib/` for this, so use the find-and-update-else-create shape from `bin/pr-canary-check` (`STICKY_MARKER` at line 19, `post_sticky()` below it):
+
+   ```bash
+   id=$(gh api "repos/{owner}/{repo}/issues/<N>/comments" --paginate \
+     --jq '.[] | select(.body | contains("<!-- pr-ready-verdict -->")) | .id' | head -1)
+   if [ -n "$id" ]; then
+     gh api --method PATCH "repos/{owner}/{repo}/issues/comments/$id" -F body=@"$tmpfile"
+   else
+     gh pr comment <N> --body-file "$tmpfile"
+   fi
+   ```
+
+   Comment body sections, in order: **rebase result** (the master SHA used, conflicts resolved), **CI result**, **plan-fidelity verdict**, **hold predicates**, and one explicit **READY / NOT READY** line.
+
+3. **STOP — hard terminator.** The run ends at the posted comment. No merge. No auto-merge arming. No backlog housekeeping. No `/post-plan` chain. No worktree teardown. The user reviews every PR deliberately.

--- a/.claude/skills/pr-ready/_plan-fidelity-review.md
+++ b/.claude/skills/pr-ready/_plan-fidelity-review.md
@@ -1,0 +1,35 @@
+# /pr-ready runtime Phase 6 — plan-intent fidelity review
+
+Purpose: the criteria and verdict shape for the semantic judgment this skill exists to produce — does the implementation do what the plan *intended*, not merely what its tests assert?
+
+**3a. This review runs on the orchestrator. It is NEVER delegated.** Do not spawn an agent for it. Do not delegate any part of it. Do not summarise the diff via a sub-agent and review the summary. `.claude/rules/agent-tiering.md` reserves this class for the Opus column — "Never delegate understanding" — and the cost of delegating is not the delegate's raw capability but that the orchestrator loses the findings the delegate filtered out. Spawning a sub-agent for any part of this phase is a defect in the run.
+
+**3b. Inputs.** Gather all five before judging anything:
+
+1. The plan file read in runtime Phase 1 (`~/claude-plans/<branch>.md`).
+2. The full **post-rebase** diff — `gh pr diff <N>`, or `git diff origin/master...HEAD` locally.
+3. The PR body.
+4. The list of conflict-resolved paths recorded in runtime Phase 3.
+5. `PHASE_4B_RAN`, the boolean from runtime Phase 1's prior-review probe.
+
+**3c. Two mandatory statements.** The review is incomplete without both, worded explicitly in the verdict:
+
+- **(a) Whether Phase 4B structured code review ran on this PR** (from `PHASE_4B_RAN`). If it did not, say so plainly and recommend running `/pr-review <N>` before the PR is merged. `/pr-ready` deliberately does **not** substitute for structured code review — it neither defines nor references the shared review-agent definitions, and it produces no scored findings.
+- **(b) That Phase 4B, when it ran, reviewed the PRE-REBASE diff.** Therefore every line produced by runtime Phase 3 conflict resolution is code no structured review has ever covered, and this fidelity review is its only coverage. **Name each conflict-resolved path** in the statement — do not summarise them as a count.
+
+**3d. The fidelity checks.** Each produces an explicit finding or an explicit "matches" — never silence:
+
+1. **Intent coverage** — for each of the plan's implementation phases, does a corresponding change exist in the diff? Name any phase with no diff footprint.
+2. **Intent fidelity** — where a change exists, does it do what the phase *said*, or a different thing that merely satisfies the phase's tests? This is the semantic question `/post-plan` Phase 5.0 (`.claude/skills/post-plan/_phase-5-final-verification.md`) structurally cannot ask: it verifies the declared test *paths* were written, never that the behavior matches intent.
+3. **Scope creep** — changes in the diff that no plan phase asked for. Flag them; do not assume they are harmless.
+4. **PR body vs. reality** — check the PR body's factual claims (files touched, tests added, counts, "no behavior change") against the actual diff. A body claim the diff contradicts is a **finding**, and it must be corrected before the PR is endorsed as ready. Never endorse readiness on the strength of the body alone.
+5. **Verification Matrix realisation** — for each `PHPUnit` / `API-test` / `E2E` / `Visual-regression` row, confirm the declared path exists in the diff. For each `Truly-manual` row, say whether it has been performed and by whom.
+6. **Conflict-resolution audit** — re-read every path from 3b's conflict list against its three-way stages. For a counted document, confirm rows are additive and roll-up totals were recomputed.
+
+**3e. Verdict shape.** Emit exactly one of:
+
+- **`READY`** — every check above says "matches", with the evidence named.
+- **`READY WITH NOTES`** — findings exist but none blocks a merge; list each note.
+- **`NOT READY`** — at least one blocking finding; each one must name the concrete next action.
+
+A green CI plus a green Phase 5.0 conformance run is **not** sufficient for `READY` on its own — that combination is exactly the state this skill exists to look past.

--- a/.claude/skills/pr-ready/_rebase-and-conflicts.md
+++ b/.claude/skills/pr-ready/_rebase-and-conflicts.md
@@ -7,9 +7,11 @@ Read this file at runtime Phase 2 and follow it end-to-end before returning to t
 **2a. Capture the pre-rebase tree diff first.** This is the input to Phase 4's lost-work proof, so it must be written *before* any history is rewritten:
 
 ```bash
-git diff origin/master...HEAD > /tmp/pr-ready-diff-pre-$$.patch
+git diff origin/master...HEAD > /tmp/pr-ready-diff-pre-<N>.patch
 git rev-list --count "$MASTER_SHA"..HEAD   # commit count drives the squash decision
 ```
+
+**The filename is keyed to the PR number, deliberately — never `$$`.** Each Bash call gets a fresh shell, so `$$` differs between the call that writes this file and Phase 4's call that reads it; a PID-keyed name is guaranteed to miss, and Phase 4 would then report `TREE DIVERGED` on every run. The PR number is stable across calls and still unique per concurrent run. Substitute the real number before running.
 
 **2b. The Phase 2 delegation packet.** Hand this to exactly one sub-agent. Substitute the real `$MASTER_SHA`, branch name, and commit count before spawning — the delegate must never resolve them itself.
 

--- a/.claude/skills/pr-ready/_rebase-and-conflicts.md
+++ b/.claude/skills/pr-ready/_rebase-and-conflicts.md
@@ -1,0 +1,56 @@
+# /pr-ready runtime Phases 2–3 — rebase onto pinned master, then resolve conflicts
+
+Purpose: the Phase 2 delegation packet (one `sonnet-4-6` sub-agent does the rebase chore against a pinned master SHA) and the Phase 3 three-way conflict-resolution procedure the orchestrator performs itself.
+
+Read this file at runtime Phase 2 and follow it end-to-end before returning to the spine. `$MASTER_SHA` is the pin taken in runtime Phase 1 — nothing in this file re-resolves `origin/master`.
+
+**2a. Capture the pre-rebase tree diff first.** This is the input to Phase 4's lost-work proof, so it must be written *before* any history is rewritten:
+
+```bash
+git diff origin/master...HEAD > /tmp/pr-ready-diff-pre-$$.patch
+git rev-list --count "$MASTER_SHA"..HEAD   # commit count drives the squash decision
+```
+
+**2b. The Phase 2 delegation packet.** Hand this to exactly one sub-agent. Substitute the real `$MASTER_SHA`, branch name, and commit count before spawning — the delegate must never resolve them itself.
+
+````
+### Delegate — rebase onto pinned master
+- **Tier:** Sonnet
+- **Spawn:** `subagent_type: "sonnet-4-6"`, **omit `model`** — never `model: "sonnet"` (that alias resolves to Sonnet 5). Flat fan-out: this delegate must NOT spawn a sub-agent of its own.
+- **Rules:** Read `.claude/rules/linear-history-squash-merge.md` first. It is path-scoped and its `paths:` list does NOT cover this skill's files, so it will not auto-attach — Read it by name.
+- **First returned line, before any other work:** `pwd` and `git rev-parse --show-toplevel`. A mismatch against the expected worktree means the EnterWorktree switch did not take, and everything after it would rebase the wrong tree.
+- **Inputs:** the pinned `$MASTER_SHA` (use this literal SHA; do NOT resolve `origin/master` yourself), the branch name, the commit count from 2a.
+- **Recipe:** squash (best-effort) then rebase, per 2c/2d below.
+- **Hard limits:** you may run `git rebase`, `git rebase --continue`, `git rebase --abort`, `git merge`, `git cherry`, `git diff`, `git show`. You may NOT run `git commit` or `git push` — `~/.claude/hooks/plan-gate-commit.sh` denies both for sub-agents and will hard-fail the call. Stop at the FIRST conflict; do not attempt to resolve it.
+- **Report back (thin — pointers only, never pasted diffs or file bodies):** line 1 = `pwd` + toplevel; line 2 = the master SHA you rebased onto; line 3 = `clean` or a newline-separated list of conflicted paths from `git diff --name-only --diff-filter=U`; line 4 = `squashed` / `squash-skipped` / `squash-failed`.
+````
+
+**2c. Squash — hook-safe form, best-effort.** When `git rev-list --count "$MASTER_SHA"..HEAD` is greater than 1, squash to one commit. The obvious recipe (`git reset --soft` + a commit) is **denied for the delegate** by the ship-overreach gate, which pattern-matches the commit/push subcommands. Use the non-interactive `rebase -i` form instead — the invoked binary is `git rebase`, which the gate allows, and the rebase machinery writes the commit without a commit call:
+
+```bash
+GIT_SEQUENCE_EDITOR="sed -i '' '2,$ s/^pick /squash /'" GIT_EDITOR=true \
+  git rebase -i "$MASTER_SHA"
+```
+
+The `2,$` range leaves the first `pick` alone and only rewrites lines that begin with `pick `, so the todo file's `#` comment block is untouched. `GIT_EDITOR=true` accepts the concatenated commit message unedited.
+
+If this command fails for any reason, report `squash-failed` and continue to 2d with the un-squashed history. **The local squash is cosmetic** — master is squash/rebase-merge-only, so GitHub collapses the branch to one commit at merge time anyway. A failed squash is never a reason to stop the run.
+
+**2d. Rebase onto the PINNED SHA.** Never run a bare `git rebase` against `origin/master` — a bare rebase replays a merged parent's already-squashed commits and fabricates conflicts (`.claude/rules/linear-history-squash-merge.md`, "The diagnostic trap this prevents"). Use the `--onto` form with the pinned SHA:
+
+```bash
+git rebase --onto "$MASTER_SHA" <parent-tip-before-merge> <branch>
+```
+
+- For a branch based directly on master, `<parent-tip-before-merge>` is `$(git merge-base "$MASTER_SHA" HEAD)`.
+- For a **stacked** branch whose parent already merged, it is the last commit belonging to the parent. Confirm the parent's work is in master **by content** (files/diff present), never by `git branch --contains` — that shows a merged SHA as absent as a normal squash artifact.
+- When 2c reported `squashed` **and the branch is not stacked**, the rebase is already done (2c's `rebase -i` targeted `$MASTER_SHA`) — skip 2d and report `clean`.
+- **If the branch IS stacked (its parent already merged), skip 2c entirely and run 2d instead.** 2c's `git rebase -i "$MASTER_SHA"` uses the default upstream/merge-base replay range, which is exactly the trap the `--onto` form exists to avoid; the squash is cosmetic and not worth risking the wrong replay range.
+
+**2e. Runtime Phase 3 — conflict resolution, on the orchestrator.** The delegate stops at the first conflict and returns; it never resolves. Everything below is the orchestrator's own work.
+
+1. **Always resolve three-way.** For each conflicted path, read all three stages before editing — `git show :1:<path>` (base), `git show :2:<path>` (ours / the rebased-onto master side), `git show :3:<path>` (theirs / the branch side). Reconstruct the intent of both edits, then write the merged file.
+2. **Never `git checkout --ours <path>` or `--theirs <path>`** unless *every* hunk in that file genuinely takes that side. A whole-file side-take is the single most common way real work disappears in this repo, and it is invisible in the resulting diff.
+3. **`ibl5/docs/backlog/maintenance-backlog.md` is a special case.** Its per-axis counts are **additive** — a conflict where both sides added rows means the merged file keeps **both** sets of rows — while the `> ✅ resolved (N): …` / `> 🚫 declined (N): …` roll-up totals are **recomputed** from the merged row set, never taken from either side. Taking either side wholesale silently drops the other side's backlog items and leaves a total that does not match the rows, which `bin/check-docs` (`checkMaintenanceResolved`) will then contradict. Same rule for any other counted roll-up encountered, including the section counts in `ibl5/docs/backlog/archive/maintenance-backlog-archive.md`.
+4. `git add <path>` each resolved file, then `git rebase --continue` (with `GIT_EDITOR=true` so it does not block on an editor). Repeat until the rebase finishes — or until `git rebase --abort` is the right call, in which case abort, report the conflict set, and stop rather than guessing.
+5. **Record the resolved paths in a run note.** Phase 6 must name them explicitly, because conflict-resolution output is **new code that no code review has ever seen**.

--- a/bin/pr-overlap
+++ b/bin/pr-overlap
@@ -5,7 +5,7 @@
 #
 # Pure textual analysis. Reads two unified-diff FILES and reports, for every file
 # that appears in BOTH diffs, whether their changed line ranges actually collide.
-# Makes NO network and NO GitHub API calls: the caller (.claude/skills/pr-attack/SKILL.md)
+# Makes NO network and NO GitHub API calls: the caller (.claude/skills/pr-ready/SKILL.md)
 # fetches diffs with `gh pr diff` and hands the saved files to this script. That
 # separation is what lets bin/test-pr-overlap drive it from synthetic fixtures.
 #


### PR DESCRIPTION
## Summary

Adds a new `/pr-ready` skill that takes one open PR from conflicted-or-unknown state to a posted readiness verdict. The skill:

- Enters the PR's existing worktree
- Delegates the rebase onto master to a Sonnet sub-agent (pinned to 4.6)
- Resolves any conflicts on the orchestrator using three-way merge
- Pushes and watches CI via a `Monitor` (not a sleep-and-poll loop on the main thread)
- Performs a **plan-intent fidelity review** on the orchestrator (never delegated — Opus column judgment)
- Posts a sticky `<!-- pr-ready-verdict -->` comment with `READY` / `NOT READY` verdict

**Design centre:** `/post-plan` Phase 5.0 checks mechanical declared-artifact conformance; Phase 4B reviews the pre-rebase diff. Neither asks whether the code does what the plan *intended*. This skill adds exactly that semantic judgment and nothing else.

## Files Changed

- `.claude/skills/pr-ready/SKILL.md` — NEW: skill spine (frontmatter, invariants, runtime phases 0–7)
- `.claude/skills/pr-ready/_rebase-and-conflicts.md` — NEW: Phase 2 delegation packet and Phase 3 conflict-resolution procedure
- `.claude/skills/pr-ready/_plan-fidelity-review.md` — NEW: Phase 6 fidelity-review criteria and verdict shape

## Manual Testing

| # | What to verify | Notes |
|---|---------------|-------|
| 16 | End-to-end read of the real thing against a live PR: from a **main-checkout** session, `Read` the skill and follow it against one real open PR — does the run enter the worktree, survive the rebase and CI wait, land a verdict, and post the sticky comment without the session compacting mid-run? | From `/Users/ajaynicolas/GitHub/IBL5` (not a worktree); pre-merge-performable against any open PR |