### PR TITLE
chore(agents): restrict sonnet-4-6 from spawning sub-agents

### DIFF
--- a/.claude/agents/sonnet-4-6.md
+++ b/.claude/agents/sonnet-4-6.md
@@ -1,9 +1,12 @@
 ---
 name: sonnet-4-6
-description: Pinned Sonnet 4.6 general-purpose agent. Use `subagent_type: "sonnet-4-6"` (omit model) wherever a skill or plan needs a Sonnet subagent pinned to 4.6 — avoids the `sonnet` alias resolving to Sonnet 5. Full tool access. Appropriate for review agents, backlog housekeeping, manual-test classification, and other judgment tasks that need Edit/Write.
+description: Pinned Sonnet 4.6 general-purpose agent. Use `subagent_type: "sonnet-4-6"` (omit model) wherever a skill or plan needs a Sonnet subagent pinned to 4.6 — avoids the `sonnet` alias resolving to Sonnet 5. Full tool access except `Agent` — it cannot spawn sub-agents; delegation stays one level deep. Appropriate for review agents, backlog housekeeping, manual-test classification, and other judgment tasks that need Edit/Write.
 model: claude-sonnet-4-6
+disallowedTools: Agent
 ---
 
 You are a capable general-purpose assistant. Complete the task given in the prompt using all tools available to you. Follow all project rules from the auto-loaded CLAUDE.md files.
 
 When you run as a sub-agent (for example, an interactive delegate), you are execution-only: never run `git commit`, `git push`, or `bin/post-plan-now`. These are structurally denied for sub-agents by the plan-gate-commit.sh Bash hook — make your edits and return; the main thread or the /post-plan session ships.
+
+**Never spawn a sub-agent.** You have no `Agent` tool by design: delegation stays one level deep (`.claude/rules/agent-tiering-detail.md` § Nested Sub-Agents). If a task genuinely needs fan-out, return that finding to whoever spawned you and let them own the fan-out.

--- a/.claude/rules/agent-tiering.md
+++ b/.claude/rules/agent-tiering.md
@@ -35,7 +35,7 @@ Sonnet surfaces are pinned to 4.6 via an agent def or skill frontmatter — **th
 |---------|-----------|---------------------|
 | **Explore** | `~/.claude/agents/Explore.md` (machine-local) | `subagent_type: "Explore"`, **omit `model`**. Blocked by `~/.claude/hooks/explore-model-gate.sh` if you pass `model: "sonnet"`. |
 | **Automouse impl delegates** | `.claude/agents/automouse-delegate.md` (in-repo) | `subagent_type: "automouse-delegate"`, **omit `model`**. Fired by `bin/automouse/prompt-impl` for each `### Delegate` packet. |
-| **General Sonnet tasks** (review agents, backlog housekeeping, any Sonnet-tier spawn) | `.claude/agents/sonnet-4-6.md` (in-repo) | `subagent_type: "sonnet-4-6"`, **omit `model`**. Full tool access. |
+| **General Sonnet tasks** (review agents, backlog housekeeping, any Sonnet-tier spawn) | `.claude/agents/sonnet-4-6.md` (in-repo) | `subagent_type: "sonnet-4-6"`, **omit `model`**. No `Agent` — it cannot spawn. |
 | **Plan architect (Sonnet tier)** | `.claude/agents/plan-architect-sonnet.md` (in-repo) | `subagent_type: "plan-architect-sonnet"`, **omit `model`**. Selected by `/plan` Step 3 precedence. |
 | **`/pr-review` & `/security-audit` runners** | Their `SKILL.md` frontmatter | Pinned via `model: claude-sonnet-4-6` in skill frontmatter. No spawn change needed. |
 


### PR DESCRIPTION
## Summary
- Add `disallowedTools: Agent` to sonnet-4-6 agent definition to enforce one-level-deep delegation.
- Update agent description and agent-tiering table to clarify that sonnet-4-6 cannot spawn sub-agents; nested delegation must return findings to the spawning thread.
- Structural constraint backed by plan-gate-commit.sh hook.

## Manual Testing

No manual testing needed — verified by automated tests.
