### PR TITLE
chore(retro): route stale-playoff git-track class to Rung 3 integration-verification trigger

### DIFF
--- a/.claude/review-shared/_plan-verification.md
+++ b/.claude/review-shared/_plan-verification.md
@@ -1,6 +1,6 @@
 ---
 description: Requires plans to classify every verification step into the test-type taxonomy at plan-write time, preventing manual-testing items from deferring to post-plan cleanup, and grounds seed/DOM-dependent E2E assertions in real fixtures.
-last_verified: 2026-07-31
+last_verified: 2026-08-10
 ---
 
 # Plan Verification Matrix
@@ -177,6 +177,7 @@ The taxonomy above classifies *how* a thing is verified; this table names five s
 | adds a CLI flag or a flag-parsing branch | asserts the **rejected** form fails loudly (unknown flag; space-form when `=` is required) |
 | reads a new environment variable | asserts **unset** and **empty** separately, and states which is legal. An unset-with-a-safe-default var needs only the empty case; a required var must fail on both |
 | writes a file or directory inside the repo tree | asserts it is gitignored, or explicitly declares it committed |
+| adds or modifies an updater or importer that reads a generated file from a repo-relative path | asserts the source path is NOT git-tracked: `git ls-files --error-unmatch <path>` exits nonzero (untracked — expected); a negation line in .gitignore force-tracks the file so deploy git-reset clobbers live content with stale committed data |
 
 The header intentionally differs from the two tables above (`| Trigger pattern | Why PHPUnit is insufficient |`, `| Trigger | Example surface |`): those map a trigger to a rationale or an example, while this one mandates a **row shape**. Do not harmonize the headers.
 

--- a/ibl5/docs/backlog/loop-engineering-backlog.md
+++ b/ibl5/docs/backlog/loop-engineering-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Loop-engineering backlog — automouse queue robustness (dependency ordering, circuit breakers, canaries, self-healing), autonomous intake loops, plan decomposition/tier-routing machinery, and the human comprehension counter-loop, with per-entry status.
-last_verified: 2026-08-09
+last_verified: 2026-08-10
 ---
 
 # Loop-Engineering Backlog
@@ -274,6 +274,7 @@ not add backticks or markdown links to a row.
 | 2026-07-25 | #1633 | class: env/supervisor precondition unverified before a long-running job | routed to: Rung 3 - forced-trigger row in .claude/review-shared/_plan-verification.md (section: Forced integration-verification trigger) | prior: -- |
 | 2026-07-25 | --   | class: shared-context wire contract between two scripts is unasserted   | routed to: Rung 3 - forced-trigger row in .claude/review-shared/_plan-verification.md (section: Forced integration-verification trigger) | prior: -- |
 | 2026-07-25 | #1654 | class: CLI entrypoint accepts an unknown flag silently instead of erroring | routed to: Rung 1 - PHPStan rule over argv option parsing, queued as L33 in this backlog, not yet built; interim Rung 3 backstop shipped in #1668 (section: Forced integration-verification trigger). A fourth occurrence forces the Rung 1 rule. | prior: #1354, #1496 |
+| 2026-08-10 | #1834 | class: app-generated file read by an updater is force-tracked via .gitignore negation, so deploy git-reset clobbers live data with stale committed content | routed to: Rung 3 - new forced-trigger row in .claude/review-shared/_plan-verification.md (section: Forced integration-verification trigger): updater/importer that reads a generated file from a repo-relative path must assert git ls-files exits nonzero for that path | prior: -- |
 ```
 
 ---


### PR DESCRIPTION
## Summary

Post-plan Phase 9 retrospective for #1834 (`fix-playoff-schedule-stale-season`).

`IS_FIX_OF_PLAN_BEHAVIOR=true`: #1834 fixed stale playoff rows that corrupted the schedule because app-generated HTML files (`Schedule.htm`, `Standings.htm`) were force-tracked in git via `.gitignore` negation lines. Every deploy's `git reset --hard` clobbered the live files with the stale committed versions.

**Class of defect:** app-generated file read by an updater is force-tracked via `.gitignore` negation, so deploy git-reset clobbers live data with stale committed content.

**Rung 1 (PHPStan rule):** not applicable — not decidable from PHP source text alone; the defect is at the repo/deploy layer.

**Rung 2 (extend bin/check-*):** not applicable — no existing gate owns this surface, and the check would need judgment about which paths are "app-generated" vs. versioned assets.

**Rung 3 (forced-trigger row in plan-verification):** fits exactly — the defect is catchable by a test the plan should have required. New row added to the Forced integration-verification trigger table: a plan that adds/modifies an updater reading a generated file from a repo-relative path must carry a `CLI-executable` row asserting `git ls-files --error-unmatch <path>` exits nonzero.

## Changes

- `.claude/review-shared/_plan-verification.md` — new forced-trigger row for updater/importer plans
- `ibl5/docs/backlog/loop-engineering-backlog.md` — class registry append

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.